### PR TITLE
docs: update dialog routing with polyfill context

### DIFF
--- a/docs/guides/progressive-complexity.md
+++ b/docs/guides/progressive-complexity.md
@@ -163,19 +163,20 @@ Use the standard `<dialog>` element with `command`/`commandfor` for native modal
 
 <!-- Dialog with form -->
 <dialog id="edit-dialog">
-    <form method="dialog">
+    <form name="save">
         <h2>Edit Item</h2>
         <input name="title" value="{{.Title}}">
+        <input type="hidden" name="id" value="{{.ID}}">
 
-        <button name="save" value="{{.ID}}">Save</button>
-        <button command="close" commandfor="edit-dialog">Cancel</button>
+        <button type="submit">Save</button>
+        <button type="button" command="close" commandfor="edit-dialog">Cancel</button>
     </form>
 </dialog>
 ```
 
 - `command="show-modal"` opens the dialog via `.showModal()` — backdrop, focus trapping, and Escape key handling are all native to `<dialog>`
 - `command="close"` closes it via `.close()`
-- `method="dialog"` on the form closes the dialog AND routes the action to the server
+- The client automatically closes any parent `<dialog>` when a form submission succeeds — so the dialog stays open for validation errors but closes on success
 - The LiveTemplate client polyfills `command`/`commandfor` for browsers that don't yet support the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/command) natively (Firefox, Safari). The polyfill uses feature detection (`commandForElement`) and becomes a no-op when browsers add native support
 
 ---

--- a/docs/guides/progressive-complexity.md
+++ b/docs/guides/progressive-complexity.md
@@ -173,10 +173,10 @@ Use the standard `<dialog>` element with `command`/`commandfor` for native modal
 </dialog>
 ```
 
-- `command="show-modal"` opens the dialog (native browser behavior)
-- `command="close"` closes it (native)
+- `command="show-modal"` opens the dialog via `.showModal()` — backdrop, focus trapping, and Escape key handling are all native to `<dialog>`
+- `command="close"` closes it via `.close()`
 - `method="dialog"` on the form closes the dialog AND routes the action to the server
-- Focus trapping, backdrop, and Escape key handling are all native
+- The LiveTemplate client polyfills `command`/`commandfor` for browsers that don't yet support the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/command) natively (Firefox, Safari). The polyfill uses feature detection (`commandForElement`) and becomes a no-op when browsers add native support
 
 ---
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -701,7 +701,24 @@ Apply entrance animations to elements.
 
 Use the native `<dialog>` element with `command`/`commandfor` for modal dialogs. No `lvt-*` attributes needed — this is a Tier 1 pattern.
 
