### PR TITLE
docs: fix broken links in CONFIGURATION.md and client-attributes.md

### DIFF
--- a/docs/references/CONFIGURATION.md
+++ b/docs/references/CONFIGURATION.md
@@ -328,6 +328,19 @@ tmpl := livetemplate.New("app",
 )
 ```
 
+### Additional Option Functions
+
+| Option | Description |
+|--------|-------------|
+| `WithUpgrader(upgrader)` | Custom `*websocket.Upgrader` for WebSocket connections |
+| `WithUpload(name, config)` | Configure file upload fields (see [Upload Reference](uploads.md)) |
+| `WithPubSubBroadcaster(broadcaster)` | Redis pub/sub for distributed deployments |
+| `WithComponentTemplates(sets...)` | Register component template sets |
+| `WithIgnoreTemplateDirs(dirs...)` | Skip directories during template discovery |
+| `WithPermissiveOriginCheck()` | Bypass origin check (dev only) |
+| `WithProgressiveEnhancement(enabled)` | Non-JS form submission support (default: true) |
+| `WithCookieMaxAge(duration)` | Session cookie max age (default: 365 days) |
+
 **Note**: Programmatic configuration takes precedence over environment variables.
 
 ## Validation
@@ -392,6 +405,6 @@ if err := envConfig.Validate(); err != nil {
 
 ## See Also
 
-- [ROADMAP.md](ROADMAP.md) - Production scalability roadmap
-- [OBSERVABILITY.md](OBSERVABILITY.md) - Logging and metrics guide
-- [SCALING.md](SCALING.md) - Scaling recommendations
+- [ROADMAP.md](../implementation-plans/ROADMAP.md) - Production scalability roadmap
+- [OBSERVABILITY.md](../guides/OBSERVABILITY.md) - Logging and metrics guide
+- [SCALING.md](../guides/SCALING.md) - Scaling recommendations

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -800,6 +800,5 @@ form.addEventListener('lvt:pending', (e) => {
 - **[Go API Reference](https://pkg.go.dev/github.com/livetemplate/livetemplate)** - Server-side API
 - **[Error Handling Reference](error-handling.md)** - Validation, error display, client-side handling
 - **[Template Support Matrix](template-support-matrix.md)** - Supported Go template features
-- **[Architecture](../ARCHITECTURE.md)** - System architecture
-- **[User Guide](../guides/user-guide.md)** - Getting started with CLI
+- **[Architecture](../design/ARCHITECTURE.md)** - System architecture
 - **[Contributing Guide](../../CONTRIBUTING.md)** - How to contribute


### PR DESCRIPTION
## Summary

**CONFIGURATION.md:**
- Fix 3 broken links in See Also section (ROADMAP, OBSERVABILITY, SCALING moved during docs reorg)
- Add missing `With*` option functions to Programmatic Configuration section (WithUpgrader, WithUpload, WithPubSubBroadcaster, WithComponentTemplates, WithIgnoreTemplateDirs, WithPermissiveOriginCheck, WithProgressiveEnhancement, WithCookieMaxAge)

**client-attributes.md:**
- Fix `../ARCHITECTURE.md` → `../design/ARCHITECTURE.md`
- Remove stale `../guides/user-guide.md` link (moved to archive)

## Test plan
- [x] Verified all link targets exist in docs/ directory
- [x] Verified all With* options exist in `template.go`
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)