### PR TITLE
ci: skip heavy workflows for docs-only changes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,10 @@ name: Performance Benchmarks
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
   workflow_dispatch:  # Allow manual triggering
 
 permissions:

--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -3,8 +3,16 @@ name: Cross-Repository Tests
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   test-lvt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,16 @@ name: Tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` for `docs/**`, `**/*.md`, and `LICENSE` to the 3 heavy CI workflows (`test.yml`, `benchmark.yml`, `cross-repo-test.yml`)
- Bot reviewer workflows (`claude-code-review.yml`, `claude.yml`) are intentionally unchanged — they still run on all PRs since they review docs too
- Saves CI minutes on docs-only PRs while keeping full test coverage for code changes

## Test plan
- [x] Verify `paths-ignore` patterns are present in `test.yml` (push + pull_request)
- [x] Verify `paths-ignore` patterns are present in `benchmark.yml` (pull_request only; `workflow_dispatch` unchanged)
- [x] Verify `paths-ignore` patterns are present in `cross-repo-test.yml` (push + pull_request)
- [x] Verify bot reviewer workflows are not modified
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)