-See [Progressive Complexity Guide — Dialogs](../guides/progressive-complexity.md#5-dialogs) for usage.
+The client polyfills the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/command) for browsers that don't support it natively (Firefox, Safari as of April 2026). The polyfill calls `.showModal()` / `.close()` on the target `<dialog>`, providing backdrop, focus trapping, and Escape key handling across all browsers. Feature detection via `commandForElement` makes the polyfill a no-op when native support lands.
+
+### Supported commands
+
+| Button Attribute | Target | Effect |
+|---|---|---|
+| `command="show-modal" commandfor="dialog-id"` | `<dialog id="dialog-id">` | Calls `.showModal()` |
+| `command="close" commandfor="dialog-id"` | `<dialog id="dialog-id">` | Calls `.close()` |
+
+### `<form method="dialog">`
+
+A `<form method="dialog">` inside a `<dialog>` closes the dialog AND routes the form action to the server. Additionally, any form inside a `<dialog>` that completes successfully will have its parent dialog closed automatically.
+
+See [Progressive Complexity Guide — Dialogs](../guides/progressive-complexity.md#5-dialogs) for the full walkthrough.
+
+### Server-managed modals
+
+For modals whose visibility is controlled by server state (e.g., confirmation dialogs triggered by a server action), use the `lvt/components/modal` package. See the [todos example](https://github.com/livetemplate/examples/tree/main/todos).
 
 ---
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -710,9 +710,11 @@ The client polyfills the [Invoker Commands API](https://developer.mozilla.org/en
 | `command="show-modal" commandfor="dialog-id"` | `<dialog id="dialog-id">` | Calls `.showModal()` |
 | `command="close" commandfor="dialog-id"` | `<dialog id="dialog-id">` | Calls `.close()` |
 
-### `<form method="dialog">`
+### Auto-close on success
 
-A `<form method="dialog">` inside a `<dialog>` closes the dialog AND routes the form action to the server. Additionally, any form inside a `<dialog>` that completes successfully will have its parent dialog closed automatically.
+Any form inside a `<dialog>` that completes successfully will have its parent dialog closed automatically. This means the dialog stays open for validation errors but closes on success — no extra attributes needed.
+
+A `<form method="dialog">` inside a `<dialog>` closes the dialog immediately on submit (before the server responds). Use this only when you don't need server-side validation feedback inside the dialog.
 
 See [Progressive Complexity Guide — Dialogs](../guides/progressive-complexity.md#5-dialogs) for the full walkthrough.
 

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -57,9 +57,11 @@ HTML validation attributes are extracted by `ctx.ValidateForm()`:
 
 | HTML Pattern | Framework Behavior |
 |---|---|
-| `command="show-modal" commandfor="id"` | Opens `<dialog>` (native browser) |
-| `command="close" commandfor="id"` | Closes `<dialog>` (native browser) |
+| `command="show-modal" commandfor="id"` | Opens `<dialog>` via `.showModal()` (polyfilled by client for cross-browser support) |
+| `command="close" commandfor="id"` | Closes `<dialog>` via `.close()` (polyfilled by client) |
 | `<form method="dialog">` inside `<dialog>` | Closes dialog AND routes action to server |
+
+> **Browser support:** The [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/command) (`command`/`commandfor`) is natively supported in Chrome 135+. The LiveTemplate client includes a lightweight polyfill for Firefox and Safari, using feature detection (`commandForElement`) to become a no-op when native support lands.
 
 ## Navigation Interception
 

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -59,7 +59,7 @@ HTML validation attributes are extracted by `ctx.ValidateForm()`:
 |---|---|
 | `command="show-modal" commandfor="id"` | Opens `<dialog>` via `.showModal()` (polyfilled by client for cross-browser support) |
 | `command="close" commandfor="id"` | Closes `<dialog>` via `.close()` (polyfilled by client) |
-| `<form method="dialog">` inside `<dialog>` | Closes dialog AND routes action to server |
+| `<form>` inside `<dialog>` | Routes action to server; dialog auto-closes on success |
 
 > **Browser support:** The [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/command) (`command`/`commandfor`) is natively supported in Chrome 135+. The LiveTemplate client includes a lightweight polyfill for Firefox and Safari, using feature detection (`commandForElement`) to become a no-op when native support lands.
 


### PR DESCRIPTION
## Summary

- Updates Dialog Routing docs to note that the client polyfills `command`/`commandfor` for cross-browser support (Chrome 135+ natively, polyfilled for Firefox/Safari)
- Expands the Modals section in `client-attributes.md` with supported commands table, `<form method="dialog">` behavior, and server-managed modal reference

## Changed files

- `docs/references/progressive-complexity-reference.md` — Dialog Routing table: added polyfill note and browser support callout
- `docs/guides/progressive-complexity.md` — Section 5 Dialogs: updated bullet points with polyfill explanation
- `docs/references/client-attributes.md` — Modals section: expanded from 3 lines to full reference with commands table, form method="dialog" docs, and server-managed modals pointer

## Dependencies

Depends on client PR livetemplate/client#57 being merged and released first (the polyfill these docs describe).

## Test plan

- [x] Pre-commit hook passed (go test, go fmt, golangci-lint)
- [ ] Verify docs render correctly on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)