### PR TITLE
fix: handle range→else transitions in top-level range handling

### DIFF
--- a/internal/diff/tree_compare.go
+++ b/internal/diff/tree_compare.go
@@ -59,23 +59,41 @@ func handleTopLevelRange(
 	registry StructureRegistry,
 	changes *TreeNode,
 ) bool {
-	// CRITICAL FIX: Check if both trees ARE range constructs (top-level range template)
-	// Example: {{range .Items}}<div>...</div>{{end}} where the entire tree is a range
-	// OR if newTree is a range but oldTree isn't (range appearing for first time, e.g., from {{else}} clause)
-	if oldTree != nil && newTree != nil && newTree.HasRange() && newTree.HasStatics() {
-		// Case 1: Both are ranges and matched
+	if oldTree == nil || newTree == nil {
+		return false
+	}
+
+	// Case 1: newTree is a range (with or without items)
+	// This covers: range→range transitions and else→range transitions
+	if newTree.HasRange() && newTree.HasStatics() {
 		if oldTree.HasRange() && oldTree.HasStatics() {
+			// Both are ranges - use differential operations if matched
 			if _, isMatched := rangeMatches[currentPath]; isMatched {
 				return handleMatchedRanges(oldTree, newTree, currentPath, registry, changes)
 			}
 		} else {
-			// Case 2: newTree is a range but oldTree isn't (range appearing for first time)
-			// This happens when going from {{else}} clause to range content
-			// Return the full new tree so client can replace the else content with range items
+			// else→range: newTree is a range but oldTree isn't
+			// Return full new tree so client can replace the else content with range items
 			*changes = *newTree
 			return true
 		}
 	}
+
+	// Case 2: range→else transition
+	// oldTree was a range (had items) but newTree is NOT a range (it's the else clause content)
+	// This happens when collection becomes empty: {{range .Items}}...{{else}}No items{{end}}
+	if oldTree.HasRange() && oldTree.HasStatics() && !newTree.HasRange() {
+		// Return full new tree so client can replace range items with else content
+		// Also invalidate registry for this path since the range structure is gone
+		registryUsable := registry != nil && !isNilRegistry(registry)
+		if registryUsable {
+			rangeStaticsPath := currentPath + ".__range_statics__"
+			registry.InvalidatePath(rangeStaticsPath)
+		}
+		*changes = *newTree
+		return true
+	}
+
 	return false
 }
 

--- a/internal/diff/tree_compare_test.go
+++ b/internal/diff/tree_compare_test.go
@@ -268,6 +268,80 @@ func TestHandleTopLevelRange_NewRange(t *testing.T) {
 	}
 }
 
+// TestHandleTopLevelRange_RangeToElse tests when range disappears and else clause appears.
+// This is the inverse of TestHandleTopLevelRange_NewRange.
+// Example: {{range .Items}}<item/>{{else}}No items{{end}}
+// When .Items goes from having items to empty, the else clause should replace the range.
+func TestHandleTopLevelRange_RangeToElse(t *testing.T) {
+	// Old tree is a range with items
+	oldTree := &TreeNode{
+		Statics: []string{"<div>", "</div>"},
+		Range: &RangeData{
+			Items:   []interface{}{map[string]interface{}{"id": "1"}},
+			Statics: []string{"<div>", "</div>"},
+		},
+	}
+
+	// New tree is NOT a range - it's the else clause content
+	// Example: <p>No items found matching "{{.SearchQuery}}"</p>
+	newTree := &TreeNode{
+		Statics:  []string{"<p>No items found matching \"", "\"</p>"},
+		Dynamics: map[string]interface{}{"0": "test query"},
+	}
+
+	changes := &TreeNode{Dynamics: make(map[string]interface{})}
+	handled := handleTopLevelRange(oldTree, newTree, "", nil, nil, changes)
+
+	if !handled {
+		t.Error("Expected handleTopLevelRange to return true for range→else transition")
+	}
+
+	// Should return full new tree (the else clause content)
+	if !changes.HasStatics() {
+		t.Error("Expected changes to have Statics from else clause")
+	}
+
+	// Verify the else clause content was properly returned
+	if changes.Dynamics["0"] != "test query" {
+		t.Errorf("Expected changes to contain else clause dynamic content, got: %v", changes.Dynamics["0"])
+	}
+}
+
+// TestHandleTopLevelRange_RangeToElse_WithRegistry tests range→else with registry invalidation.
+func TestHandleTopLevelRange_RangeToElse_WithRegistry(t *testing.T) {
+	registry := newMockRegistry()
+
+	// Mark the range statics as seen
+	registry.MarkSeen("testpath.__range_statics__", true)
+
+	// Old tree is a range
+	oldTree := &TreeNode{
+		Statics: []string{"<li>", "</li>"},
+		Range: &RangeData{
+			Items:   []interface{}{map[string]interface{}{"id": "1"}},
+			Statics: []string{"<li>", "</li>"},
+		},
+	}
+
+	// New tree is else clause
+	newTree := &TreeNode{
+		Statics:  []string{"<p>Empty</p>"},
+		Dynamics: map[string]interface{}{},
+	}
+
+	changes := &TreeNode{Dynamics: make(map[string]interface{})}
+	handled := handleTopLevelRange(oldTree, newTree, "testpath", nil, registry, changes)
+
+	if !handled {
+		t.Error("Expected handleTopLevelRange to return true")
+	}
+
+	// Registry should have been invalidated for range statics path
+	if registry.HasSeen("testpath.__range_statics__", nil) {
+		t.Error("Expected registry to be invalidated for range statics path after range→else transition")
+	}
+}
+
 // TestHandleMatchedRanges_WithOps tests matched ranges with operations.
 func TestHandleMatchedRanges_WithOps(t *testing.T) {
 	item1 := map[string]interface{}{"id": "1", "name": "Item 1"}


### PR DESCRIPTION
## Summary
- Fix bug where searching for non-existent terms shows repeated "No posts found matching [title]" messages
- Handle `range → else` transitions when collection becomes empty
- Invalidate registry for range statics path when transitioning to else clause

## Problem
When a Go template range construct transitions from having items to empty (the `{{else}}` clause), the tree changes from a Range structure to a non-Range else clause content. The existing code handled:
- `range → range` (differential updates)
- `else → range` (show items replacing else)

But missed:
- `range → else` (collection becomes empty, show else clause)

This caused the else clause template to be incorrectly merged with each existing range item.

## Solution
Added a new case in `handleTopLevelRange` that detects when:
- oldTree has Range and Statics (was a range with items)
- newTree does NOT have Range (is the else clause content)

In this case, return the full newTree so the client can replace the range items with the else clause content.

## Test plan
- [x] Added unit test `TestHandleTopLevelRange_RangeToElse`
- [x] Added unit test `TestHandleTopLevelRange_RangeToElse_WithRegistry`
- [x] All existing tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)