### PR TITLE
Fix template auto-discovery warnings by ignoring internal directories

### DIFF
--- a/template.go
+++ b/template.go
@@ -105,14 +105,15 @@ import (
 
 // Config holds template configuration options
 type Config struct {
-	Upgrader          *websocket.Upgrader
-	SessionStore      SessionStore
-	Authenticator     Authenticator // User authentication and session grouping
-	AllowedOrigins    []string      // Allowed WebSocket origins (empty = allow all in dev, restrict in prod)
-	WebSocketDisabled bool
-	LoadingDisabled   bool     // Disables automatic loading indicator on page load
-	TemplateFiles     []string // If set, overrides auto-discovery
-	DevMode           bool     // Development mode - use local client library instead of CDN
+	Upgrader           *websocket.Upgrader
+	SessionStore       SessionStore
+	Authenticator      Authenticator // User authentication and session grouping
+	AllowedOrigins     []string      // Allowed WebSocket origins (empty = allow all in dev, restrict in prod)
+	WebSocketDisabled  bool
+	LoadingDisabled    bool     // Disables automatic loading indicator on page load
+	TemplateFiles      []string // If set, overrides auto-discovery
+	IgnoreTemplateDirs []string // Additional directories to ignore during auto-discovery
+	DevMode            bool     // Development mode - use local client library instead of CDN
 }
 
 // Template represents a live template with caching and tree-based optimization capabilities.
@@ -280,6 +281,18 @@ func WithAllowedOrigins(origins []string) Option {
 	}
 }
 
+// WithIgnoreTemplateDirs adds directories to ignore during template auto-discovery.
+// This is useful to skip directories containing generator templates or other non-runtime templates.
+//
+// Example:
+//
+//	tmpl := livetemplate.New("app", livetemplate.WithIgnoreTemplateDirs("generators", "scaffolds"))
+func WithIgnoreTemplateDirs(dirs ...string) Option {
+	return func(c *Config) {
+		c.IgnoreTemplateDirs = append(c.IgnoreTemplateDirs, dirs...)
+	}
+}
+
 // New creates a new template with the given name and options.
 //
 // By default, New auto-discovers template files in the current directory and common
@@ -357,7 +370,7 @@ func New(name string, opts ...Option) *Template {
 
 	// Auto-discover and parse templates if not explicitly provided
 	if len(config.TemplateFiles) == 0 {
-		files, err := discoverTemplateFiles()
+		files, err := discoverTemplateFiles(config.IgnoreTemplateDirs)
 		if err == nil && len(files) > 0 {
 			if _, err := tmpl.ParseFiles(files...); err != nil {
 				log.Printf("Warning: failed to parse template files: %v", err)

--- a/template_discovery.go
+++ b/template_discovery.go
@@ -12,10 +12,11 @@ var ignoredTemplateDirs = map[string]struct{}{
 	"node_modules": {},
 	"vendor":       {},
 	".git":         {},
+	"internal":     {}, // Skip internal directories (e.g., code generator templates with mixed delimiters)
 }
 
 // discoverTemplateFiles searches for template files in the calling directory and subdirectories
-func discoverTemplateFiles() ([]string, error) {
+func discoverTemplateFiles(customIgnoreDirs []string) ([]string, error) {
 	// Get the caller's directory (2 frames up: discoverTemplateFiles -> New -> user code)
 	_, filename, _, ok := runtime.Caller(2)
 	if !ok {
@@ -25,13 +26,22 @@ func discoverTemplateFiles() ([]string, error) {
 	baseDir := filepath.Dir(filename)
 	var files []string
 
+	// Build combined ignore map (default + custom)
+	ignoreMap := make(map[string]struct{}, len(ignoredTemplateDirs)+len(customIgnoreDirs))
+	for k, v := range ignoredTemplateDirs {
+		ignoreMap[k] = v
+	}
+	for _, dir := range customIgnoreDirs {
+		ignoreMap[dir] = struct{}{}
+	}
+
 	err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		if d.IsDir() {
-			if _, skip := ignoredTemplateDirs[d.Name()]; skip {
+			if _, skip := ignoreMap[d.Name()]; skip {
 				return fs.SkipDir
 			}
 			return nil


### PR DESCRIPTION
Adds 'internal' to default ignored directories during template auto-discovery
to prevent parsing errors from code generator templates that use mixed
delimiter syntax ([[...]] for generation, {{...}} for runtime).

Changes:
- Add 'internal' to ignoredTemplateDirs in template_discovery.go
- Add IgnoreTemplateDirs config field for custom ignore patterns
- Add WithIgnoreTemplateDirs() option for runtime configuration
- Update discoverTemplateFiles() to merge default and custom ignore lists

Resolves template parsing warnings that appeared during test runs due to
generator templates in cmd/lvt/internal/generator/templates/ being
incorrectly parsed as runtime templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
