### PR TITLE
feat!: remove Store interface, always use method dispatch

### DIFF
--- a/action.go
+++ b/action.go
@@ -472,14 +472,6 @@ func ValidationToMultiError(err error) MultiError {
 	return fieldErrors
 }
 
-// Store is an optional interface for stores that want explicit control over action routing.
-// If a store implements this interface, Change() will be called for all actions.
-// If a store does NOT implement this interface, actions are automatically dispatched
-// to methods matching the action name (e.g., "increment" → Increment(ctx *ActionContext) error).
-type Store interface {
-	Change(ctx *ActionContext) error
-}
-
 // StoreInitializer is an optional interface that stores can implement
 // to perform initialization after being cloned for a new session.
 // This is useful for loading data from external sources like databases.
@@ -488,8 +480,8 @@ type StoreInitializer interface {
 }
 
 // Stores is a map of named stores.
-// Stores can be any type - if they implement the Store interface, Change() is called.
-// Otherwise, actions are automatically dispatched to matching methods.
+// Actions are automatically dispatched to methods matching the action name
+// (e.g., action "increment" → method Increment(ctx *ActionContext) error).
 type Stores map[string]interface{}
 
 // parseAction splits "counter.increment" into ("counter", "increment")

--- a/docs/references/controller-pattern.md
+++ b/docs/references/controller-pattern.md
@@ -1,0 +1,537 @@
+# Controller Pattern Reference
+
+Controllers separate state (data) from logic (behavior), enabling proper dependency injection and cleaner persistence. Use them when stores need database connections, loggers, or other dependencies that shouldn't be serialized to Redis.
+
+## Overview
+
+Actions are automatically dispatched to methods matching the action name:
+
+```go
+type Counter struct {
+    Count int
+}
+
+// Action "increment" → method Increment()
+func (c *Counter) Increment(ctx *livetemplate.ActionContext) error {
+    c.Count++
+    return nil
+}
+
+// Action "decrement" → method Decrement()
+func (c *Counter) Decrement(ctx *livetemplate.ActionContext) error {
+    c.Count--
+    return nil
+}
+```
+
+**Key features:**
+- No boilerplate switch statements
+- Method names are discoverable by IDE
+- Type-safe action handlers
+- Cached method lookups (O(1) after first call)
+
+## State vs Controller
+
+For stores with dependencies, separate concerns into two parts:
+
+```go
+// State: Pure data, no dependencies, serializable
+type CounterState struct {
+    Count int `json:"count"`
+}
+
+// Controller: Logic + dependencies, wraps state
+type CounterController struct {
+    State  *CounterState `lvt:"state"` // Persisted to Redis
+    DB     *sql.DB                     // NOT persisted
+    Logger *slog.Logger                // NOT persisted
+}
+```
+
+**State characteristics:**
+- Contains only data fields
+- JSON-serializable
+- No pointers to external resources
+- Can be safely stored in Redis
+
+**Controller characteristics:**
+- Contains state reference(s) tagged with `lvt:"state"`
+- Holds dependencies (DB connections, loggers, clients)
+- Defines action methods
+- Dependencies are cloned from template, not serialized
+
+## State Tags
+
+The `lvt:"state"` struct tag marks fields for persistence:
+
+```go
+type UserController struct {
+    // These fields ARE persisted to Redis
+    Profile  *UserProfile  `lvt:"state"`
+    Settings *UserSettings `lvt:"state"`
+
+    // These fields are NOT persisted
+    DB       *sql.DB       // Database connection
+    Logger   *slog.Logger  // Logger instance
+    Client   *http.Client  // HTTP client
+}
+```
+
+**How it works:**
+
+1. When saving to Redis, only `lvt:"state"` tagged fields are serialized
+2. When loading from Redis, state is deserialized and injected
+3. Dependencies come from cloning the template controller (not from Redis)
+
+**Serialization flow:**
+```
+Save: Controller → ExtractState() → Serialize → Redis
+Load: Redis → Deserialize → Clone template → InjectState() → Controller
+```
+
+## Action Dispatch
+
+Define methods matching action names—routing happens automatically:
+
+```go
+// Action "increment" → method Increment()
+func (c *CounterController) Increment(ctx *livetemplate.ActionContext) error {
+    c.State.Count++
+    c.Logger.Info("counter incremented", slog.Int("value", c.State.Count))
+    return nil
+}
+
+// Action "set_value" → method SetValue()
+func (c *CounterController) SetValue(ctx *livetemplate.ActionContext) error {
+    c.State.Count = ctx.GetInt("value")
+    return nil
+}
+```
+
+**Naming conventions:**
+
+| Action Name | Method Name |
+|-------------|-------------|
+| `increment` | `Increment()` |
+| `addItem` | `AddItem()` |
+| `add_item` | `AddItem()` |
+| `setUserProfile` | `SetUserProfile()` |
+| `set_user_profile` | `SetUserProfile()` |
+
+**Method signature requirement:**
+
+```go
+func (receiver *ControllerType) MethodName(ctx *livetemplate.ActionContext) error
+```
+
+- Must be a pointer receiver
+- Must accept `*ActionContext` as the only parameter
+- Must return `error`
+- Methods with wrong signatures are silently ignored
+
+**Performance:** Method lookups are cached by type. After the first call, routing is O(1) with zero reflection overhead.
+
+## ActionContext API
+
+The `ActionContext` provides access to action data sent from the client:
+
+```go
+type ActionContext struct {
+    Action string        // The action name (e.g., "increment")
+    Data   *ActionData   // Form/JSON data from client
+    Ctx    context.Context
+}
+```
+
+### Data Extraction Methods
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `GetString(key)` | `string` | Get string value (empty if missing) |
+| `GetInt(key)` | `int` | Get integer value (0 if missing/invalid) |
+| `GetFloat(key)` | `float64` | Get float value (0 if missing/invalid) |
+| `GetBool(key)` | `bool` | Get boolean value (false if missing) |
+| `Has(key)` | `bool` | Check if key exists |
+
+Example:
+
+```go
+func (c *Controller) UpdateSettings(ctx *livetemplate.ActionContext) error {
+    theme := ctx.GetString("theme")
+    fontSize := ctx.GetInt("fontSize")
+    darkMode := ctx.GetBool("darkMode")
+
+    if !ctx.Has("theme") {
+        return livetemplate.FieldError{Field: "theme", Message: "Theme is required"}
+    }
+
+    c.State.Theme = theme
+    c.State.FontSize = fontSize
+    c.State.DarkMode = darkMode
+    return nil
+}
+```
+
+### Struct Binding
+
+Bind form data directly to a struct:
+
+```go
+type CreateUserForm struct {
+    Name  string `json:"name"`
+    Email string `json:"email"`
+    Age   int    `json:"age"`
+}
+
+func (c *Controller) CreateUser(ctx *livetemplate.ActionContext) error {
+    var form CreateUserForm
+    if err := ctx.Bind(&form); err != nil {
+        return err
+    }
+
+    // Use form.Name, form.Email, form.Age
+    return c.DB.CreateUser(form)
+}
+```
+
+### Binding with Validation
+
+Use with a validator (e.g., `go-playground/validator`):
+
+```go
+type RegisterForm struct {
+    Email    string `json:"email" validate:"required,email"`
+    Password string `json:"password" validate:"required,min=8"`
+    Name     string `json:"name" validate:"required"`
+}
+
+func (c *Controller) Register(ctx *livetemplate.ActionContext) error {
+    var form RegisterForm
+    validate := validator.New()
+
+    if err := ctx.BindAndValidate(&form, validate); err != nil {
+        return err // Returns MultiError with field-specific messages
+    }
+
+    return c.createAccount(form)
+}
+```
+
+### HTTP Context
+
+For HTTP POST actions (not WebSocket), you can access HTTP primitives:
+
+```go
+func (c *Controller) Login(ctx *livetemplate.ActionContext) error {
+    if !ctx.IsHTTP() {
+        return errors.New("login requires HTTP")
+    }
+
+    // Set cookie
+    ctx.SetCookie(&http.Cookie{
+        Name:  "session",
+        Value: token,
+    })
+
+    // Redirect
+    ctx.Redirect("/dashboard")
+
+    return nil
+}
+```
+
+## Initialization
+
+The `StoreInitializer` interface allows setup after a controller is cloned:
+
+```go
+type StoreInitializer interface {
+    Init() error
+}
+```
+
+**When Init() is called:**
+1. New session created → Template controller cloned → `Init()` called
+2. Existing session loaded → Template cloned → State injected → `Init()` called
+
+**Use cases:**
+- Load initial data from database
+- Set up computed fields
+- Validate state consistency
+
+Example:
+
+```go
+type TodoController struct {
+    State  *TodoState `lvt:"state"`
+    DB     *sql.DB
+    Logger *slog.Logger
+}
+
+func (c *TodoController) Init() error {
+    // Load todos from database if state is empty
+    if len(c.State.Items) == 0 {
+        items, err := c.DB.LoadTodos(c.State.UserID)
+        if err != nil {
+            return fmt.Errorf("failed to load todos: %w", err)
+        }
+        c.State.Items = items
+    }
+    return nil
+}
+```
+
+## Error Handling
+
+### FieldError
+
+Return a single field error:
+
+```go
+func (c *Controller) UpdateEmail(ctx *livetemplate.ActionContext) error {
+    email := ctx.GetString("email")
+
+    if !isValidEmail(email) {
+        return livetemplate.FieldError{
+            Field:   "email",
+            Message: "Please enter a valid email address",
+        }
+    }
+
+    c.State.Email = email
+    return nil
+}
+```
+
+### MultiError
+
+Return multiple field errors at once:
+
+```go
+func (c *Controller) Register(ctx *livetemplate.ActionContext) error {
+    var errors livetemplate.MultiError
+
+    email := ctx.GetString("email")
+    password := ctx.GetString("password")
+
+    if !isValidEmail(email) {
+        errors = append(errors, livetemplate.FieldError{
+            Field:   "email",
+            Message: "Invalid email format",
+        })
+    }
+
+    if len(password) < 8 {
+        errors = append(errors, livetemplate.FieldError{
+            Field:   "password",
+            Message: "Password must be at least 8 characters",
+        })
+    }
+
+    if len(errors) > 0 {
+        return errors
+    }
+
+    return c.createUser(email, password)
+}
+```
+
+### General Errors
+
+Non-field errors are sent as `_general`:
+
+```go
+func (c *Controller) SaveData(ctx *livetemplate.ActionContext) error {
+    if err := c.DB.Save(c.State); err != nil {
+        // Appears as general error in template
+        return fmt.Errorf("failed to save: %w", err)
+    }
+    return nil
+}
+```
+
+**Client-side handling:**
+
+```html
+{{if .Errors.email}}
+  <span class="error">{{.Errors.email}}</span>
+{{end}}
+
+{{if .Errors._general}}
+  <div class="alert">{{.Errors._general}}</div>
+{{end}}
+```
+
+## Common Patterns
+
+### Counter with Logging
+
+```go
+type CounterState struct {
+    Count int `json:"count"`
+}
+
+type CounterController struct {
+    State  *CounterState `lvt:"state"`
+    Logger *slog.Logger
+}
+
+func (c *CounterController) Increment(ctx *livetemplate.ActionContext) error {
+    c.State.Count++
+    c.Logger.Info("incremented", slog.Int("count", c.State.Count))
+    return nil
+}
+
+func (c *CounterController) Decrement(ctx *livetemplate.ActionContext) error {
+    if c.State.Count > 0 {
+        c.State.Count--
+    }
+    return nil
+}
+```
+
+### Form with Validation
+
+```go
+type ContactState struct {
+    Name    string
+    Email   string
+    Message string
+    Sent    bool
+}
+
+type ContactController struct {
+    State  *ContactState `lvt:"state"`
+    Mailer *mail.Client
+}
+
+func (c *ContactController) Submit(ctx *livetemplate.ActionContext) error {
+    var errors livetemplate.MultiError
+
+    c.State.Name = strings.TrimSpace(ctx.GetString("name"))
+    c.State.Email = strings.TrimSpace(ctx.GetString("email"))
+    c.State.Message = strings.TrimSpace(ctx.GetString("message"))
+
+    if c.State.Name == "" {
+        errors = append(errors, livetemplate.FieldError{
+            Field: "name", Message: "Name is required",
+        })
+    }
+    if !isValidEmail(c.State.Email) {
+        errors = append(errors, livetemplate.FieldError{
+            Field: "email", Message: "Valid email is required",
+        })
+    }
+    if len(c.State.Message) < 10 {
+        errors = append(errors, livetemplate.FieldError{
+            Field: "message", Message: "Message must be at least 10 characters",
+        })
+    }
+
+    if len(errors) > 0 {
+        return errors
+    }
+
+    if err := c.Mailer.Send(c.State.Email, c.State.Message); err != nil {
+        return fmt.Errorf("failed to send message")
+    }
+
+    c.State.Sent = true
+    return nil
+}
+```
+
+### CRUD with Database
+
+```go
+type TodoState struct {
+    Items []Todo `json:"items"`
+}
+
+type Todo struct {
+    ID        string `json:"id"`
+    Title     string `json:"title"`
+    Completed bool   `json:"completed"`
+}
+
+type TodoController struct {
+    State *TodoState `lvt:"state"`
+    DB    *sql.DB
+}
+
+func (c *TodoController) AddTodo(ctx *livetemplate.ActionContext) error {
+    title := strings.TrimSpace(ctx.GetString("title"))
+    if title == "" {
+        return livetemplate.FieldError{Field: "title", Message: "Title required"}
+    }
+
+    todo := Todo{
+        ID:    uuid.New().String(),
+        Title: title,
+    }
+
+    if err := c.DB.InsertTodo(todo); err != nil {
+        return fmt.Errorf("database error")
+    }
+
+    c.State.Items = append(c.State.Items, todo)
+    return nil
+}
+
+func (c *TodoController) ToggleTodo(ctx *livetemplate.ActionContext) error {
+    id := ctx.GetString("id")
+
+    for i := range c.State.Items {
+        if c.State.Items[i].ID == id {
+            c.State.Items[i].Completed = !c.State.Items[i].Completed
+            return c.DB.UpdateTodo(c.State.Items[i])
+        }
+    }
+
+    return fmt.Errorf("todo not found")
+}
+
+func (c *TodoController) DeleteTodo(ctx *livetemplate.ActionContext) error {
+    id := ctx.GetString("id")
+
+    for i, todo := range c.State.Items {
+        if todo.ID == id {
+            if err := c.DB.DeleteTodo(id); err != nil {
+                return fmt.Errorf("database error")
+            }
+            c.State.Items = append(c.State.Items[:i], c.State.Items[i+1:]...)
+            return nil
+        }
+    }
+
+    return fmt.Errorf("todo not found")
+}
+```
+
+## Registration
+
+```go
+// Simple store (no dependencies)
+counter := &Counter{Count: 0}
+tmpl.Handle(counter)
+
+// Controller with dependencies
+controller := &MyController{
+    State:  &MyState{},
+    DB:     db,
+    Logger: logger,
+}
+tmpl.Handle(controller)
+
+// Multiple stores
+tmpl.Handle(livetemplate.Stores{
+    "counter": &Counter{},
+    "user":    &UserController{State: &UserState{}, DB: db},
+})
+```
+
+## See Also
+
+- [Session Reference](session.md) - Session stores and connection management
+- [Server Actions Reference](server-actions.md) - Server-initiated updates with SessionAware
+- [Error Handling Reference](error-handling.md) - Detailed error handling patterns

