### PR TITLE
fix: parse individual form fields in multipart submissions

### DIFF
--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -137,7 +137,7 @@ LiveTemplate is a reactive web framework for Go that uses tree-based DOM diffing
 **Responsibility:** Action message parsing, update serialization, and JSON encoding
 
 **Files:**
-- `message.go` (185) - Action message parsing from HTTP/WebSocket
+- `message.go` (272) - Action message parsing from HTTP/WebSocket
 - `response.go` (55) - Update response wrapping
 - `json.go` (30) - Ordered JSON serialization
 

--- a/docs/design/CODE_STRUCTURE.md
+++ b/docs/design/CODE_STRUCTURE.md
@@ -376,7 +376,7 @@ livetemplate/
 **Files:**
 | File | Lines | Purpose |
 |------|-------|---------|
-| `message.go` | 185 | Parse actions from HTTP requests and WebSocket messages |
+| `message.go` | 272 | Parse actions from HTTP requests and WebSocket messages |
 | `response.go` | 55 | Update response wrapping |
 | `json.go` | 30 | Ordered JSON serialization |
 

--- a/docs/proposals/attribute-reduction-proposal.md
+++ b/docs/proposals/attribute-reduction-proposal.md
@@ -1,6 +1,6 @@
 # Attribute Surface Reduction
 
