### PR TITLE
docs: update template-support-matrix.md with current codebase state

### DIFF
--- a/docs/references/template-support-matrix.md
+++ b/docs/references/template-support-matrix.md
@@ -184,6 +184,7 @@ Template composition is fully supported through automatic AST flattening. `Flatt
 | Phase 6 | 11 seeds | 61 | Pipelines, comparison/logical functions, index/len |
 
 **Total Baseline Coverage**: 2150 interesting inputs (after fuzzing)
+**Fuzz Executions**: Ongoing via multi-layer infrastructure (diff fuzzing, TypeScript oracle, mutation testing)
 **Failures**: 0 crashes, 0 structural errors
 
 ---


### PR DESCRIPTION
## Summary

- Fix broken file references (`tree_ast.go` → `internal/parse/`, `tree_fuzz_test.go` → `fuzz_diff_test.go`/`fuzz_ts_oracle_test.go`, `docs/fuzz-testing-strategy.md` → `docs/fuzz-framework-design.md`)
- Mark template composition (`{{define}}`/`{{template}}`/`{{block}}`) as ✅ fully supported via `FlattenTemplate()` (was ⚠️ limited)
- Add `$c := .` context alias variable declaration row
- Update validation level references to `internal/parse/var_context.go`
- Remove obsolete regex→AST parser migration section
- Remove stale `getOrderedDynamicKeys` reference
- Update metadata date and fuzz testing description

## Test plan

- [x] All 16 packages pass (`go test ./... -timeout=300s`)
- [x] No remaining references to `tree_ast.go`, `tree_fuzz_test.go`, `fuzz-testing-strategy.md`, or `getOrderedDynamicKeys`
- [x] All referenced files verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)