### PR TITLE
docs: replace api-reference.md with Go library API reference

### DIFF
--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -206,16 +206,14 @@ Primarily useful in tests. In production, Context is created internally and pass
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `GetStringOk` | `(key string) (string, bool)` | Get a string value; bool indicates presence |
-| `GetIntOk` | `(key string) (int, bool)` | Get an integer value; bool indicates presence |
-| `GetFloatOk` | `(key string) (float64, bool)` | Get a float value; bool indicates presence |
-| `GetBoolOk` | `(key string) (bool, bool)` | Get a boolean value; bool indicates presence |
+| `GetString` | `(key string) string` | Get a string value from action data |
+| `GetInt` | `(key string) int` | Get an integer value |
+| `GetFloat` | `(key string) float64` | Get a float value |
+| `GetBool` | `(key string) bool` | Get a boolean value |
 | `Has` | `(key string) bool` | Check if a key exists in action data |
 | `Get` | `(key string) interface{}` | Get a raw value |
 | `Bind` | `(v interface{}) error` | Unmarshal action data into a struct |
 | `BindAndValidate` | `(v interface{}, validate *validator.Validate) error` | Bind and validate in one step |
-
-**Deprecated:** `GetString`, `GetInt`, `GetFloat`, `GetBool` (without `Ok` suffix) still work but return zero values on missing keys, making it impossible to distinguish missing from empty. Use the `*Ok` variants instead.
 
 ### HTTP Operations
 


### PR DESCRIPTION
## Summary

- Replaces the existing `api-reference.md` which documented the `lvt` CLI tool (separate repo) with a comprehensive Go library API reference
- Covers all public types, interfaces, and functions: Template, Controller+State, Context (26+ methods), Session, Authentication, SessionStores, Configuration (env vars + option functions), Uploads, Health checks, PubSub, and Error types
- All signatures verified against current source code

## Test plan

- [x] All Go tests pass (pre-commit hook)
- [x] Verified all documented API signatures match actual source code
- [x] Cross-referenced links to other reference docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)