### PR TITLE
docs: fix authentication.md phantom methods and broken link

### DIFF
--- a/docs/references/authentication.md
+++ b/docs/references/authentication.md
@@ -205,16 +205,6 @@ ctx.Redirect("https://evil.com", http.StatusFound)  // Rejected
 ctx.Redirect("//evil.com", http.StatusFound)        // Rejected (protocol-relative)
 ```
 
-### Header Operations
-
-```go
-// Set response header
-ctx.SetHeader("X-Custom-Header", "value")
-
-// Get request header
-authHeader := ctx.GetHeader("Authorization")
-```
-
 ### Error Types
 
 ```go
@@ -430,4 +420,4 @@ LiveTemplate's `Redirect()` method automatically prevents open redirects by:
 - [Server Actions Reference](server-actions.md) - Push updates from server-side code
 - [Session Reference](session.md) - Session stores and connection management
 - [Error Handling](error-handling.md) - Validation and error display
-- [Scaling Guide](../SCALING.md) - Redis-backed session stores for distributed deployments
+- [Scaling Guide](../guides/SCALING.md) - Redis-backed session stores for distributed deployments


### PR DESCRIPTION
## Summary
- Remove undocumented `SetHeader()`/`GetHeader()` methods from Context HTTP Methods section (these methods don't exist in `context.go`)
- Fix broken link: `../SCALING.md` → `../guides/SCALING.md` (moved during docs reorg)

## Test plan
- [x] Verified `SetHeader`/`GetHeader` do not exist in `context.go`
- [x] Verified `docs/guides/SCALING.md` exists as link target
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)