### PR TITLE
docs: expand server-actions.md with pubsub package details

### DIFF
--- a/docs/references/server-actions.md
+++ b/docs/references/server-actions.md
@@ -446,6 +446,8 @@ type Broadcaster interface {
 
 ```go
 import (
+    "time"
+
     "github.com/livetemplate/livetemplate"
     "github.com/livetemplate/livetemplate/pubsub"
     "github.com/redis/go-redis/v9"


### PR DESCRIPTION
## Summary
- Expand Distributed Deployments section with full `pubsub.Broadcaster` interface docs
- Add Redis setup example with `NewRedisBroadcaster`
- Document broadcast scopes (Global, Group, User, ServerAction)
- Add deprecation note for old `Broadcaster`/`BroadcastAware` interfaces in `mount.go`
- Fix broken link: `../SCALING.md` → `../guides/SCALING.md`
- Remove stale examples repository link

## Test plan
- [x] Verified `pubsub.Broadcaster` interface matches `pubsub/types.go`
- [x] Verified `NewRedisBroadcaster` API matches `pubsub/redis.go`
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)