### PR TITLE
fix: handle non-TreeNode to TreeNode transitions in range updates

### DIFF
--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -378,11 +378,14 @@ func handleNestedTreeNodeChange(
 	// Check if old value is also a TreeNode
 	oldTreeNode, oldIsTree := oldValue.(*TreeNode)
 
-	// If old value is NOT a TreeNode (e.g., empty string "") but new value IS a TreeNode,
-	// we need to send the full new TreeNode WITH statics, because the client doesn't have
-	// these statics cached for this field. This handles transitions like "" -> {"s":["checked"]}
-	if !oldIsTree && exists {
-		// Transition from non-TreeNode to TreeNode - send full new value with statics
+	// If old value is NOT a TreeNode (e.g., empty string "", nil, or non-existent),
+	// but new value IS a TreeNode, we need to send the full new TreeNode WITH statics,
+	// because the client doesn't have these statics cached for this field.
+	// This handles transitions like:
+	// - "" -> {"s":["checked"]} (empty string to TreeNode)
+	// - nil -> {"s":["checked"]} (non-existent field to TreeNode)
+	if !oldIsTree {
+		// Transition from non-TreeNode (or non-existent) to TreeNode - send full new value with statics
 		changes[fieldKey] = PrepareTreeForClient(newTreeNode, false)
 		return
 	}

--- a/internal/diff/range_ops_test.go
+++ b/internal/diff/range_ops_test.go
@@ -970,3 +970,98 @@ func TestCompareRangeItemsForChanges_Changed(t *testing.T) {
 		t.Error("Unchanged field should not be in changes")
 	}
 }
+
+// TestCompareRangeItemsForChanges_NonTreeNodeToTreeNode tests transition from
+// non-TreeNode value (e.g., empty string) to TreeNode with statics.
+// This is the case for checkbox toggles: "" -> {"s":["checked"]}
+func TestCompareRangeItemsForChanges_NonTreeNodeToTreeNode(t *testing.T) {
+	// Old item has an empty string for the checkbox field
+	oldItem := &TreeNode{
+		Dynamics: map[string]interface{}{
+			"0": "task1",
+			"1": "",         // Empty string (unchecked checkbox)
+			"2": "Task text",
+		},
+	}
+
+	// New item has a TreeNode with statics for the checkbox field
+	newItem := &TreeNode{
+		Dynamics: map[string]interface{}{
+			"0": "task1",
+			"1": &TreeNode{Statics: []string{"checked"}}, // TreeNode with statics (checked)
+			"2": "Task text",
+		},
+	}
+
+	statics := []string{"<li>", "<input ", ">", "</li>"}
+
+	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
+
+	// Should have 1 change for field "1"
+	if len(changes) != 1 {
+		t.Fatalf("Expected 1 change, got %d: %v", len(changes), changes)
+	}
+
+	// The change should include the full TreeNode with statics (not stripped)
+	change1, ok := changes["1"]
+	if !ok {
+		t.Fatal("Expected change for field '1'")
+	}
+
+	// PrepareTreeForClient returns *TreeNode when clientHasStatics=false
+	changeTree, ok := change1.(*TreeNode)
+	if !ok {
+		t.Fatalf("Expected *TreeNode for change, got %T: %v", change1, change1)
+	}
+
+	// Statics should be preserved (["checked"])
+	if len(changeTree.Statics) != 1 || changeTree.Statics[0] != "checked" {
+		t.Errorf("Expected statics ['checked'], got %v", changeTree.Statics)
+	}
+}
+
+// TestCompareRangeItemsForChanges_NonExistentToTreeNode tests transition from
+// non-existent field to TreeNode with statics.
+func TestCompareRangeItemsForChanges_NonExistentToTreeNode(t *testing.T) {
+	// Old item doesn't have the field at all
+	oldItem := &TreeNode{
+		Dynamics: map[string]interface{}{
+			"0": "task1",
+			// Field "1" doesn't exist
+		},
+	}
+
+	// New item has a TreeNode with statics for the field
+	newItem := &TreeNode{
+		Dynamics: map[string]interface{}{
+			"0": "task1",
+			"1": &TreeNode{Statics: []string{"checked"}}, // TreeNode with statics
+		},
+	}
+
+	statics := []string{"<li>", "<input ", ">", "</li>"}
+
+	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
+
+	// Should have 1 change for field "1"
+	if len(changes) != 1 {
+		t.Fatalf("Expected 1 change, got %d: %v", len(changes), changes)
+	}
+
+	// The change should include the full TreeNode with statics
+	change1, ok := changes["1"]
+	if !ok {
+		t.Fatal("Expected change for field '1'")
+	}
+
+	// PrepareTreeForClient returns *TreeNode when clientHasStatics=false
+	changeTree, ok := change1.(*TreeNode)
+	if !ok {
+		t.Fatalf("Expected *TreeNode for change, got %T: %v", change1, change1)
+	}
+
+	// Statics should be preserved (["checked"])
+	if len(changeTree.Statics) != 1 || changeTree.Statics[0] != "checked" {
+		t.Errorf("Expected statics ['checked'], got %v", changeTree.Statics)
+	}
+}


### PR DESCRIPTION
## Summary

When a field transitions from a non-TreeNode value (e.g., empty string `""`) to a TreeNode with statics (e.g., `{"s":["checked"]}`), the client doesn't have these statics cached. Previously, the code stripped statics and sent an empty string, causing the DOM update to fail.

Now `handleNestedTreeNodeChange` detects this transition and sends the full TreeNode WITH statics, ensuring the client can properly render the new structure.

## Problem

In range loops, when toggling a checkbox from unchecked to checked:
- Old value: `""` (empty string, not a TreeNode)
- New value: `{"s":["checked"]}` (TreeNode with statics)

The previous code would:
1. Strip statics from the new TreeNode
2. Get an empty result
3. Send `["u", "task1"]` without any change data
4. DOM doesn't update

## Solution

Detect when `oldValue` is not a TreeNode but `newValue` is, and send the full TreeNode with statics in that case.

## Test plan

- [x] All existing diff tests pass
- [x] Fixes checkbox toggle updates in livemdtools markdown data source E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)