--- a/health.go
+++ b/health.go
@@ -227,13 +227,9 @@ func NewSessionStoreHealthChecker(store SessionStore) *SessionStoreHealthChecker
 	return &SessionStoreHealthChecker{store: store}
 }
 
-// healthCheckStore is a minimal Store implementation for health checking.
+// healthCheckStore is a minimal store for health checking.
 type healthCheckStore struct {
 	value string
-}
-
-func (h *healthCheckStore) Change(ctx *ActionContext) error {
-	return nil
 }
 
 // Check verifies the session store is accessible by performing a Get/Set/Delete cycle.

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -7,13 +7,9 @@ import (
 	"testing"
 )
 
-// TestState is a simple test state
+// MetricsTestState is a simple test state
 type MetricsTestState struct {
 	Value int
-}
-
-func (s *MetricsTestState) Change(ctx *ActionContext) error {
-	return nil
 }
 
 func TestLiveHandler_MetricsHandler(t *testing.T) {

--- a/mount.go
+++ b/mount.go
@@ -38,12 +38,12 @@ import (
 // Security: Session is scoped to the current user only. There is no way to
 // target other users, preventing unauthorized cross-user actions.
 type Session interface {
-	// TriggerAction triggers Store.Change() with the given action and data,
+	// TriggerAction dispatches the action to the matching store method,
 	// then sends the updated template to ALL connections for this user.
 	//
 	// This behaves identically to client-initiated actions - the action is
-	// routed through Change(), errors are captured, and updates are broadcast
-	// to all of the user's connections (tabs/devices).
+	// dispatched to the matching method, errors are captured, and updates
+	// are broadcast to all of the user's connections (tabs/devices).
 	//
 	// Example:
 	//   session.TriggerAction("tick", nil)
@@ -162,7 +162,7 @@ type liveSession struct {
 	mu             sync.Mutex                  // Mutex for thread-safe operations
 }
 
-// TriggerAction triggers Store.Change() on all connections for this user,
+// TriggerAction dispatches the action to the matching store method,
 // then sends updates to all those connections.
 //
 // In distributed deployments with PubSub configured, this also publishes the
@@ -961,17 +961,9 @@ func (h *liveHandler) handleAction(ctx context.Context, msg message, state *conn
 		r:       r,
 	}
 
-	// Route action to store
-	// If store implements Store interface, call Change() for explicit routing
-	// Otherwise, auto-dispatch to method matching action name
-	var actionErr error
-	if changer, ok := store.(Store); ok {
-		// Store has explicit Change() method - use it
-		actionErr = changer.Change(actionCtx)
-	} else {
-		// No Change() method - auto-dispatch to action method
-		actionErr = Dispatch(store, actionCtx)
-	}
+	// Route action to store method matching the action name
+	// e.g., action "increment" → method Increment(ctx *ActionContext) error
+	actionErr := Dispatch(store, actionCtx)
 
 	if actionErr != nil {
 		// Process the error
@@ -1330,7 +1322,7 @@ func (h *liveHandler) handlePubSubMessage(msg *pubsub.BroadcastMessage) error {
 // handleServerActionMessage handles incoming server action messages from other instances.
 //
 // This is called by the RedisBroadcaster subscriber when a server action message is received.
-// It triggers Store.Change() and sends updates to local connections for the target user.
+// It dispatches to the matching store method and sends updates to local connections for the target user.
 func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage) error {
 	// Get all connections for this user
 	connections := h.registry.GetByUser(msg.UserID)
@@ -1553,7 +1545,7 @@ func (h *liveHandler) handleMultipartUploads(r *http.Request, sessionID string, 
 			errors: make(map[string]string),
 		}
 
-		uploadAction := fmt.Sprintf("upload:%s:complete", uploadName)
+		uploadAction := fmt.Sprintf("upload_%s_complete", uploadName)
 		uploadMsg := message{
 			Action: uploadAction,
 			Data:   make(map[string]interface{}),
@@ -1894,10 +1886,10 @@ func (h *liveHandler) handleUploadComplete(ctx context.Context, conn *websocket.
 	}
 
 	// Hybrid approach: Trigger action with special upload action name
-	// Stores can handle "upload:<field>:complete" for auto-processing
+	// Stores can handle "upload_<field>_complete" via UploadFieldComplete method
 	// or wait for explicit form submission where uploads will be accessible via ActionContext
 	if len(completedEntries) > 0 {
-		uploadAction := fmt.Sprintf("upload:%s:complete", completeMsg.UploadName)
+		uploadAction := fmt.Sprintf("upload_%s_complete", completeMsg.UploadName)
 		uploadMsg := message{
 			Action: uploadAction,
 			Data:   make(map[string]interface{}), // Empty data, uploads are in ActionContext

--- a/pubsub/redis.go
+++ b/pubsub/redis.go
@@ -147,8 +147,8 @@ func (b *RedisBroadcaster) PublishToUser(userID string, payload []byte) error {
 
 // PublishServerAction publishes a server-initiated action to all instances for a user.
 //
-// This triggers Store.Change() on receiving instances, enabling server-initiated
-// actions to work across a distributed deployment.
+// This dispatches to the matching store method on receiving instances, enabling
+// server-initiated actions to work across a distributed deployment.
 func (b *RedisBroadcaster) PublishServerAction(userID string, action string, data map[string]interface{}) error {
 	if userID == "" {
 		return fmt.Errorf("userID cannot be empty")

--- a/pubsub/types.go
+++ b/pubsub/types.go
@@ -66,7 +66,7 @@ type Broadcaster interface {
 	PublishToUser(userID string, payload []byte) error
 
 	// PublishServerAction publishes a server-initiated action to all instances for a user.
-	// This triggers Store.Change() on receiving instances.
+	// This dispatches to the matching store method on receiving instances.
 	PublishServerAction(userID string, action string, data map[string]interface{}) error
 
 	// Subscribe starts listening for broadcast messages and calls the handler
@@ -87,8 +87,8 @@ type MessageHandler func(msg *BroadcastMessage) error
 
 // ServerActionMessage represents a server-initiated action sent over Redis Pub/Sub.
 //
-// This message type triggers Store.Change() on receiving instances, enabling
-// server-initiated actions to work across a distributed deployment.
+// This message type dispatches to the matching store method on receiving instances,
+// enabling server-initiated actions to work across a distributed deployment.
 type ServerActionMessage struct {
 	// Type identifies the message type (always "server_action")
 	Type string `json:"type"`

--- a/session_test.go
+++ b/session_test.go
@@ -338,12 +338,13 @@ func TestSessionStore_Interface(t *testing.T) {
 	var _ SessionStore = (*MemorySessionStore)(nil)
 }
 
-// testStore is a simple Store implementation for testing (memory store tests)
+// testStore is a simple store for testing (memory store tests)
 type testStore struct {
 	value int
 }
 
-func (s *testStore) Change(ctx *ActionContext) error {
+// Increment handles the "increment" action
+func (s *testStore) Increment(_ *ActionContext) error {
 	s.value++
 	return nil
 }
@@ -352,13 +353,14 @@ func (s *testStore) Change(ctx *ActionContext) error {
 // Redis Session Store Tests
 // =============================================================================
 
-// TestStore is a Store implementation for testing with gob serialization
+// TestStore is a store for testing with gob serialization
 type TestStore struct {
 	Value   int
 	Message string
 }
 
-func (t *TestStore) Change(ctx *ActionContext) error {
+// Increment handles the "increment" action
+func (t *TestStore) Increment(_ *ActionContext) error {
 	t.Value++
 	return nil
 }
@@ -924,19 +926,35 @@ type SessionTestStore struct {
 	mu        sync.Mutex
 }
 
-func (s *SessionTestStore) Change(ctx *ActionContext) error {
+// Increment handles the "increment" action
+func (s *SessionTestStore) Increment(_ *ActionContext) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	switch ctx.Action {
-	case "increment":
-		s.Counter++
-	case "decrement":
-		s.Counter--
-	case "tick":
-		s.Counter++
-	case "reset":
-		s.Counter = 0
-	}
+	s.Counter++
+	return nil
+}
+
+// Decrement handles the "decrement" action
+func (s *SessionTestStore) Decrement(_ *ActionContext) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Counter--
+	return nil
+}
+
+// Tick handles the "tick" action
+func (s *SessionTestStore) Tick(_ *ActionContext) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Counter++
+	return nil
+}
+
+// Reset handles the "reset" action
+func (s *SessionTestStore) Reset(_ *ActionContext) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Counter = 0
 	return nil
 }
 

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -12,10 +12,6 @@ type ShutdownState struct {
 	Value int
 }
 
-func (s *ShutdownState) Change(ctx *ActionContext) error {
-	return nil
-}
-
 func TestLiveHandler_Shutdown_RejectsNewConnections(t *testing.T) {
 	tmpl := Must(New("shutdown-test"))
 	handler := tmpl.Handle(&ShutdownState{})

--- a/template.go
+++ b/template.go
@@ -4,35 +4,38 @@
 //
 // # Quick Start
 //
-// Define your application state as a Go struct that implements the Store interface:
+// Define your application state as a Go struct with methods for each action:
 //
-//	type CounterState struct {
-//	    Counter int `json:"counter"`
+//	type Counter struct {
+//	    Count int
 //	}
 //
-//	func (s *CounterState) Change(ctx *livetemplate.ActionContext) error {
-//	    switch ctx.Action {
-//	    case "increment":
-//	        s.Counter++
-//	    case "decrement":
-//	        s.Counter--
-//	    }
+//	func (c *Counter) Increment(ctx *livetemplate.ActionContext) error {
+//	    c.Count++
 //	    return nil
 //	}
+//
+//	func (c *Counter) Decrement(ctx *livetemplate.ActionContext) error {
+//	    c.Count--
+//	    return nil
+//	}
+//
+// Actions are automatically dispatched to methods matching the action name
+// (e.g., "increment" → Increment, "add_item" → AddItem).
 //
 // Create a template with `lvt-*` attributes for event binding:
 //
 //	<!-- counter.tmpl -->
-//	<h1>Counter: {{.Counter}}</h1>
+//	<h1>Counter: {{.Count}}</h1>
 //	<button lvt-click="increment">+</button>
 //	<button lvt-click="decrement">-</button>
 //
 // Wire it up in your main function:
 //
 //	func main() {
-//	    state := &CounterState{Counter: 0}
+//	    counter := &Counter{Count: 0}
 //	    tmpl := livetemplate.New("counter")
-//	    http.Handle("/", tmpl.Handle(state))
+//	    http.Handle("/", tmpl.Handle(counter))
 //	    http.ListenAndServe(":8080", nil)
 //	}
 //
@@ -1208,17 +1211,16 @@ func (t *Template) compareTreesAndGetChangesWithContext(oldTree, newTree *treeNo
 
 // Handle creates an http.Handler for the template with the given stores.
 // For single store: actions like "increment", "decrement"
-// For multiple stores: actions like "counterstate.increment", "userstate.logout"
+// For multiple stores: actions like "counter.increment", "user.logout"
 // Store names are automatically derived from struct type names (case-insensitive matching).
 //
-// Stores can be any struct type:
-//   - If the store implements Store interface (has Change() method), that is called for all actions
-//   - Otherwise, actions are automatically dispatched to matching methods (e.g., "increment" → Increment())
+// Actions are automatically dispatched to methods matching the action name.
+// Method signature: func (s *Store) ActionName(ctx *ActionContext) error
 //
 // The automatic dispatch supports multiple action formats:
 //   - snake_case: "add_item" → AddItem()
 //   - camelCase: "addItem" → AddItem()
-//   - lowercase: "additem" → AddItem() (case-insensitive)
+//   - PascalCase: "AddItem" → AddItem()
 func (t *Template) Handle(stores ...interface{}) LiveHandler {
 	if len(stores) == 0 {
 		panic("Handle requires at least one store")

--- a/upload_actioncontext_test.go
+++ b/upload_actioncontext_test.go
@@ -1,7 +1,6 @@
 package livetemplate
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -21,30 +20,23 @@ func TestActionContextUploadAccess(t *testing.T) {
 		t.Fatalf("Failed to parse template: %v", err)
 	}
 
-	// Create test store that handles upload action
+	// Create test store that handles upload action via UploadAvatarComplete method
 	store := &testUploadActionStore{
 		onUploadAction: func(ctx *ActionContext) error {
 			t.Logf("Upload action called: %s", ctx.Action)
 
-			// Verify action name format
-			if !strings.HasPrefix(ctx.Action, "upload:") {
-				t.Errorf("Expected action to start with 'upload:', got: %s", ctx.Action)
+			// Verify action name format (now uses underscores: upload_avatar_complete)
+			expected := "upload_avatar_complete"
+			if ctx.Action != expected {
+				t.Errorf("Expected action %q, got: %s", expected, ctx.Action)
 			}
-
-			// Extract upload name from action
-			parts := strings.Split(ctx.Action, ":")
-			if len(parts) < 2 {
-				t.Errorf("Invalid upload action format: %s", ctx.Action)
-				return nil
-			}
-			uploadName := parts[1]
 
 			// Verify we can access uploads via ActionContext
-			if !ctx.HasUploads(uploadName) {
+			if !ctx.HasUploads("avatar") {
 				t.Log("HasUploads returned false (expected in this test)")
 			}
 
-			uploads := ctx.GetCompletedUploads(uploadName)
+			uploads := ctx.GetCompletedUploads("avatar")
 			t.Logf("Found %d completed uploads", len(uploads))
 
 			return nil
@@ -65,8 +57,9 @@ type testUploadActionStore struct {
 	onUploadAction func(ctx *ActionContext) error
 }
 
-func (s *testUploadActionStore) Change(ctx *ActionContext) error {
-	if strings.HasPrefix(ctx.Action, "upload:") && s.onUploadAction != nil {
+// UploadAvatarComplete handles the "upload_avatar_complete" action
+func (s *testUploadActionStore) UploadAvatarComplete(ctx *ActionContext) error {
+	if s.onUploadAction != nil {
 		return s.onUploadAction(ctx)
 	}
 	return nil

--- a/upload_integration_test.go
+++ b/upload_integration_test.go
@@ -19,28 +19,32 @@ type TestUploadState struct {
 	consumeError    error
 }
 
-// TestStore for integration testing - uses new ActionContext pattern
+// TestUploadStore for integration testing - uses new ActionContext pattern
 type TestUploadStore struct {
 	State *TestUploadState // Shared state across clones (exported for cloning)
 }
 
-func (s *TestUploadStore) Change(ctx *ActionContext) error {
-	// Handle upload completion via ActionContext
-	if strings.HasPrefix(ctx.Action, "upload:") {
-		// Extract upload name from action (e.g., "upload:avatar:complete" -> "avatar")
-		parts := strings.Split(ctx.Action, ":")
-		if len(parts) >= 2 {
-			uploadName := parts[1]
+// UploadAvatarComplete handles the "upload_avatar_complete" action
+func (s *TestUploadStore) UploadAvatarComplete(ctx *ActionContext) error {
+	if s.State != nil {
+		s.State.uploadsCalled = true
+		s.State.consumedUpload = "avatar"
+		s.State.consumedEntries = ctx.GetCompletedUploads("avatar")
+		if s.State.consumeError != nil {
+			return s.State.consumeError
+		}
+	}
+	return nil
+}
 
-			if s.State != nil {
-				s.State.uploadsCalled = true
-				s.State.consumedUpload = uploadName
-				s.State.consumedEntries = ctx.GetCompletedUploads(uploadName)
-				// If there's a consume error set, return it
-				if s.State.consumeError != nil {
-					return s.State.consumeError
-				}
-			}
+// UploadDocumentsComplete handles the "upload_documents_complete" action
+func (s *TestUploadStore) UploadDocumentsComplete(ctx *ActionContext) error {
+	if s.State != nil {
+		s.State.uploadsCalled = true
+		s.State.consumedUpload = "documents"
+		s.State.consumedEntries = ctx.GetCompletedUploads("documents")
+		if s.State.consumeError != nil {
+			return s.State.consumeError
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Remove the `Store` interface with `Change()` method - all stores now use automatic method dispatch
- Simplify routing logic in `mount.go` to always use `Dispatch()`
- Change upload action format from `upload:name:complete` to `upload_name_complete` (colons invalid in Go method names)
- Add comprehensive `docs/references/controller-pattern.md` reference documentation

**BREAKING CHANGE**: The dual action routing system has been removed. The `Store` interface no longer exists. All stores must use method dispatch where actions route to methods by name.

## Migration

Convert `Change()` switch statements to individual methods:

```go
// Before
func (s *Counter) Change(ctx *ActionContext) error {
    switch ctx.Action {
    case "increment": s.Count++
    case "decrement": s.Count--
    }
    return nil
}

// After
func (s *Counter) Increment(_ *ActionContext) error {
    s.Count++
    return nil
}
func (s *Counter) Decrement(_ *ActionContext) error {
    s.Count--
    return nil
}
```

For upload actions, change action names:
- Before: `upload:avatar:complete`
- After: `upload_avatar_complete` → method `UploadAvatarComplete()`

## Test plan

- [x] All existing tests pass
- [x] Test stores migrated to method dispatch
- [x] Upload integration tests updated with new action format

🤖 Generated with [Claude Code](https://claude.com/claude-code)