### PR TITLE
fix: skip Redis tests gracefully when Docker is unavailable

### DIFF
--- a/internal/testutil/redis.go
+++ b/internal/testutil/redis.go
@@ -3,6 +3,8 @@ package testutil
 import (
 	"context"
 	"log"
+	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,15 +12,46 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/redis"
 )
 
+var (
+	dockerAvailable     bool
+	dockerAvailableOnce sync.Once
+)
+
+// IsDockerAvailable checks if Docker is available for running containers.
+// The result is cached after the first call.
+func IsDockerAvailable() bool {
+	dockerAvailableOnce.Do(func() {
+		// Try to run "docker info" to check if Docker is available
+		cmd := exec.Command("docker", "info")
+		if err := cmd.Run(); err != nil {
+			dockerAvailable = false
+			return
+		}
+		dockerAvailable = true
+	})
+	return dockerAvailable
+}
+
+// SkipIfNoDocker skips the test if Docker is not available.
+func SkipIfNoDocker(t *testing.T) {
+	t.Helper()
+	if !IsDockerAvailable() {
+		t.Skip("Docker not available, skipping test")
+	}
+}
+
 // RedisContainer holds the Redis testcontainer and client
 type RedisContainer struct {
 	Container *redis.RedisContainer
 	Client    goredis.UniversalClient
 }
 
-// StartRedisContainer starts a Redis container for testing
+// StartRedisContainer starts a Redis container for testing.
+// If Docker is not available, the test is skipped.
 func StartRedisContainer(ctx context.Context, t *testing.T) (*RedisContainer, error) {
 	t.Helper()
+
+	SkipIfNoDocker(t)
 
 	// Start Redis container
 	container, err := redis.Run(ctx,
@@ -94,8 +127,11 @@ func (rc *RedisContainer) Close(ctx context.Context) error {
 
 // GetTestRedisClient is a convenience function that starts a Redis container
 // and returns a client. It registers cleanup with t.Cleanup.
+// If Docker is not available, the test is skipped.
 func GetTestRedisClient(t *testing.T) goredis.UniversalClient {
 	t.Helper()
+
+	SkipIfNoDocker(t)
 
 	ctx := context.Background()
 	rc, err := StartRedisContainer(ctx, t)


### PR DESCRIPTION
## Summary
- Add Docker availability detection before running testcontainers
- Tests now skip gracefully with `t.Skip()` instead of panicking when Docker isn't available
- Uses `docker info` command to check availability, with result cached via `sync.Once`

## Problem
When running tests without Docker installed, the test suite would panic with:
```
panic: rootless Docker not found [recovered, repanicked]
```

This made it impossible to run any tests in environments without Docker.

## Solution
Added `IsDockerAvailable()` and `SkipIfNoDocker(t)` helpers that check for Docker before attempting to use testcontainers. Tests now output:
```
=== RUN   TestRedisSessionStore_SetAndGet
    session_test.go:260: Docker not available, skipping test
--- SKIP: TestRedisSessionStore_SetAndGet (0.92s)
```

## Test plan
- [x] Run `go test ./...` without Docker - tests skip gracefully
- [x] All other tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)