### PR TITLE
fix: add type guard in SetDynamic to prevent raw structs in tree dynamics

### DIFF
--- a/internal/build/types.go
+++ b/internal/build/types.go
@@ -195,6 +195,7 @@ func (tn *TreeNode) SetDynamic(position string, value interface{}) {
 //   - TreeNode pointers (for nested tree structures)
 //   - RangeData pointers (for range operations)
 //   - Maps (for serialized data in diff operations)
+//   - Slices and arrays (valid JSON types)
 //
 // Raw structs and struct pointers (other than TreeNode/RangeData) are NOT tree-compatible
 // because they would serialize to JSON objects instead of strings.
@@ -227,8 +228,7 @@ func isTreeCompatible(v interface{}) bool {
 		return true
 	}
 
-	// For other types, check if it's a struct or pointer to struct
-	// These are NOT tree-compatible and should be converted to string
+	// For other types, use reflection to check the kind
 	rv := reflect.ValueOf(v)
 	kind := rv.Kind()
 
@@ -240,13 +240,29 @@ func isTreeCompatible(v interface{}) bool {
 		kind = rv.Elem().Kind()
 	}
 
-	// Structs (other than TreeNode/RangeData) are not tree-compatible
+	// Slices and arrays are valid JSON types - always compatible
+	if kind == reflect.Slice || kind == reflect.Array {
+		return true
+	}
+
+	// Maps are valid JSON types - always compatible
+	if kind == reflect.Map {
+		return true
+	}
+
+	// Structs (other than TreeNode/RangeData which are handled above) are not tree-compatible
+	// because they would serialize to JSON objects instead of strings
 	if kind == reflect.Struct {
 		return false
 	}
 
-	// Other types (channels, functions, etc.) are also not tree-compatible
-	return false
+	// Channels, functions, and other special types are not tree-compatible
+	if kind == reflect.Chan || kind == reflect.Func || kind == reflect.UnsafePointer {
+		return false
+	}
+
+	// All other types (including remaining primitives) are compatible
+	return true
 }
 
 // GetDynamic retrieves a dynamic value at the given position.

--- a/internal/build/types_test.go
+++ b/internal/build/types_test.go
@@ -128,8 +128,21 @@ func TestIsTreeCompatible(t *testing.T) {
 		{"*RangeData", &RangeData{}, true},
 		{"map[string]interface{}", map[string]interface{}{"key": "value"}, true},
 		{"[]interface{}", []interface{}{"a", "b"}, true},
+		// Typed slices should be compatible (valid JSON arrays)
+		{"[]string", []string{"a", "b", "c"}, true},
+		{"[]int", []int{1, 2, 3}, true},
+		{"[]CustomStruct", []CustomStruct{{Field: "a"}, {Field: "b"}}, true},
+		// Arrays should be compatible (valid JSON arrays)
+		{"[3]int", [3]int{1, 2, 3}, true},
+		{"[2]string", [2]string{"a", "b"}, true},
+		// Typed maps should be compatible (valid JSON objects)
+		{"map[string]string", map[string]string{"key": "value"}, true},
+		{"map[string]int", map[string]int{"count": 42}, true},
+		// Raw structs should NOT be compatible
 		{"custom struct", CustomStruct{Field: "test"}, false},
 		{"*custom struct", &CustomStruct{Field: "test"}, false},
+		// Channels and functions should NOT be compatible
+		{"chan int", make(chan int), false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add defense-in-depth type checking in `SetDynamic()` to ensure only tree-compatible values are stored in the Dynamics map
- Raw structs and struct pointers (other than TreeNode/RangeData) are automatically converted to their string representation
- This prevents "Object value reached string conversion" errors in the client when raw struct values accidentally leak into the tree JSON

## Changes

### `internal/build/types.go`
- Added `isTreeCompatible()` function to check if a value can be stored in tree dynamics
- Modified `SetDynamic()` to convert incompatible types to strings

### `internal/build/types_test.go`
- Added `TestTreeNode_SetDynamic_TypeGuard` to verify struct-to-string conversion
- Added `TestIsTreeCompatible` to test the type checking logic

## Tree-Compatible Types

| Type | Compatible | Reason |
|------|------------|--------|
| `string`, `int*`, `float*`, `bool` | ✅ | Primitives serialize correctly |
| `*TreeNode`, `*RangeData` | ✅ | Intentional tree structures |
| `map[string]interface{}` | ✅ | Used in diff operations |
| `[]interface{}` | ✅ | Used in RangeData.Items |
| Custom structs | ❌ → string | Would serialize as JSON objects |
| `*CustomStruct` | ❌ → string | Same as above |

## Test plan

- [x] All existing livetemplate tests pass
- [x] New type guard tests pass
- [x] lvt e2e tests work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)