### PR TITLE
Export NewActionData for external packages

### DIFF
--- a/action.go
+++ b/action.go
@@ -26,6 +26,12 @@ func newActionData(data map[string]interface{}) *ActionData {
 	return &ActionData{raw: data}
 }
 
+// NewActionData creates ActionData from a map
+// This is the public version for use by external packages like livepage
+func NewActionData(data map[string]interface{}) *ActionData {
+	return newActionData(data)
+}
+
 // Bind unmarshals the data into a struct
 func (a *ActionData) Bind(v interface{}) error {
 	// Lazy marshal to JSON


### PR DESCRIPTION
## Summary

- Add public `NewActionData` function to allow external packages (like livepage) to create `ActionData` instances
- This is needed for RPC-based plugin systems where plugins need to construct `ActionContext` objects

## Background

The existing `newActionData` function was private (lowercase), making it impossible for external packages to create `ActionData` instances. This is required by the livepage RPC plugin system implementation where plugin code needs to construct `ActionContext` objects.

## Changes

- Added public `NewActionData(map[string]interface{}) *ActionData` function
- The function simply wraps the existing private `newActionData` function
- No breaking changes - all existing code continues to work

## Related

This change is required by https://github.com/livetemplate/livepage/pull/XX (RPC plugin system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)