### PR TITLE
test: ensure .lvt.Error is route scoped

### DIFF
--- a/handle_test.go
+++ b/handle_test.go
@@ -1515,12 +1515,15 @@ func TestWebSocketDisabled_ErrorsDoNotLeakAcrossRoutes_JSONClient(t *testing.T) 
 
 	handler := newWSDisabledHandler(t)
 
-	// Step 1: GET /page-a (HTML) to create session
+	// Step 1: GET /page-a (HTML first to create session before JSON requests)
 	req := httptest.NewRequest("GET", "/page-a", nil)
 	req.Header.Set("Accept", "text/html")
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d", rec.Code)
+	}
 	cookie := extractSessionCookie(rec)
 	if cookie == nil {
 		t.Fatal("Expected session cookie")


### PR DESCRIPTION
## Summary

- Adds regression tests verifying `.lvt.Error` does not leak across HTTP routes (closes #270)
- Code analysis confirmed errors are already correctly scoped: each HTTP request creates a fresh `connState` with empty messages (`mount.go:902-907`)
- Two tests cover: progressive enhancement HTML mode and JSON client mode (both include cross-route navigation)

## Test plan

- [x] `TestWebSocketDisabled_ErrorsDoNotLeakAcrossRoutes` — POST error on `/page-a`, verify GET on same and different route shows no errors, state integrity preserved
- [x] `TestWebSocketDisabled_ErrorsDoNotLeakAcrossRoutes_JSONClient` — Same via JSON API, verifying `meta.success` and `meta.errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)