### PR TITLE
fix: skip HTTP POST persistence on action error + multi-tab dedup logging

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -1146,7 +1146,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		connSt.state = newState
 	}
 
-	if h.config.StatePersistence || h.config.SharedState {
+	if actionErr == nil && (h.config.StatePersistence || h.config.SharedState) {
 		h.config.SessionStore.Set(r.Context(), groupID, connSt.state)
 	}
 
@@ -1780,6 +1780,14 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 	// sharing a groupID, while correctly handling multi-device users with
 	// different groupIDs).
 	if h.config.StatePersistence || h.config.SharedState {
+		successCount := len(connections) - errCount
+		if len(groupStates) > 0 && len(groupStates) < successCount {
+			slog.Debug("Server action: multi-tab state deduped for persistence",
+				slog.String("component", "pubsub_handler"),
+				slog.String("action", msg.Action),
+				slog.Int("connections", successCount),
+				slog.Int("groups_persisted", len(groupStates)))
+		}
 		for gid, st := range groupStates {
 			h.config.SessionStore.Set(context.Background(), gid, st)
 		}


### PR DESCRIPTION
## Summary

Follow-up fixes from PR #295 review (comment 4158039158).

## Changes

1. **Gate HTTP POST persistence behind `actionErr == nil`** (mount.go:1149)
   - Previously persisted unchanged state on validation errors (wasteful no-op)
   - Now aligned with WS action handler which already checks `actionErr == nil`

2. **Add `slog.Debug` for multi-tab server action dedup** (mount.go:1782)
   - Logs when multiple connections share a groupID and state is deduplicated
   - Helps operators diagnose unexpected state in multi-tab scenarios

## Test plan

- [x] `TestWebSocketDisabled_POSTValidationError` — passes (error path)
- [x] All persistence tests pass with `WithStatePersistence()`
- [x] All SharedState tests pass
- [x] Full suite: 16 packages, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)