### PR TITLE
fix(ci): update @livetemplate/client to latest in cross-repo tests

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -192,6 +192,8 @@ jobs:
       run: |
         echo "Installing client dependencies..."
         npm ci
+        echo "Updating @livetemplate/client to latest published version..."
+        npm install @livetemplate/client@latest
         echo "Building client library..."
         npm run build
         echo "✓ Tinkerdown client built successfully"


### PR DESCRIPTION
## Summary

- Tinkerdown's `package-lock.json` pins `@livetemplate/client` to v0.8.4, but `npm ci` installs exact lock file versions. This missed the `form.name` DOM shadowing fix released in v0.8.17, causing `TestAutoTables_SQLiteAdd` and `TestExecArgsForm` to fail since April 4.
- Add `npm install @livetemplate/client@latest` after `npm ci` so the Tinkerdown client always builds against the latest published version, matching how `go mod edit -replace` handles Go dependencies.

## Test plan

- [ ] Cross-Repository Tests workflow passes (specifically `TestAutoTables_SQLiteAdd` and `TestExecArgsForm`)
- [ ] Tests and LVT jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)