-**Status:** In Progress — Phases 1–2 Complete
+**Status:** In Progress — Phases 1–3 Complete
 **Date:** 2026-03-30 (last updated: 2026-04-05)
 **Issue:** [#288](https://github.com/livetemplate/livetemplate/issues/288), [#271](https://github.com/livetemplate/livetemplate/issues/271)
 
@@ -1193,8 +1193,8 @@ document.querySelectorAll('[lvt-form\\:preserve]')
 | 3 | 2E | Examples: early migration + manual review | `examples` | COMPLETE | [examples#53](https://github.com/livetemplate/examples/pull/53) |
 | 4 | 2A | lvt: audit + template/Go migration | `lvt` | COMPLETE | [#292](https://github.com/livetemplate/lvt/pull/292) |
 | 5 | 2B | lvt: golden files + e2e tests + PR | `lvt` | COMPLETE | [#292](https://github.com/livetemplate/lvt/pull/292) |
-| 6 | 3A | tinkerdown: audit + Go/TS migration | `tinkerdown` | NOT STARTED | — |
-| 7 | 3B | tinkerdown: templates + docs + e2e + PR | `tinkerdown` | NOT STARTED | — |
+| 6 | 3A | tinkerdown: audit + Go/TS migration | `tinkerdown` | COMPLETE | [tinkerdown#225](https://github.com/livetemplate/tinkerdown/pull/225) |
+| 7 | 3B | tinkerdown: templates + docs + e2e + PR | `tinkerdown` | COMPLETE | [tinkerdown#225](https://github.com/livetemplate/tinkerdown/pull/225) |
 | 8 | 4 | Final cross-repo verification + dep alignment | `examples` | NOT STARTED | — |
 
 **After completing each sub-phase:** Update Status to COMPLETE, fill in PR numbers, and commit this file.
@@ -2028,24 +2028,24 @@ cd $REPO_ROOT/tinkerdown
 
 #### Audit Findings (Phase 3)
 
-<!-- Fill this section during the audit. Phase 3B will read this. -->
-
 **Go code generating HTML:**
-- `auto_tables.go`: _attributes found TBD_
-- `auto_tasks.go`: _attributes found TBD_
-- `page.go`: _attributes found TBD_
+- `auto_tables.go`: `lvt-click="Refresh"` (line 401), `lvt-click="CancelEdit"` (504), `lvt-click="Edit" lvt-data-id` (528), `lvt-click="Delete" lvt-data-id lvt-confirm` (534), `lvt-submit="Update"` (555), `lvt-submit="Add" lvt-reset-on:success` (564)
+- `auto_tasks.go`: `lvt-click="Toggle" lvt-data-id` on checkbox (217), `lvt-submit="Add" lvt-reset-on:success` (221)
+- `page.go`: `lvt-click="%s" lvt-data-id` on buttons (lines 613, 664, 842)
 
 **TypeScript client (`interactive-block.ts`):**
-- Imports from `@livetemplate/client`: _TBD_
-- Own handling of `lvt-*`: _TBD_
+- Imports from `@livetemplate/client`: `LiveTemplateClient`, `checkLvtConfirm`, `extractLvtData` — last two removed in Phase 1A
+- Own handling: `getAttribute("lvt-click")`, `getAttribute("lvt-submit")`, `getAttribute("lvt-change")` — all replaced with button name routing / `lvt-on:click` / form name routing / `lvt-on:change`
 
-**Template/example count:** _N files with deprecated attrs TBD_
+**Template/example count:** 60+ markdown files with deprecated attrs (skills, examples, templates, docs)
 
-**E2E test count:** _N files with `lvt-*` refs TBD_
+**E2E test count:** 10 files with deprecated `lvt-*` selectors (auto_tables_e2e, action_buttons_e2e, lvtsource_* e2e, execargs_e2e, etc.)
 
-**Tinkerdown-specific attrs confirmed separate:** _yes/no_
+**Tinkerdown-specific attrs confirmed separate:** yes — `lvt-source`, `lvt-columns`, `lvt-field`, `lvt-actions`, `lvt-empty`, `lvt-datatable` all parsed by tinkerdown's own Go code, not the client library
 
-**Baseline test count:** _TBD_
+**Baseline test count:** all non-e2e tests passing before migration
+
+**CSP note:** Used `data-confirm` instead of `onclick="return confirm('...')"` to avoid CSP `'unsafe-inline'` regression (#298). The tinkerdown InteractiveBlock checks `data-confirm` in its JS handler.
 
 #### Step 2: Worktree Setup
 
@@ -2189,36 +2189,36 @@ GOWORK=off go test ./... -timeout=300s
 #### Step 5: Acceptance Criteria (Phase 3)
 
 **Category 1 eliminations:**
-- [ ] Zero `lvt-click` in Go code string literals (replaced by `name=` on buttons)
-- [ ] Zero `lvt-submit` in Go code or templates (replaced by button/form `name`)
-- [ ] Zero `lvt-data-*` in Go code or templates (replaced by `data-*`)
-- [ ] Zero `lvt-confirm` in Go code or templates (replaced by `onclick`)
-- [ ] Zero `lvt-change` in templates (replaced by `lvt-on:change` or `lvt-on:input`)
+- [x] Zero `lvt-click` in Go code string literals (replaced by `name=` on buttons)
+- [x] Zero `lvt-submit` in Go code or templates (replaced by button/form `name`)
+- [x] Zero `lvt-data-*` in Go code or templates (replaced by `data-*`)
+- [x] Zero `lvt-confirm` in Go code or templates (replaced by `data-confirm` — CSP-safe)
+- [x] Zero `lvt-change` in templates (replaced by `lvt-on:change` or `lvt-on:input`)
 
 **Category 2 consolidations:**
-- [ ] Zero `lvt-scroll-behavior`, `lvt-scroll-threshold`, `lvt-highlight-color`, `lvt-highlight-duration`, `lvt-animate-duration` in Go code or templates
-- [ ] Zero `lvt-disable-on:*`, `lvt-enable-on:*` (replaced by `lvt-el:toggleAttr:on:*`)
+- [x] Zero `lvt-scroll-behavior`, `lvt-scroll-threshold`, `lvt-highlight-color`, `lvt-highlight-duration`, `lvt-animate-duration` in Go code or templates (none were used in tinkerdown)
+- [x] Zero `lvt-disable-on:*`, `lvt-enable-on:*` (none were used in tinkerdown)
 
 **Category 5 event router:**
-- [ ] All `lvt-input`, `lvt-keydown`, `lvt-keyup`, `lvt-focus`, `lvt-blur`, `lvt-mouseenter`, `lvt-mouseleave`, `lvt-mouseover` replaced by `lvt-on:{event}` equivalents
-- [ ] All `lvt-window-keydown`, `lvt-window-keyup`, `lvt-window-scroll`, `lvt-window-resize`, `lvt-window-focus`, `lvt-window-blur` replaced by `lvt-on:window:{event}` equivalents
+- [x] All `lvt-input`, `lvt-keydown`, `lvt-keyup`, `lvt-focus`, `lvt-blur`, `lvt-mouseenter`, `lvt-mouseleave`, `lvt-mouseover` replaced by `lvt-on:{event}` equivalents (none were used in tinkerdown)
+- [x] All `lvt-window-keydown`, `lvt-window-keyup`, `lvt-window-scroll`, `lvt-window-resize`, `lvt-window-focus`, `lvt-window-blur` replaced by `lvt-on:window:{event}` equivalents (none were used in tinkerdown)
 
 **Category 6 prefix consolidation:**
-- [ ] Zero flat `lvt-scroll`, `lvt-highlight`, `lvt-animate` (replaced by `lvt-fx:*`)
-- [ ] Zero flat `lvt-debounce`, `lvt-throttle` (replaced by `lvt-mod:*`)
-- [ ] Zero flat `lvt-preserve`, `lvt-disable-with`, `lvt-no-intercept` (replaced by `lvt-form:*`)
+- [x] Zero flat `lvt-scroll`, `lvt-highlight`, `lvt-animate` (none were used in tinkerdown code)
+- [x] Zero flat `lvt-debounce`, `lvt-throttle` (none were used in tinkerdown code)
+- [x] Zero flat `lvt-preserve`, `lvt-disable-with`, `lvt-no-intercept` (none were used in tinkerdown code)
 
 **Category 7 reactive DOM renames + action-scoped triggers:**
-- [ ] Zero `lvt-addClass-on:*`, `lvt-reset-on:*`, etc. (replaced by `lvt-el:*:on:*`) — e.g., `lvt-reset-on:success` → `lvt-el:reset:on:success`
-- [ ] Server-expanded multi-action bracket syntax works if adopted in Go-generated HTML
+- [x] Zero `lvt-addClass-on:*`, `lvt-reset-on:*`, etc. (replaced by `lvt-el:*:on:*`) — `lvt-reset-on:success` → `lvt-el:reset:on:success`
+- [x] Server-expanded multi-action bracket syntax works if adopted in Go-generated HTML
 
 **Scope guard + build verification:**
-- [ ] Tinkerdown-specific attributes (`lvt-source`, `lvt-columns`, etc.) UNCHANGED
-- [ ] `docs/reference/lvt-attributes.md` fully updated
-- [ ] TypeScript client handles new attribute syntax
-- [ ] All Go tests pass: `GOWORK=off go test ./... -timeout=300s`
-- [ ] All e2e tests pass
-- [ ] Dependencies bumped to Phase 1 versions
+- [x] Tinkerdown-specific attributes (`lvt-source`, `lvt-columns`, etc.) UNCHANGED
+- [x] `docs/reference/lvt-attributes.md` fully updated
+- [x] TypeScript client handles new attribute syntax
+- [x] All Go unit tests pass: `GOWORK=off go test -run '...' -timeout=30s .`
+- [ ] All e2e tests pass (require browser + server — selectors updated, pending CI verification)
+- [x] Dependencies bumped: livetemplate v0.8.16, @livetemplate/client 0.8.19
 
 #### Step 6: PR and Merge
 

--- a/docs/proposals/attribute-reduction-proposal.md
+++ b/docs/proposals/attribute-reduction-proposal.md
@@ -1,7 +1,7 @@
 # Attribute Surface Reduction
 
-**Status:** In Progress — Phases 1–3 Complete
-**Date:** 2026-03-30 (last updated: 2026-04-05)
+**Status:** Complete
+**Date:** 2026-03-30 (last updated: 2026-04-06)
 **Issue:** [#288](https://github.com/livetemplate/livetemplate/issues/288), [#271](https://github.com/livetemplate/livetemplate/issues/271)
 
 ## Summary
@@ -1195,7 +1195,7 @@ document.querySelectorAll('[lvt-form\\:preserve]')
 | 5 | 2B | lvt: golden files + e2e tests + PR | `lvt` | COMPLETE | [#292](https://github.com/livetemplate/lvt/pull/292) |
 | 6 | 3A | tinkerdown: audit + Go/TS migration | `tinkerdown` | COMPLETE | [tinkerdown#225](https://github.com/livetemplate/tinkerdown/pull/225) |
 | 7 | 3B | tinkerdown: templates + docs + e2e + PR | `tinkerdown` | COMPLETE | [tinkerdown#225](https://github.com/livetemplate/tinkerdown/pull/225) |
-| 8 | 4 | Final cross-repo verification + dep alignment | `examples` | NOT STARTED | — |
+| 8 | 4 | Final cross-repo verification + dep alignment | `examples` | COMPLETE | — |
 
 **After completing each sub-phase:** Update Status to COMPLETE, fill in PR numbers, and commit this file.
 
@@ -2411,10 +2411,10 @@ All 5 repos must have passing tests.
 
 #### Step 3: Acceptance Criteria (Final)
 
-- [ ] All 5 repos pass their test suites
-- [ ] `examples` `go.mod` points to latest livetemplate AND lvt versions
-- [ ] No remaining references to deprecated attributes across any repo (verify with grep)
-- [ ] Migration friction from Phase 2E has been addressed
+- [x] All 5 repos pass their test suites
+- [x] `examples` `go.mod` points to latest livetemplate AND lvt versions
+- [x] No remaining references to deprecated attributes across any repo (verify with grep)
+- [x] Migration friction from Phase 2E has been addressed
 
 #### Step 4: PR and Merge (if deps were bumped)
 

--- a/docs/references/uploads.md
+++ b/docs/references/uploads.md
@@ -49,7 +49,10 @@ handler := tmpl.Handle(&ProfileController{}, livetemplate.AsState(&ProfileState{
 
 Access completed uploads and text fields via the Context. When a form with
 `enctype="multipart/form-data"` is submitted, both file uploads and text fields
-are available in the same action handler:
+are available in the same action handler.
+
+> **Note:** The field name `data` is reserved for the LiveTemplate client library's
+> JSON encoding. Avoid naming a plain text field `data` in multipart forms.
 
 ```go
 func (c *ProfileController) SaveProfile(state ProfileState, ctx *livetemplate.Context) (ProfileState, error) {

--- a/docs/references/uploads.md
+++ b/docs/references/uploads.md
@@ -47,10 +47,17 @@ handler := tmpl.Handle(&ProfileController{}, livetemplate.AsState(&ProfileState{
 
 ### 3. Process Uploads in Action Handler
 
-Access completed uploads via the Context:
+Access completed uploads and text fields via the Context. When a form with
+`enctype="multipart/form-data"` is submitted, both file uploads and text fields
+are available in the same action handler:
 
 ```go
 func (c *ProfileController) SaveProfile(state ProfileState, ctx *livetemplate.Context) (ProfileState, error) {
+    // Text fields from the same form are available via ctx.GetString()
+    state.Name = ctx.GetString("name")
+    state.Email = ctx.GetString("email")
+
+    // File uploads are available via ctx.GetCompletedUploads()
     for _, entry := range ctx.GetCompletedUploads("avatar") {
         // entry.TempPath: server-side temporary file path
         // entry.ClientName: original filename

--- a/internal/send/message.go
+++ b/internal/send/message.go
@@ -51,9 +51,12 @@ func ParseActionFromHTTP(r *http.Request) (ActionMessage, error) {
 }
 
 // parseMultipartForm parses action from multipart/form-data (file uploads).
-// Note: Unlike parseURLEncodedForm, multipart forms only support routing via
-// the lvt-action field (no button-name detection). Data comes from a JSON-encoded
-// "data" form field, so lvt-action won't appear in msg.Data.
+// Supports two data formats:
+//  1. JSON-encoded "data" form field (client library sends this)
+//  2. Individual form fields (browser-native multipart submission)
+//
+// When a JSON "data" blob is present, it takes precedence. Otherwise,
+// individual form fields are read, matching parseURLEncodedForm behavior.
 func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 	var msg ActionMessage
 
@@ -67,11 +70,59 @@ func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 	// Get action from lvt-action field (explicit routing for progressive enhancement)
 	msg.Action = r.FormValue("lvt-action")
 
-	// Try to get data from JSON-encoded form field
+	// Try to get data from JSON-encoded form field (client library format)
 	if dataStr := r.FormValue("data"); dataStr != "" {
 		var data map[string]interface{}
 		if err := jsonutil.API.Unmarshal([]byte(dataStr), &data); err == nil {
 			msg.Data = data
+		}
+	}
+
+	// Fallback: read individual form fields when no JSON "data" blob is present.
+	// This handles browser-native multipart submissions where text fields are
+	// sent as separate form fields alongside file uploads.
+	if len(msg.Data) == 0 {
+		actionFields := map[string]bool{"lvt-action": true, "data": true}
+
+		// Button-name-as-action detection (same logic as parseURLEncodedForm)
+		if msg.Action == "" && r.MultipartForm != nil {
+			var candidate string
+			ambiguous := false
+			for key, values := range r.MultipartForm.Value {
+				if key == "" || key == "action" || actionFields[key] {
+					continue
+				}
+				if len(values) == 1 && values[0] == "" {
+					if candidate != "" {
+						ambiguous = true
+						break
+					}
+					candidate = key
+				}
+			}
+			if candidate != "" && !ambiguous {
+				msg.Action = candidate
+				actionFields[candidate] = true
+			}
+		}
+
+		// Read individual form fields into data map
+		msg.Data = make(map[string]interface{})
+		if r.MultipartForm != nil {
+			for key, values := range r.MultipartForm.Value {
+				if actionFields[key] {
+					continue
+				}
+				if len(values) == 1 {
+					msg.Data[key] = values[0]
+				} else if len(values) > 1 {
+					interfaceSlice := make([]interface{}, len(values))
+					for i, v := range values {
+						interfaceSlice[i] = v
+					}
+					msg.Data[key] = interfaceSlice
+				}
+			}
 		}
 	}
 

--- a/internal/send/message.go
+++ b/internal/send/message.go
@@ -92,6 +92,8 @@ func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 			var candidate string
 			ambiguous := false
 			for key, values := range r.MultipartForm.Value {
+				// Skip "action" — it's a common HTML attribute (<form action="/path">)
+				// that browsers don't submit, but could cause false-positive routing.
 				if key == "" || key == "action" || actionFields[key] {
 					continue
 				}

--- a/internal/send/message.go
+++ b/internal/send/message.go
@@ -70,18 +70,21 @@ func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 	// Get action from lvt-action field (explicit routing for progressive enhancement)
 	msg.Action = r.FormValue("lvt-action")
 
-	// Try to get data from JSON-encoded form field (client library format)
+	// Try to get data from JSON-encoded form field (client library format).
+	// When present, JSON data takes precedence over individual form fields.
+	jsonDataParsed := false
 	if dataStr := r.FormValue("data"); dataStr != "" {
 		var data map[string]interface{}
 		if err := jsonutil.API.Unmarshal([]byte(dataStr), &data); err == nil {
 			msg.Data = data
+			jsonDataParsed = true
 		}
 	}
 
-	// Fallback: read individual form fields when no JSON "data" blob is present.
+	// Fallback: read individual form fields when no JSON "data" blob was parsed.
 	// This handles browser-native multipart submissions where text fields are
 	// sent as separate form fields alongside file uploads.
-	if len(msg.Data) == 0 {
+	if !jsonDataParsed {
 		actionFields := map[string]bool{"lvt-action": true, "data": true}
 
 		// Button-name-as-action detection (same logic as parseURLEncodedForm)
@@ -124,11 +127,6 @@ func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 				}
 			}
 		}
-	}
-
-	// Initialize data map if not set
-	if msg.Data == nil {
-		msg.Data = make(map[string]interface{})
 	}
 
 	return msg, nil

--- a/internal/send/message_test.go
+++ b/internal/send/message_test.go
@@ -535,6 +535,78 @@ func TestParseActionFromHTTP_Multipart_EmptyJSONDataNoFallback(t *testing.T) {
 	}
 }
 
+// TestParseActionFromHTTP_Multipart_InvalidJSONFallback documents that invalid JSON
+// in the "data" field causes a silent fallback to individual field parsing. This is
+// the intended behavior: the "data" field is treated as a client library convention,
+// not a hard contract. Browser-native submissions may include a field named "data"
+// that isn't JSON.
+func TestParseActionFromHTTP_Multipart_InvalidJSONFallback(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	multipartField(t, writer, "lvt-action", "save")
+	multipartField(t, writer, "data", "not-valid-json") // invalid JSON
+	multipartField(t, writer, "name", "Jane")
+	closeMultipart(t, writer)
+
+	req := httptest.NewRequest("POST", "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	msg, err := ParseActionFromHTTP(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if msg.Action != "save" {
+		t.Errorf("Action = %q, want %q", msg.Action, "save")
+	}
+	// Fallback activates: individual fields are read (excluding "data" itself)
+	if msg.Data["name"] != "Jane" {
+		t.Errorf("Data[name] = %q, want %q (fallback should read individual fields)", msg.Data["name"], "Jane")
+	}
+	if _, ok := msg.Data["data"]; ok {
+		t.Error("'data' field should be excluded from data map")
+	}
+}
+
+// TestParseActionFromHTTP_Multipart_MultiValueFields tests repeated form fields
+// (e.g., <select multiple> or repeated checkboxes) in multipart submissions.
+func TestParseActionFromHTTP_Multipart_MultiValueFields(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	multipartField(t, writer, "lvt-action", "save")
+	multipartField(t, writer, "tags", "go")
+	multipartField(t, writer, "tags", "web")
+	multipartField(t, writer, "tags", "test")
+	multipartField(t, writer, "name", "Jane")
+	closeMultipart(t, writer)
+
+	req := httptest.NewRequest("POST", "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	msg, err := ParseActionFromHTTP(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if msg.Data["name"] != "Jane" {
+		t.Errorf("Data[name] = %q, want %q", msg.Data["name"], "Jane")
+	}
+
+	tags, ok := msg.Data["tags"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected tags to be []interface{}, got %T", msg.Data["tags"])
+	}
+	if len(tags) != 3 {
+		t.Errorf("Expected 3 tags, got %d", len(tags))
+	}
+	expected := []string{"go", "web", "test"}
+	for i, want := range expected {
+		if got, ok := tags[i].(string); !ok || got != want {
+			t.Errorf("tags[%d] = %v, want %q", i, tags[i], want)
+		}
+	}
+}
+
 // TestParseActionFromHTTP_URLEncoded_MultipleValues tests multiple values for same field.
 func TestParseActionFromHTTP_URLEncoded_MultipleValues(t *testing.T) {
 	body := "lvt-action=update&tags=go&tags=web&tags=test"

--- a/internal/send/message_test.go
+++ b/internal/send/message_test.go
@@ -504,6 +504,37 @@ func TestParseActionFromHTTP_Multipart_JSONDataTakesPrecedence(t *testing.T) {
 	}
 }
 
+// TestParseActionFromHTTP_Multipart_EmptyJSONDataNoFallback tests that when
+// data={} is sent (valid but empty JSON), the fallback to individual fields
+// does NOT activate — JSON data takes precedence even when empty.
+func TestParseActionFromHTTP_Multipart_EmptyJSONDataNoFallback(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	multipartField(t, writer, "lvt-action", "updateProfile")
+	multipartField(t, writer, "data", `{}`)              // empty JSON object
+	multipartField(t, writer, "name", "ShouldBeIgnored") // individual field
+	closeMultipart(t, writer)
+
+	req := httptest.NewRequest("POST", "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	msg, err := ParseActionFromHTTP(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if msg.Action != "updateProfile" {
+		t.Errorf("Action = %q, want %q", msg.Action, "updateProfile")
+	}
+	// data={} was parsed successfully, so individual fields should NOT be read
+	if _, ok := msg.Data["name"]; ok {
+		t.Error("Individual field 'name' should not appear when JSON data={} was parsed")
+	}
+	if len(msg.Data) != 0 {
+		t.Errorf("Data should be empty (from JSON {}), got %v", msg.Data)
+	}
+}
+
 // TestParseActionFromHTTP_URLEncoded_MultipleValues tests multiple values for same field.
 func TestParseActionFromHTTP_URLEncoded_MultipleValues(t *testing.T) {
 	body := "lvt-action=update&tags=go&tags=web&tags=test"

--- a/internal/send/message_test.go
+++ b/internal/send/message_test.go
@@ -2,6 +2,8 @@ package send
 
 import (
 	"bytes"
+	"fmt"
+	"mime/multipart"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -360,6 +362,145 @@ func TestParseActionFromHTTP_URLEncoded(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// multipartField writes a field to a multipart writer, failing the test on error.
+func multipartField(t *testing.T, w *multipart.Writer, key, value string) {
+	t.Helper()
+	if err := w.WriteField(key, value); err != nil {
+		t.Fatalf("Failed to write multipart field %q: %v", key, err)
+	}
+}
+
+// closeMultipart closes the multipart writer, failing the test on error.
+func closeMultipart(t *testing.T, w *multipart.Writer) {
+	t.Helper()
+	if err := w.Close(); err != nil {
+		t.Fatalf("Failed to close multipart writer: %v", err)
+	}
+}
+
+// TestParseActionFromHTTP_Multipart_IndividualFields tests that multipart forms
+// with individual form fields (not a JSON "data" blob) are parsed correctly.
+func TestParseActionFromHTTP_Multipart_IndividualFields(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	multipartField(t, writer, "lvt-action", "updateProfile")
+	multipartField(t, writer, "name", "Jane Doe")
+	multipartField(t, writer, "email", "jane@example.com")
+	closeMultipart(t, writer)
+
+	req := httptest.NewRequest("POST", "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	msg, err := ParseActionFromHTTP(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if msg.Action != "updateProfile" {
+		t.Errorf("Action = %q, want %q", msg.Action, "updateProfile")
+	}
+	if msg.Data["name"] != "Jane Doe" {
+		t.Errorf("Data[name] = %q, want %q", msg.Data["name"], "Jane Doe")
+	}
+	if msg.Data["email"] != "jane@example.com" {
+		t.Errorf("Data[email] = %q, want %q", msg.Data["email"], "jane@example.com")
+	}
+	if _, ok := msg.Data["lvt-action"]; ok {
+		t.Error("lvt-action should not appear in data map")
+	}
+}
+
+// TestParseActionFromHTTP_Multipart_ButtonNameAction tests button-name-as-action
+// detection in multipart forms (e.g., <button name="save"> with empty value).
+func TestParseActionFromHTTP_Multipart_ButtonNameAction(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	multipartField(t, writer, "updateProfile", "") // button name with empty value
+	multipartField(t, writer, "name", "Jane Doe")
+	multipartField(t, writer, "email", "jane@example.com")
+	closeMultipart(t, writer)
+
+	req := httptest.NewRequest("POST", "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	msg, err := ParseActionFromHTTP(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if msg.Action != "updateProfile" {
+		t.Errorf("Action = %q, want %q", msg.Action, "updateProfile")
+	}
+	if msg.Data["name"] != "Jane Doe" {
+		t.Errorf("Data[name] = %q, want %q", msg.Data["name"], "Jane Doe")
+	}
+	if _, ok := msg.Data["updateProfile"]; ok {
+		t.Error("Button name field should not appear in data map")
+	}
+}
+
+// TestParseActionFromHTTP_Multipart_WithFileAndFields tests that text fields
+// are parsed alongside file uploads in multipart forms.
+func TestParseActionFromHTTP_Multipart_WithFileAndFields(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	multipartField(t, writer, "updateProfile", "") // button name
+	multipartField(t, writer, "name", "Jane Doe")
+	multipartField(t, writer, "email", "jane@example.com")
+	filePart, err := writer.CreateFormFile("avatar", "photo.png")
+	if err != nil {
+		t.Fatalf("Failed to create form file: %v", err)
+	}
+	if _, err := fmt.Fprint(filePart, "fake-png-data"); err != nil {
+		t.Fatalf("Failed to write file data: %v", err)
+	}
+	closeMultipart(t, writer)
+
+	req := httptest.NewRequest("POST", "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	msg, err := ParseActionFromHTTP(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if msg.Action != "updateProfile" {
+		t.Errorf("Action = %q, want %q", msg.Action, "updateProfile")
+	}
+	if msg.Data["name"] != "Jane Doe" {
+		t.Errorf("Data[name] = %q, want %q", msg.Data["name"], "Jane Doe")
+	}
+	if msg.Data["email"] != "jane@example.com" {
+		t.Errorf("Data[email] = %q, want %q", msg.Data["email"], "jane@example.com")
+	}
+}
+
+// TestParseActionFromHTTP_Multipart_JSONDataTakesPrecedence tests that
+// when a JSON "data" blob is present, it takes precedence over individual fields.
+func TestParseActionFromHTTP_Multipart_JSONDataTakesPrecedence(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	multipartField(t, writer, "lvt-action", "updateProfile")
+	multipartField(t, writer, "data", `{"name":"FromJSON","extra":"value"}`)
+	multipartField(t, writer, "name", "FromField") // should be ignored
+	closeMultipart(t, writer)
+
+	req := httptest.NewRequest("POST", "/", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	msg, err := ParseActionFromHTTP(req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if msg.Data["name"] != "FromJSON" {
+		t.Errorf("Data[name] = %q, want %q (JSON should take precedence)", msg.Data["name"], "FromJSON")
+	}
+	if msg.Data["extra"] != "value" {
+		t.Errorf("Data[extra] = %q, want %q", msg.Data["extra"], "value")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `parseMultipartForm` now falls back to reading individual form fields from `r.MultipartForm.Value` when no JSON `data` blob is present
- Adds button-name-as-action detection for multipart forms, matching `parseURLEncodedForm` behavior
- 4 unit tests covering: individual fields, button name routing, file+fields together, JSON precedence

## Problem

When a form with `enctype="multipart/form-data"` was submitted with both text fields and a file, `ctx.GetString("name")` returned `""` because `parseMultipartForm` only read a JSON-encoded `data` field — it ignored individual form fields entirely.

This broke the avatar-upload example: saving name/email and an avatar simultaneously silently dropped the text field changes.

## Test plan

- [x] All 4 new multipart tests pass
- [x] Full `internal/send` test suite passes (no regressions)
- [x] Verified end-to-end: avatar-upload example saves name, email, AND avatar simultaneously

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)