### PR TITLE
fix: wire Session.TriggerAction into lifecycle contexts

### DIFF
--- a/action.go
+++ b/action.go
@@ -156,12 +156,19 @@ func (a *ActionData) GetInt(key string) int {
 // support matters for Session.TriggerAction, where callers pass Go-native
 // values rather than JSON-unmarshaled ones.
 //
-// Unsigned integers that exceed math.MaxInt on the current platform are
-// rejected (returns (0, false)) rather than silently wrapping to a negative
-// int. This matters on 64-bit platforms for values in the range
-// (math.MaxInt64, math.MaxUint64] and on 32-bit platforms for values in
-// (math.MaxInt32, math.MaxUint32]. Similarly, int64 values are rejected on
-// 32-bit platforms when they exceed the 32-bit int range.
+// Overflow and bounds safety:
+//
+//   - Unsigned integers that exceed math.MaxInt on the current platform
+//     return (0, false) rather than silently wrapping to a negative int.
+//     This matters on 64-bit platforms for values in (math.MaxInt64,
+//     math.MaxUint64] and on 32-bit platforms for values in (math.MaxInt32,
+//     math.MaxUint32].
+//   - int64 values outside [math.MinInt, math.MaxInt] return (0, false);
+//     this only matters on 32-bit platforms.
+//   - float values that are NaN, infinite, out of the int range, or
+//     non-integer (e.g. 1.7) return (0, false). Silently truncating a
+//     float to an int would hide caller mistakes when a map entry meant
+//     for a string field or a float-typed field gets routed to GetInt.
 func (a *ActionData) GetIntOk(key string) (int, bool) {
 	switch v := a.raw[key].(type) {
 	case int:
@@ -187,7 +194,10 @@ func (a *ActionData) GetIntOk(key string) (int, bool) {
 	case uint16:
 		return int(v), true
 	case uint32:
-		if uint64(v) > math.MaxInt {
+		// On 64-bit platforms math.MaxInt == math.MaxInt64, and uint32's
+		// max (4_294_967_295) is always within range — this check only
+		// triggers on 32-bit builds, where uint32 can exceed math.MaxInt32.
+		if uint64(v) > uint64(math.MaxInt) {
 			return 0, false
 		}
 		return int(v), true
@@ -197,15 +207,27 @@ func (a *ActionData) GetIntOk(key string) (int, bool) {
 		}
 		return int(v), true
 	case float32:
-		return int(v), true
+		return floatToIntOk(float64(v))
 	case float64:
-		return int(v), true
+		return floatToIntOk(v)
 	case string:
 		if i, err := strconv.Atoi(v); err == nil {
 			return i, true
 		}
 	}
 	return 0, false
+}
+
+// floatToIntOk converts a float to int with strict bounds and integer
+// checks. Rejects NaN, ±Inf, values outside the platform int range, and
+// non-integer values (e.g. 1.7). See GetIntOk's doc comment for rationale.
+func floatToIntOk(v float64) (int, bool) {
+	// NaN takes the v != math.Trunc(v) branch (NaN != anything, including
+	// NaN itself) and is rejected. ±Inf is rejected by the bounds checks.
+	if v < math.MinInt || v > math.MaxInt || v != math.Trunc(v) {
+		return 0, false
+	}
+	return int(v), true
 }
 
 // GetFloat extracts a float64 value.

--- a/action.go
+++ b/action.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -154,6 +155,13 @@ func (a *ActionData) GetInt(key string) int {
 // and numeric strings from form fields and data-* attributes. Native numeric
 // support matters for Session.TriggerAction, where callers pass Go-native
 // values rather than JSON-unmarshaled ones.
+//
+// Unsigned integers that exceed math.MaxInt on the current platform are
+// rejected (returns (0, false)) rather than silently wrapping to a negative
+// int. This matters on 64-bit platforms for values in the range
+// (math.MaxInt64, math.MaxUint64] and on 32-bit platforms for values in
+// (math.MaxInt32, math.MaxUint32]. Similarly, int64 values are rejected on
+// 32-bit platforms when they exceed the 32-bit int range.
 func (a *ActionData) GetIntOk(key string) (int, bool) {
 	switch v := a.raw[key].(type) {
 	case int:
@@ -165,16 +173,28 @@ func (a *ActionData) GetIntOk(key string) (int, bool) {
 	case int32:
 		return int(v), true
 	case int64:
+		if v > math.MaxInt || v < math.MinInt {
+			return 0, false
+		}
 		return int(v), true
 	case uint:
+		if v > math.MaxInt {
+			return 0, false
+		}
 		return int(v), true
 	case uint8:
 		return int(v), true
 	case uint16:
 		return int(v), true
 	case uint32:
+		if uint64(v) > math.MaxInt {
+			return 0, false
+		}
 		return int(v), true
 	case uint64:
+		if v > math.MaxInt {
+			return 0, false
+		}
 		return int(v), true
 	case float32:
 		return int(v), true

--- a/action.go
+++ b/action.go
@@ -150,15 +150,37 @@ func (a *ActionData) GetInt(key string) int {
 // Returns (value, true) if key exists and value is a number or numeric string.
 // Returns (0, false) if key doesn't exist or value cannot be parsed as int.
 //
-// This method handles both JSON numbers (float64) and string values from
-// form fields and data-* attributes, which are always transmitted as strings.
+// Accepts native Go numeric types (int, int32, int64, float32, float64, etc.)
+// and numeric strings from form fields and data-* attributes. Native numeric
+// support matters for Session.TriggerAction, where callers pass Go-native
+// values rather than JSON-unmarshaled ones.
 func (a *ActionData) GetIntOk(key string) (int, bool) {
-	// Handle float64 (JSON numbers)
-	if v, ok := a.raw[key].(float64); ok {
+	switch v := a.raw[key].(type) {
+	case int:
+		return v, true
+	case int8:
 		return int(v), true
-	}
-	// Handle string values from form fields and data-* attributes
-	if v, ok := a.raw[key].(string); ok {
+	case int16:
+		return int(v), true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case uint:
+		return int(v), true
+	case uint8:
+		return int(v), true
+	case uint16:
+		return int(v), true
+	case uint32:
+		return int(v), true
+	case uint64:
+		return int(v), true
+	case float32:
+		return int(v), true
+	case float64:
+		return int(v), true
+	case string:
 		if i, err := strconv.Atoi(v); err == nil {
 			return i, true
 		}
@@ -181,15 +203,37 @@ func (a *ActionData) GetFloat(key string) float64 {
 // Returns (value, true) if key exists and value is a number or numeric string.
 // Returns (0, false) if key doesn't exist or value cannot be parsed as float.
 //
-// This method handles both JSON numbers (float64) and string values from
-// form fields and data-* attributes, which are always transmitted as strings.
+// Accepts native Go numeric types (int, int32, int64, float32, float64, etc.)
+// and numeric strings from form fields and data-* attributes. Native numeric
+// support matters for Session.TriggerAction, where callers pass Go-native
+// values rather than JSON-unmarshaled ones.
 func (a *ActionData) GetFloatOk(key string) (float64, bool) {
-	// Handle float64 (JSON numbers)
-	if v, ok := a.raw[key].(float64); ok {
+	switch v := a.raw[key].(type) {
+	case float64:
 		return v, true
-	}
-	// Handle string values from form fields and data-* attributes
-	if v, ok := a.raw[key].(string); ok {
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case string:
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			return f, true
 		}

--- a/action.go
+++ b/action.go
@@ -249,6 +249,10 @@ func (a *ActionData) GetFloat(key string) float64 {
 // and numeric strings from form fields and data-* attributes. Native numeric
 // support matters for Session.TriggerAction, where callers pass Go-native
 // values rather than JSON-unmarshaled ones.
+//
+// Precision note: float64 has a 53-bit mantissa, so integer values larger
+// than 2^53 (int64 and uint64) lose precision during conversion. Callers
+// needing exact large integer round-trips should use GetInt instead.
 func (a *ActionData) GetFloatOk(key string) (float64, bool) {
 	switch v := a.raw[key].(type) {
 	case float64:
@@ -264,6 +268,7 @@ func (a *ActionData) GetFloatOk(key string) (float64, bool) {
 	case int32:
 		return float64(v), true
 	case int64:
+		// Values outside [-2^53, 2^53] lose precision. See doc comment.
 		return float64(v), true
 	case uint:
 		return float64(v), true
@@ -274,6 +279,7 @@ func (a *ActionData) GetFloatOk(key string) (float64, bool) {
 	case uint32:
 		return float64(v), true
 	case uint64:
+		// Values above 2^53 lose precision. See doc comment.
 		return float64(v), true
 	case string:
 		if f, err := strconv.ParseFloat(v, 64); err == nil {

--- a/context_test.go
+++ b/context_test.go
@@ -168,6 +168,59 @@ func TestContext_GetInt_FloatRejection(t *testing.T) {
 	}
 }
 
+// TestContext_GetFloat_Uint64PrecisionLoss documents the known precision
+// boundary for GetFloat when reading large uint64 values. float64 has a
+// 53-bit mantissa, so integer values above 2^53 cannot be represented
+// exactly. This matches Go's standard float64(uint64) semantics — the
+// test exists so a future refactor doesn't accidentally tighten the
+// contract without also updating the doc comment in GetFloatOk.
+//
+// Callers that need exact large-integer round-trips should use GetInt.
+func TestContext_GetFloat_Uint64PrecisionLoss(t *testing.T) {
+	// 2^53 is the largest integer exactly representable in float64.
+	// 2^53 + 1 cannot be represented — it rounds to 2^53.
+	const exact = uint64(1 << 53)
+	const beyond = uint64(1<<53) + 1
+
+	data := map[string]interface{}{
+		"exact":  exact,
+		"beyond": beyond,
+	}
+	ctx := NewContext(context.Background(), "test", data)
+	d := ctx.data
+
+	// The 2^53 boundary converts exactly.
+	if got, ok := d.GetFloatOk("exact"); !ok || got != float64(exact) {
+		t.Errorf("GetFloatOk(exact) = (%v, %v), want (%v, true)", got, ok, float64(exact))
+	}
+
+	// Beyond 2^53: the uint64 value cannot be represented exactly in
+	// float64. GetFloatOk still returns (value, true) — the rounded
+	// float — and the contract is that the caller knows they're
+	// reading a float, not a lossless integer.
+	got, ok := d.GetFloatOk("beyond")
+	if !ok {
+		t.Fatalf("GetFloatOk(beyond) unexpectedly returned ok=false")
+	}
+
+	// Demonstrate the precision loss by round-tripping through uint64.
+	// The float64 approximation of (2^53 + 1) rounds to (2^53), so
+	// converting back to uint64 gives 2^53, not the original 2^53+1.
+	// A comparison like `got == float64(beyond)` does NOT demonstrate
+	// precision loss — the compiler evaluates float64(beyond) at
+	// compile time and produces the same rounded value, so the
+	// equality is trivially true. Round-tripping through uint64 is
+	// the only way to observe that the exact integer identity was
+	// lost during conversion.
+	recovered := uint64(got)
+	if recovered == beyond {
+		t.Errorf("Expected precision loss at 2^53+1, but round-trip uint64(float64(%d)) == %d (no loss observed)", beyond, recovered)
+	}
+	if recovered != exact {
+		t.Errorf("Expected round-trip to round down to 2^53 (%d), got %d", exact, recovered)
+	}
+}
+
 // TestContext_GetFloat_NativeTypes mirrors TestContext_GetInt_NativeTypes
 // for the float path. Verifies that all Go numeric types convert cleanly
 // to float64 via GetFloat.

--- a/context_test.go
+++ b/context_test.go
@@ -86,10 +86,14 @@ func TestContext_GetInt_NativeTypes(t *testing.T) {
 // (0, false) for these cases so callers can detect the overflow.
 func TestContext_GetInt_UnsignedOverflow(t *testing.T) {
 	data := map[string]interface{}{
-		"max_int":       uint64(math.MaxInt),     // exactly fits
-		"overflow_u64":  uint64(math.MaxInt) + 1, // one past
-		"overflow_uint": uint(math.MaxInt64) + 1, // one past on 64-bit; always overflows
-		"int64_ok":      int64(math.MaxInt32),    // fits on any platform
+		"max_int":      uint64(math.MaxInt),     // exactly fits
+		"overflow_u64": uint64(math.MaxInt) + 1, // one past
+		// math.MaxUint is the full unsigned range on this platform — it
+		// is always strictly greater than math.MaxInt regardless of word
+		// size, so this case tests the uint overflow branch without
+		// relying on accidental wrap-around arithmetic.
+		"overflow_uint": uint(math.MaxUint),
+		"int64_ok":      int64(math.MaxInt32), // fits on any platform
 	}
 	ctx := NewContext(context.Background(), "test", data)
 	d := ctx.data
@@ -104,7 +108,7 @@ func TestContext_GetInt_UnsignedOverflow(t *testing.T) {
 		t.Errorf("GetIntOk(overflow_u64) = (%d, %v), want (0, false)", got, ok)
 	}
 
-	// Overflowing uint (platform-dependent but always overflows on 64-bit).
+	// Overflowing uint: returns (0, false).
 	if got, ok := d.GetIntOk("overflow_uint"); ok || got != 0 {
 		t.Errorf("GetIntOk(overflow_uint) = (%d, %v), want (0, false)", got, ok)
 	}
@@ -112,6 +116,55 @@ func TestContext_GetInt_UnsignedOverflow(t *testing.T) {
 	// In-range int64: should succeed.
 	if got, ok := d.GetIntOk("int64_ok"); !ok || got != math.MaxInt32 {
 		t.Errorf("GetIntOk(int64_ok) = (%d, %v), want (%d, true)", got, ok, math.MaxInt32)
+	}
+}
+
+// TestContext_GetInt_FloatRejection verifies that GetInt rejects floats
+// that cannot be losslessly converted to int: NaN, ±Inf, out-of-range
+// magnitudes, and non-integer values (e.g. 1.7). Silently truncating such
+// values would hide caller mistakes when a float meant for a string or
+// float field gets routed to GetInt.
+func TestContext_GetInt_FloatRejection(t *testing.T) {
+	data := map[string]interface{}{
+		"integer_float64": float64(42),
+		"integer_float32": float32(17),
+		"nan":             math.NaN(),
+		"pos_inf":         math.Inf(1),
+		"neg_inf":         math.Inf(-1),
+		"too_large_f64":   float64(1e20),
+		"too_small_f64":   float64(-1e20),
+		"non_integer_f64": float64(1.7),
+		"non_integer_f32": float32(2.5),
+		"max_int_as_f64":  float64(math.MaxInt32), // fits on any platform
+	}
+	ctx := NewContext(context.Background(), "test", data)
+	d := ctx.data
+
+	// Integer-valued floats convert cleanly.
+	if got, ok := d.GetIntOk("integer_float64"); !ok || got != 42 {
+		t.Errorf("GetIntOk(integer_float64) = (%d, %v), want (42, true)", got, ok)
+	}
+	if got, ok := d.GetIntOk("integer_float32"); !ok || got != 17 {
+		t.Errorf("GetIntOk(integer_float32) = (%d, %v), want (17, true)", got, ok)
+	}
+	if got, ok := d.GetIntOk("max_int_as_f64"); !ok || got != math.MaxInt32 {
+		t.Errorf("GetIntOk(max_int_as_f64) = (%d, %v), want (%d, true)", got, ok, math.MaxInt32)
+	}
+
+	// Non-convertible floats all return (0, false).
+	rejected := []string{
+		"nan",
+		"pos_inf",
+		"neg_inf",
+		"too_large_f64",
+		"too_small_f64",
+		"non_integer_f64",
+		"non_integer_f32",
+	}
+	for _, key := range rejected {
+		if got, ok := d.GetIntOk(key); ok || got != 0 {
+			t.Errorf("GetIntOk(%q) = (%d, %v), want (0, false)", key, got, ok)
+		}
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -48,6 +48,37 @@ func TestContext_GetInt(t *testing.T) {
 	}
 }
 
+// TestContext_GetInt_NativeTypes verifies that GetInt accepts native Go
+// numeric types. This matters for Session.TriggerAction, which passes
+// Go-native values rather than JSON-unmarshaled ones.
+func TestContext_GetInt_NativeTypes(t *testing.T) {
+	data := map[string]interface{}{
+		"native_int":     int(10),
+		"native_int32":   int32(20),
+		"native_int64":   int64(30),
+		"native_uint":    uint(40),
+		"native_float32": float32(50),
+		"native_float64": float64(60),
+		"numeric_string": "70",
+	}
+	ctx := NewContext(context.Background(), "test", data)
+
+	cases := map[string]int{
+		"native_int":     10,
+		"native_int32":   20,
+		"native_int64":   30,
+		"native_uint":    40,
+		"native_float32": 50,
+		"native_float64": 60,
+		"numeric_string": 70,
+	}
+	for key, want := range cases {
+		if got := ctx.GetInt(key); got != want {
+			t.Errorf("GetInt(%q) = %d, want %d", key, got, want)
+		}
+	}
+}
+
 func TestContext_GetBool(t *testing.T) {
 	data := map[string]interface{}{"active": true}
 	ctx := NewContext(context.Background(), "test", data)

--- a/context_test.go
+++ b/context_test.go
@@ -2,6 +2,7 @@ package livetemplate
 
 import (
 	"context"
+	"math"
 	"testing"
 )
 
@@ -75,6 +76,74 @@ func TestContext_GetInt_NativeTypes(t *testing.T) {
 	for key, want := range cases {
 		if got := ctx.GetInt(key); got != want {
 			t.Errorf("GetInt(%q) = %d, want %d", key, got, want)
+		}
+	}
+}
+
+// TestContext_GetInt_UnsignedOverflow verifies that GetInt rejects unsigned
+// integers that exceed math.MaxInt on the current platform rather than
+// silently wrapping to a negative value. The GetIntOk variant must return
+// (0, false) for these cases so callers can detect the overflow.
+func TestContext_GetInt_UnsignedOverflow(t *testing.T) {
+	data := map[string]interface{}{
+		"max_int":       uint64(math.MaxInt),     // exactly fits
+		"overflow_u64":  uint64(math.MaxInt) + 1, // one past
+		"overflow_uint": uint(math.MaxInt64) + 1, // one past on 64-bit; always overflows
+		"int64_ok":      int64(math.MaxInt32),    // fits on any platform
+	}
+	ctx := NewContext(context.Background(), "test", data)
+	d := ctx.data
+
+	// Exact-fit uint64: should succeed.
+	if got, ok := d.GetIntOk("max_int"); !ok || got != math.MaxInt {
+		t.Errorf("GetIntOk(max_int) = (%d, %v), want (%d, true)", got, ok, math.MaxInt)
+	}
+
+	// Overflowing uint64: should return (0, false), NOT a wrapped negative.
+	if got, ok := d.GetIntOk("overflow_u64"); ok || got != 0 {
+		t.Errorf("GetIntOk(overflow_u64) = (%d, %v), want (0, false)", got, ok)
+	}
+
+	// Overflowing uint (platform-dependent but always overflows on 64-bit).
+	if got, ok := d.GetIntOk("overflow_uint"); ok || got != 0 {
+		t.Errorf("GetIntOk(overflow_uint) = (%d, %v), want (0, false)", got, ok)
+	}
+
+	// In-range int64: should succeed.
+	if got, ok := d.GetIntOk("int64_ok"); !ok || got != math.MaxInt32 {
+		t.Errorf("GetIntOk(int64_ok) = (%d, %v), want (%d, true)", got, ok, math.MaxInt32)
+	}
+}
+
+// TestContext_GetFloat_NativeTypes mirrors TestContext_GetInt_NativeTypes
+// for the float path. Verifies that all Go numeric types convert cleanly
+// to float64 via GetFloat.
+func TestContext_GetFloat_NativeTypes(t *testing.T) {
+	data := map[string]interface{}{
+		"native_int":     int(10),
+		"native_int32":   int32(20),
+		"native_int64":   int64(30),
+		"native_uint":    uint(40),
+		"native_uint32":  uint32(45),
+		"native_float32": float32(50.5),
+		"native_float64": float64(60.25),
+		"numeric_string": "70.5",
+	}
+	ctx := NewContext(context.Background(), "test", data)
+
+	cases := map[string]float64{
+		"native_int":     10,
+		"native_int32":   20,
+		"native_int64":   30,
+		"native_uint":    40,
+		"native_uint32":  45,
+		"native_float32": 50.5,
+		"native_float64": 60.25,
+		"numeric_string": 70.5,
+	}
+	for key, want := range cases {
+		if got := ctx.GetFloat(key); got != want {
+			t.Errorf("GetFloat(%q) = %v, want %v", key, got, want)
 		}
 	}
 }

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -258,9 +258,27 @@ type Session interface {
 }
 ```
 
-Enables server-initiated actions for the current user's connections (all tabs/devices). Use cases: timers, background job notifications, webhook-triggered updates.
+Enables server-initiated actions for every connection in the current
+session group. Use cases: timers, background job notifications,
+webhook-triggered updates.
 
-Accessed via `ctx.Session()` inside your controller's `OnConnect(state, ctx)` lifecycle method (or any action method). The returned `Session` handle can be captured and used from background goroutines to trigger actions for all of the user's connections. See [Server Actions](server-actions.md) for examples.
+**Scope** — `Session.TriggerAction` targets a session group (groupID),
+not a user identity (userID). For the typical anonymous flow where each
+browser session maps to one group via cookie, this is equivalent to
+"all tabs of this browser". For authenticated flows the mapping depends
+on how the `Authenticator` assigns groupIDs:
+
+- If `GetSessionGroup` returns a stable groupID keyed on userID, all of
+  a user's devices share one group and `TriggerAction` fans out to all
+  of them.
+- If `GetSessionGroup` returns a per-session groupID, each device has
+  its own group and `TriggerAction` only fans out within a single
+  device's tabs.
+
+Accessed via `ctx.Session()` inside your controller's `OnConnect(state, ctx)`
+lifecycle method (or any action method). The returned `Session` handle
+can be captured and used from background goroutines. See
+[Server Actions](server-actions.md) for examples.
 
 ---
 

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -260,7 +260,7 @@ type Session interface {
 
 Enables server-initiated actions for the current user's connections (all tabs/devices). Use cases: timers, background job notifications, webhook-triggered updates.
 
-Accessed by implementing `SessionAware` on your controller. The framework calls `SessionAware.OnConnect(ctx, session)` on each WebSocket connect, providing a `Session` handle for async action dispatch. See [Server Actions](server-actions.md) for examples.
+Accessed via `ctx.Session()` inside your controller's `OnConnect(state, ctx)` lifecycle method (or any action method). The returned `Session` handle can be captured and used from background goroutines to trigger actions for all of the user's connections. See [Server Actions](server-actions.md) for examples.
 
 ---
 

--- a/docs/references/server-actions.md
+++ b/docs/references/server-actions.md
@@ -9,7 +9,7 @@ LiveTemplate supports two types of updates:
 | Type | Trigger | Scope | Use Case |
 |------|---------|-------|----------|
 | **Client Action** | User interaction (click, submit) | Same session group | Form submissions, button clicks |
-| **Server Action** | Server-side code | All user's connections | Timers, webhooks, background jobs |
+| **Server Action** | Server-side code | Same session group | Timers, webhooks, background jobs |
 
 Server actions use the `Session` interface to trigger updates:
 
@@ -32,8 +32,10 @@ type Session interface {
 
 **Key Points:**
 - `TriggerAction()` calls your action method just like client-initiated actions
-- Updates are sent to ALL of the user's connections (all tabs/devices)
-- Scoped to the current user only - cannot target other users
+- Updates are sent to ALL connections in the current session group
+  (typically all tabs of the browser session; for authenticated flows
+  the group mapping depends on the `Authenticator` — see [API Reference](api-reference.md#session))
+- Scoped to a session group only — cannot target other groups or other users
 - Thread-safe - can be called from any goroutine
 
 ## Getting the Session Reference

--- a/lifecycle_integration_test.go
+++ b/lifecycle_integration_test.go
@@ -119,11 +119,24 @@ func TestOnDisconnect_FiresOnAbruptClose(t *testing.T) {
 		t.Fatalf("Underlying conn close failed: %v", err)
 	}
 
-	select {
-	case <-ctrl.disconnectCh:
-		// Success.
-	case <-time.After(5 * time.Second):
-		t.Fatal("OnDisconnect was not called within 5s after abrupt close")
+	// Abrupt-close detection depends on the server's read pump noticing
+	// the TCP EOF, which can take longer than a clean close under CI
+	// load. The t.Log markers below disambiguate a slow machine from a
+	// real regression in CI output.
+	deadline := time.After(5 * time.Second)
+	progress := time.NewTicker(1 * time.Second)
+	defer progress.Stop()
+	elapsed := 0
+	for {
+		select {
+		case <-ctrl.disconnectCh:
+			return
+		case <-progress.C:
+			elapsed++
+			t.Logf("OnDisconnect not yet received after %ds (server hasn't noticed TCP EOF yet)...", elapsed)
+		case <-deadline:
+			t.Fatal("OnDisconnect was not called within 5s after abrupt close")
+		}
 	}
 }
 

--- a/lifecycle_integration_test.go
+++ b/lifecycle_integration_test.go
@@ -188,8 +188,11 @@ func TestBroadcastAction_PeerCanSetFlash(t *testing.T) {
 	ws2 := connectWS(t, wsURL)
 	defer func() { _ = ws2.Close() }()
 
-	// Small settle delay so ws2 is fully registered before ws1 sends the action.
-	time.Sleep(100 * time.Millisecond)
+	// No explicit settle delay is required: connectWS blocks until the
+	// initial render arrives on the socket, which only happens after the
+	// server has completed the mount handshake and registered the
+	// connection in the group. By the time the second connectWS returns,
+	// both connections are guaranteed to be in the registry.
 
 	// Trigger Bump on ws1. This should produce:
 	//   - ws1 response with state.Counter=1 and flash success="bump complete on sender"

--- a/lifecycle_integration_test.go
+++ b/lifecycle_integration_test.go
@@ -62,8 +62,11 @@ func TestOnDisconnect_FiresOnWebSocketClose(t *testing.T) {
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
 
-	// Open the WebSocket and read the initial render so we know the server
-	// has fully set up the connection (OnConnect has run, event loop active).
+	// Open the WebSocket. connectWSRaw blocks until the initial render
+	// frame is delivered, which means the server has already completed
+	// Mount + OnConnect and entered its event loop. Discarding the frame
+	// bytes is safe — the test doesn't care about the initial render
+	// contents, only about triggering OnDisconnect on the subsequent close.
 	ws, _ := connectWSRaw(t, wsURL)
 
 	// Close the connection cleanly and wait for OnDisconnect.
@@ -104,6 +107,10 @@ func TestOnDisconnect_FiresOnAbruptClose(t *testing.T) {
 	defer server.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	// connectWSRaw blocks on the initial render so the server has
+	// finished OnConnect by the time it returns. The initial frame
+	// bytes are discarded because the test only cares about the
+	// disconnect hook firing on the subsequent abrupt close.
 	ws, _ := connectWSRaw(t, wsURL)
 
 	// Close the underlying TCP connection without sending a close frame.

--- a/lifecycle_integration_test.go
+++ b/lifecycle_integration_test.go
@@ -1,0 +1,243 @@
+package livetemplate
+
+import (
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// =============================================================================
+// OnDisconnect Integration Test
+// =============================================================================
+//
+// The reflection-level lifecycle_test.go verifies that callOnDisconnect can
+// invoke a controller's OnDisconnect method when called directly. This test
+// verifies the end-to-end path: a real WebSocket connection closes, the
+// framework detects it, and OnDisconnect fires on the controller.
+//
+// This matters for patterns like Presence Tracking (proposal #28), which
+// rely on OnDisconnect to clean up per-connection state.
+
+type onDisconnectTestState struct {
+	Count int
+}
+
+type onDisconnectTestController struct {
+	disconnectCalls atomic.Int32
+	disconnectCh    chan struct{}
+}
+
+func (c *onDisconnectTestController) Mount(state onDisconnectTestState, ctx *Context) (onDisconnectTestState, error) {
+	return state, nil
+}
+
+func (c *onDisconnectTestController) OnDisconnect() {
+	c.disconnectCalls.Add(1)
+	// Non-blocking notification — test may not be listening yet.
+	select {
+	case c.disconnectCh <- struct{}{}:
+	default:
+	}
+}
+
+func TestOnDisconnect_FiresOnWebSocketClose(t *testing.T) {
+	ctrl := &onDisconnectTestController{disconnectCh: make(chan struct{}, 1)}
+
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Count}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(ctrl, AsState(&onDisconnectTestState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	// Open the WebSocket and read the initial render so we know the server
+	// has fully set up the connection (OnConnect has run, event loop active).
+	ws, _ := connectWSRaw(t, wsURL)
+
+	// Close the connection cleanly and wait for OnDisconnect.
+	if err := ws.Close(); err != nil {
+		t.Fatalf("WebSocket close failed: %v", err)
+	}
+
+	select {
+	case <-ctrl.disconnectCh:
+		// Success — OnDisconnect fired.
+	case <-time.After(3 * time.Second):
+		t.Fatal("OnDisconnect was not called within 3s after WebSocket close")
+	}
+
+	if got := ctrl.disconnectCalls.Load(); got != 1 {
+		t.Errorf("OnDisconnect call count = %d, want 1", got)
+	}
+}
+
+// TestOnDisconnect_FiresOnAbruptClose verifies the hook fires even when the
+// client goes away without a clean WebSocket close frame (network drop,
+// browser tab kill). This is the scenario that presence tracking needs to
+// handle — most real disconnects are not clean.
+func TestOnDisconnect_FiresOnAbruptClose(t *testing.T) {
+	ctrl := &onDisconnectTestController{disconnectCh: make(chan struct{}, 1)}
+
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Count}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(ctrl, AsState(&onDisconnectTestState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	ws, _ := connectWSRaw(t, wsURL)
+
+	// Close the underlying TCP connection without sending a close frame.
+	// This simulates a browser tab being killed or network failure.
+	if err := ws.UnderlyingConn().Close(); err != nil {
+		t.Fatalf("Underlying conn close failed: %v", err)
+	}
+
+	select {
+	case <-ctrl.disconnectCh:
+		// Success.
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnDisconnect was not called within 5s after abrupt close")
+	}
+}
+
+// =============================================================================
+// SetFlash via BroadcastAction Integration Test
+// =============================================================================
+//
+// Verifies that ctx.SetFlash messages survive the BroadcastAction dispatch
+// path: the initiating connection sees its own flash, and each peer's
+// dispatched action handler can also set its own flash that gets rendered
+// on that peer's client.
+//
+// Before this test, broadcast_test.go covered BroadcastAction itself but
+// nothing verified that FlashSetter is wired on peer connections too.
+
+type flashBroadcastState struct {
+	Counter int
+}
+
+type flashBroadcastController struct{}
+
+func (c *flashBroadcastController) Mount(state flashBroadcastState, ctx *Context) (flashBroadcastState, error) {
+	return state, nil
+}
+
+// Bump increments the counter, sets a "success" flash on the initiator,
+// and broadcasts PeerSync to peer connections.
+func (c *flashBroadcastController) Bump(state flashBroadcastState, ctx *Context) (flashBroadcastState, error) {
+	state.Counter++
+	ctx.SetFlash("success", "bump complete on sender")
+	ctx.BroadcastAction("PeerSync", map[string]interface{}{"counter": state.Counter})
+	return state, nil
+}
+
+// PeerSync runs on peer connections when Bump broadcasts. It sets its own
+// flash to verify FlashSetter is available in the dispatched action context.
+func (c *flashBroadcastController) PeerSync(state flashBroadcastState, ctx *Context) (flashBroadcastState, error) {
+	state.Counter = ctx.GetInt("counter")
+	ctx.SetFlash("info", "peer received broadcast")
+	return state, nil
+}
+
+func TestBroadcastAction_PeerCanSetFlash(t *testing.T) {
+	auth := &fixedGroupAuth{groupID: "flash-broadcast-group"}
+
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	// Template renders both flash slots so we can verify propagation by
+	// inspecting the wire-format tree dynamics instead of relying on
+	// internal state.
+	tmpl, err = tmpl.Parse(
+		`<div>{{.Counter}}|s:{{.lvt.Flash "success"}}|i:{{.lvt.Flash "info"}}</div>`,
+	)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&flashBroadcastController{}, AsState(&flashBroadcastState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	// Two WebSocket connections in the same session group. ws1 will send
+	// the Bump action; ws2 should receive the PeerSync broadcast.
+	ws1 := connectWS(t, wsURL)
+	defer func() { _ = ws1.Close() }()
+	ws2 := connectWS(t, wsURL)
+	defer func() { _ = ws2.Close() }()
+
+	// Small settle delay so ws2 is fully registered before ws1 sends the action.
+	time.Sleep(100 * time.Millisecond)
+
+	// Trigger Bump on ws1. This should produce:
+	//   - ws1 response with state.Counter=1 and flash success="bump complete on sender"
+	//   - ws2 dispatched PeerSync with state.Counter=1 and flash info="peer received broadcast"
+	actionMsg := []byte(`{"action":"bump","data":{}}`)
+	if err := ws1.WriteMessage(websocket.TextMessage, actionMsg); err != nil {
+		t.Fatalf("ws1 write failed: %v", err)
+	}
+
+	// ws1 should receive its own response with the sender-side flash rendered
+	// into the tree.
+	ws1Update := readWSUpdate(t, ws1, 3*time.Second)
+	assertTreeContains(t, ws1Update, "bump complete on sender", "ws1 (sender)")
+
+	// ws2 should receive the dispatched PeerSync action with its own flash
+	// rendered into the tree.
+	ws2Update := readWSUpdate(t, ws2, 3*time.Second)
+	assertTreeContains(t, ws2Update, "peer received broadcast", "ws2 (peer)")
+}
+
+// assertTreeContains walks the wire-format tree response and fails the test
+// if `want` does not appear in any of the string dynamics. Recurses into
+// nested tree maps. This is more resilient than indexing by numeric key,
+// which can shift if the template structure changes.
+func assertTreeContains(t *testing.T, update map[string]interface{}, want, label string) {
+	t.Helper()
+	tree, ok := update["tree"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s: expected tree in update, got: %v", label, update)
+	}
+	if treeContainsString(tree, want) {
+		return
+	}
+	t.Errorf("%s: expected %q somewhere in tree dynamics, tree=%v", label, want, tree)
+}
+
+func treeContainsString(node map[string]interface{}, want string) bool {
+	for _, v := range node {
+		switch vv := v.(type) {
+		case string:
+			if strings.Contains(vv, want) {
+				return true
+			}
+		case map[string]interface{}:
+			if treeContainsString(vv, want) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/mount.go
+++ b/mount.go
@@ -28,8 +28,11 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// Session allows stores to trigger server-initiated actions for connected clients.
-// Actions triggered via Session affect ALL connections for the current user (all tabs/devices).
+// Session allows controllers to trigger server-initiated actions for
+// connected clients. Actions triggered via Session affect every connection
+// in the same session group (all tabs sharing one browser session, plus
+// any additional devices that the configured Authenticator places in the
+// same group).
 //
 // This is the recommended way to implement:
 //   - Timers and ticks
@@ -37,15 +40,23 @@ import (
 //   - Webhook-triggered updates
 //   - Cross-tab synchronization
 //
-// Security: Session is scoped to the current user only. There is no way to
-// target other users, preventing unauthorized cross-user actions.
+// Scope: Session is scoped to a session group (groupID), not to a user
+// identity (userID). For the typical anonymous flow where each browser
+// session maps to one group via cookie, this is equivalent to "all tabs
+// of this browser". For authenticated flows the mapping depends on how
+// the Authenticator assigns groupIDs — a user with multiple devices may
+// share a group across devices (by returning a stable groupID keyed on
+// userID) or may have per-device groups (by returning a per-session
+// groupID). Session.TriggerAction always targets the group of the
+// Context it was obtained from, never other groups.
 type Session interface {
-	// TriggerAction dispatches the action to the matching store method,
-	// then sends the updated template to ALL connections for this user.
+	// TriggerAction dispatches the action to the matching controller
+	// method on every connection in the session group, then sends the
+	// updated template to each of those connections.
 	//
-	// This behaves identically to client-initiated actions - the action is
-	// dispatched to the matching method, errors are captured, and updates
-	// are broadcast to all of the user's connections (tabs/devices).
+	// This behaves identically to client-initiated actions: the action
+	// runs through the controller's action method, errors are captured,
+	// and diffs are sent over WebSocket to each connection.
 	//
 	// Example:
 	//   session.TriggerAction("tick", nil)
@@ -1443,6 +1454,16 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 	ctx := NewContext(context.Background(), req.Action, req.Data)
 	ctx = ctx.WithUserID(userID)
 	ctx = ctx.WithFlashSetter(connSt)
+	// Wire Session so dispatched actions (from BroadcastAction or
+	// Session.TriggerAction) can also call ctx.Session().TriggerAction
+	// for follow-on server pushes. pendingBroadcasts from ctx is still
+	// dropped below to prevent storm loops, but TriggerAction goes
+	// through a different queue (EnqueueDispatch directly) and is
+	// allowed — each hop runs through a connection event loop, so the
+	// only unbounded failure mode is a handler that recursively
+	// re-triggers itself, which is a caller bug rather than framework
+	// amplification.
+	ctx = ctx.WithSession(newLocalSession(h, connSt.groupID, userID))
 
 	newState, err := DispatchWithState(h.config.Controller, connSt.state, ctx)
 	if err != nil {
@@ -2332,6 +2353,9 @@ func (h *liveHandler) handleUploadComplete(ctx context.Context, conn WSConn, raw
 		// Create Context for action dispatch
 		actionCtx := NewContext(ctx, uploadAction, make(map[string]interface{}))
 		actionCtx = actionCtx.WithUploads(uploadRegistry)
+		actionCtx = actionCtx.WithUserID(connection.UserID)
+		actionCtx = actionCtx.WithFlashSetter(state)
+		actionCtx = actionCtx.WithSession(newLocalSession(h, connection.GroupID, connection.UserID))
 
 		// Dispatch action using Controller+State pattern
 		newState, actionErr := DispatchWithState(h.config.Controller, state.state, actionCtx)

--- a/mount.go
+++ b/mount.go
@@ -1775,7 +1775,19 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 		// Create context with timeout for server-initiated actions
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
-		// Create Context for action dispatch
+		// Create Context for action dispatch.
+		//
+		// Asymmetry note: this actionCtx has a live Session attached, so
+		// a server-action handler can chain session.TriggerAction(...) to
+		// re-enqueue more dispatches. The pendingBroadcasts() drop below
+		// only catches ctx.BroadcastAction calls — it does not intercept
+		// chained TriggerAction calls, which bypass the broadcast queue
+		// entirely and go straight to EnqueueDispatch. In practice this
+		// is not a footgun because chained TriggerAction requires explicit
+		// caller intent and each hop still runs through the per-connection
+		// event loop (no unbounded recursion on a single goroutine), but
+		// handlers that recursively trigger themselves will loop until the
+		// session disconnects.
 		actionCtx := NewContext(ctx, msg.Action, msg.Data)
 		actionCtx = actionCtx.WithUserID(msg.UserID)
 		actionCtx = actionCtx.WithFlashSetter(state)

--- a/mount.go
+++ b/mount.go
@@ -503,7 +503,7 @@ func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	lifecycleCtx := NewContext(context.Background(), "", wsQueryData)
 	lifecycleCtx = lifecycleCtx.WithUserID(userID)
 	lifecycleCtx = lifecycleCtx.WithFlashSetter(connSt)
-	lifecycleCtx = lifecycleCtx.WithSession(newLocalSession(h, groupID, userID))
+	lifecycleCtx = lifecycleCtx.WithSession(newLocalSession(h, groupID))
 
 	// Call Mount on every WebSocket connect (new session AND reconnect).
 	// Mount() refreshes state from the database, ensuring actions always
@@ -679,7 +679,7 @@ eventLoop:
 			actionCtx = actionCtx.WithUserID(userID)
 			actionCtx = actionCtx.WithUploads(uploadRegistry)
 			actionCtx = actionCtx.WithFlashSetter(connSt)
-			actionCtx = actionCtx.WithSession(newLocalSession(h, groupID, userID))
+			actionCtx = actionCtx.WithSession(newLocalSession(h, groupID))
 
 			// Dispatch action using Controller+State pattern
 			newState, actionErr := DispatchWithState(h.config.Controller, connSt.state, actionCtx)
@@ -945,7 +945,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	lifecycleCtx := NewContext(ctx, "", queryData)
 	lifecycleCtx = lifecycleCtx.WithUserID(userID)
 	lifecycleCtx = lifecycleCtx.WithFlashSetter(connSt)
-	lifecycleCtx = lifecycleCtx.WithSession(newLocalSession(h, groupID, userID))
+	lifecycleCtx = lifecycleCtx.WithSession(newLocalSession(h, groupID))
 
 	// Read flash messages from cookie (set by POST redirect)
 	if flashCookie, err := r.Cookie("lvt-flash"); err == nil && flashCookie.Value != "" {
@@ -1154,7 +1154,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	actionCtx = actionCtx.WithHTTP(w, r)
 	actionCtx = actionCtx.WithUploads(uploadRegistry)
 	actionCtx = actionCtx.WithFlashSetter(connSt)
-	actionCtx = actionCtx.WithSession(newLocalSession(h, groupID, userID))
+	actionCtx = actionCtx.WithSession(newLocalSession(h, groupID))
 
 	// Dispatch action using Controller+State pattern
 	newState, actionErr := DispatchWithState(h.config.Controller, connSt.state, actionCtx)
@@ -1463,7 +1463,7 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 	// only unbounded failure mode is a handler that recursively
 	// re-triggers itself, which is a caller bug rather than framework
 	// amplification.
-	ctx = ctx.WithSession(newLocalSession(h, connSt.groupID, userID))
+	ctx = ctx.WithSession(newLocalSession(h, connSt.groupID))
 
 	newState, err := DispatchWithState(h.config.Controller, connSt.state, ctx)
 	if err != nil {
@@ -1812,7 +1812,7 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 		actionCtx := NewContext(ctx, msg.Action, msg.Data)
 		actionCtx = actionCtx.WithUserID(msg.UserID)
 		actionCtx = actionCtx.WithFlashSetter(state)
-		actionCtx = actionCtx.WithSession(newLocalSession(h, conn.GroupID, msg.UserID))
+		actionCtx = actionCtx.WithSession(newLocalSession(h, conn.GroupID))
 
 		// Dispatch action using Controller+State pattern
 		newState, actionErr := DispatchWithState(h.config.Controller, state.state, actionCtx)
@@ -2355,7 +2355,7 @@ func (h *liveHandler) handleUploadComplete(ctx context.Context, conn WSConn, raw
 		actionCtx = actionCtx.WithUploads(uploadRegistry)
 		actionCtx = actionCtx.WithUserID(connection.UserID)
 		actionCtx = actionCtx.WithFlashSetter(state)
-		actionCtx = actionCtx.WithSession(newLocalSession(h, connection.GroupID, connection.UserID))
+		actionCtx = actionCtx.WithSession(newLocalSession(h, connection.GroupID))
 
 		// Dispatch action using Controller+State pattern
 		newState, actionErr := DispatchWithState(h.config.Controller, state.state, actionCtx)

--- a/mount.go
+++ b/mount.go
@@ -53,68 +53,13 @@ type Session interface {
 	TriggerAction(action string, data map[string]interface{}) error
 }
 
-// SessionAware is implemented by stores that need server-initiated actions.
-// When a WebSocket connection is established, OnConnect is called with a Session
-// handle that can be used to trigger actions from background goroutines.
-//
-// Example usage:
-//
-//	type TimerStore struct {
-//	    Seconds int
-//	    session livetemplate.Session
-//	}
-//
-//	func (s *TimerStore) OnConnect(ctx context.Context, session livetemplate.Session) error {
-//	    s.session = session
-//	    go s.runTimer(ctx)
-//	    return nil
-//	}
-//
-//	func (s *TimerStore) runTimer(ctx context.Context) {
-//	    ticker := time.NewTicker(time.Second)
-//	    defer ticker.Stop()
-//	    for {
-//	        select {
-//	        case <-ctx.Done():
-//	            return
-//	        case <-ticker.C:
-//	            s.session.TriggerAction("tick", nil)
-//	        }
-//	    }
-//	}
-//
-//	func (s *TimerStore) OnDisconnect() {
-//	    // Cleanup if needed
-//	}
-//
-//	func (s *TimerStore) Tick(state TimerState, ctx *livetemplate.Context) (TimerState, error) {
-//	    state.Seconds++
-//	    return state, nil
-//	}
-type SessionAware interface {
-	OnConnect(ctx context.Context, session Session) error
-	OnDisconnect()
-}
-
-// Deprecated: Broadcaster is deprecated. Use Session instead.
-// Broadcaster allows stores to push updates to connected clients without user interaction.
-type Broadcaster interface {
-	Send() error // Re-renders template and sends update to this connection
-}
-
-// Deprecated: BroadcastAware is deprecated. Use SessionAware instead.
-// BroadcastAware is implemented by stores that need server-initiated updates.
-type BroadcastAware interface {
-	OnConnect(ctx context.Context, b Broadcaster) error
-	OnDisconnect()
-}
-
 // LiveHandler is the interface returned by Template.Handle()
 // It provides HTTP handling and lifecycle management for live template connections.
 //
-// For server-initiated actions, use the Session interface provided to stores
-// via SessionAware.OnConnect(). Session.TriggerAction() is the recommended way
-// to push updates from the server.
+// For server-initiated actions, implement an OnConnect(state, ctx) lifecycle
+// method on your controller and call ctx.Session() to obtain a Session handle
+// that can be used to trigger actions from background goroutines. See the
+// Session interface above and docs/references/server-actions.md for details.
 type LiveHandler interface {
 	http.Handler
 
@@ -547,6 +492,7 @@ func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	lifecycleCtx := NewContext(context.Background(), "", wsQueryData)
 	lifecycleCtx = lifecycleCtx.WithUserID(userID)
 	lifecycleCtx = lifecycleCtx.WithFlashSetter(connSt)
+	lifecycleCtx = lifecycleCtx.WithSession(newLocalSession(h, groupID, userID))
 
 	// Call Mount on every WebSocket connect (new session AND reconnect).
 	// Mount() refreshes state from the database, ensuring actions always
@@ -722,6 +668,7 @@ eventLoop:
 			actionCtx = actionCtx.WithUserID(userID)
 			actionCtx = actionCtx.WithUploads(uploadRegistry)
 			actionCtx = actionCtx.WithFlashSetter(connSt)
+			actionCtx = actionCtx.WithSession(newLocalSession(h, groupID, userID))
 
 			// Dispatch action using Controller+State pattern
 			newState, actionErr := DispatchWithState(h.config.Controller, connSt.state, actionCtx)
@@ -987,6 +934,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	lifecycleCtx := NewContext(ctx, "", queryData)
 	lifecycleCtx = lifecycleCtx.WithUserID(userID)
 	lifecycleCtx = lifecycleCtx.WithFlashSetter(connSt)
+	lifecycleCtx = lifecycleCtx.WithSession(newLocalSession(h, groupID, userID))
 
 	// Read flash messages from cookie (set by POST redirect)
 	if flashCookie, err := r.Cookie("lvt-flash"); err == nil && flashCookie.Value != "" {
@@ -1195,6 +1143,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	actionCtx = actionCtx.WithHTTP(w, r)
 	actionCtx = actionCtx.WithUploads(uploadRegistry)
 	actionCtx = actionCtx.WithFlashSetter(connSt)
+	actionCtx = actionCtx.WithSession(newLocalSession(h, groupID, userID))
 
 	// Dispatch action using Controller+State pattern
 	newState, actionErr := DispatchWithState(h.config.Controller, connSt.state, actionCtx)
@@ -1830,6 +1779,7 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 		actionCtx := NewContext(ctx, msg.Action, msg.Data)
 		actionCtx = actionCtx.WithUserID(msg.UserID)
 		actionCtx = actionCtx.WithFlashSetter(state)
+		actionCtx = actionCtx.WithSession(newLocalSession(h, conn.GroupID, msg.UserID))
 
 		// Dispatch action using Controller+State pattern
 		newState, actionErr := DispatchWithState(h.config.Controller, state.state, actionCtx)
@@ -1859,6 +1809,20 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 			state.state = newState
 			conn.Stores = newState
 			groupStates[conn.GroupID] = newState
+		}
+
+		// Chained BroadcastAction calls from server-initiated actions are
+		// intentionally not processed. Server actions already fan out to all
+		// the user's connections via this loop, and chaining BroadcastAction
+		// on top would cause duplicate fan-out plus storm risk — matching
+		// the behavior of handleDispatchedAction above. Log them so the
+		// failure is observable instead of silent (the pre-fix behavior).
+		if dropped := actionCtx.pendingBroadcasts(); len(dropped) > 0 {
+			slog.Error("BroadcastAction calls inside a server-initiated action are ignored (prevents fan-out amplification and broadcast storms)",
+				slog.String("component", "pubsub_handler"),
+				slog.String("action", msg.Action),
+				slog.String("user_id", msg.UserID),
+				slog.Int("dropped_count", len(dropped)))
 		}
 
 		// Send update to this connection (with flash messages)

--- a/session_impl.go
+++ b/session_impl.go
@@ -69,14 +69,19 @@ func newLocalSession(handler *liveHandler, groupID, userID string) *localSession
 //     connected to another instance. Goroutines that need a hard lifetime
 //     bound in this mode should implement their own termination condition.
 func (s *localSession) TriggerAction(action string, data map[string]interface{}) error {
-	if s == nil || s.handler == nil {
-		return fmt.Errorf("livetemplate: session not initialized")
+	// Callers obtain a Session via ctx.Session(), which returns a nil
+	// interface when WithSession was never called (and panics at the
+	// interface dispatch site, not here). The framework's wiring always
+	// passes a fully-constructed *localSession to WithSession, so by the
+	// time we enter this method, s and s.handler are guaranteed non-nil.
+	// The only input-level validation that belongs here is action/group
+	// emptiness — the framework can't cause those either, but they're
+	// cheap to check and document the contract.
+	if action == "" {
+		return fmt.Errorf("livetemplate: action cannot be empty")
 	}
 	if s.groupID == "" {
 		return fmt.Errorf("livetemplate: session has no groupID")
-	}
-	if action == "" {
-		return fmt.Errorf("livetemplate: action cannot be empty")
 	}
 
 	connections := s.handler.registry.GetByGroup(s.groupID)

--- a/session_impl.go
+++ b/session_impl.go
@@ -2,6 +2,7 @@ package livetemplate
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/livetemplate/livetemplate/internal/session"
 	"github.com/livetemplate/livetemplate/pubsub"
@@ -85,19 +86,48 @@ func (s *localSession) TriggerAction(action string, data map[string]interface{})
 		return fmt.Errorf("livetemplate: no connected sessions for group %q", s.groupID)
 	}
 
+	// Defensive shallow copy of the caller's data map. Dispatch happens
+	// asynchronously (via EnqueueDispatch and/or a Redis publish), so if
+	// the caller reused or mutated the same map after TriggerAction
+	// returned, the dispatched action handlers could observe torn reads
+	// or a mutated value. A one-time copy at this boundary makes the
+	// payload immutable from the framework's perspective.
+	var payload map[string]interface{}
+	if len(data) > 0 {
+		payload = make(map[string]interface{}, len(data))
+		for k, v := range data {
+			payload[k] = v
+		}
+	}
+
 	// Local fan-out: enqueue the dispatch onto each connection's event
 	// loop. The connection's own goroutine dequeues, runs the controller
 	// method, and sends the diff back over WebSocket.
 	for _, conn := range connections {
-		conn.EnqueueDispatch(&session.DispatchRequest{Action: action, Data: data})
+		conn.EnqueueDispatch(&session.DispatchRequest{Action: action, Data: payload})
 	}
 
 	// Remote fan-out: publish to Redis for other instances. The local
 	// instance filters its own messages, so local connections are not
 	// double-dispatched.
+	//
+	// Partial-success handling: if PubSub publishing fails after local
+	// enqueue has already happened, we log at Warn level and return nil
+	// instead of propagating the error. Returning an error would
+	// encourage callers to retry, which would double-enqueue the action
+	// on local connections. Logging + returning nil preserves
+	// at-least-once delivery for local connections while surfacing the
+	// remote-publish failure in operator logs. The goroutine-cancellation
+	// contract is unaffected: returning nil only happens when local
+	// delivery succeeded.
 	if hasRemote {
-		if err := gab.PublishGroupAction(s.groupID, action, data); err != nil {
-			return fmt.Errorf("livetemplate: pubsub publish failed: %w", err)
+		if err := gab.PublishGroupAction(s.groupID, action, payload); err != nil {
+			slog.Warn("livetemplate: Session.TriggerAction pubsub publish failed",
+				slog.String("component", "local_session"),
+				slog.String("group_id", s.groupID),
+				slog.String("action", action),
+				slog.Int("local_connections", len(connections)),
+				slog.Any("error", err))
 		}
 	}
 

--- a/session_impl.go
+++ b/session_impl.go
@@ -45,6 +45,18 @@ func newLocalSession(handler *liveHandler, groupID, userID string) *localSession
 //     instances. The RedisBroadcaster filters messages from its own
 //     instance ID, so local connections are not double-dispatched.
 //
+// Origin of the Session handle:
+//   - A Session obtained via ctx.Session() inside OnConnect (the typical
+//     path) targets the WebSocket connections in the current group.
+//   - A Session obtained via ctx.Session() inside an HTTP POST action
+//     handler is also valid: it identifies the session group of the
+//     HTTP request (e.g. via cookie) and will fan out to any WebSocket
+//     connections registered in that same group. Callers should be
+//     aware that TriggerAction from an HTTP context may have no effect
+//     if the same browser tab made the POST without an open WebSocket
+//     in the same group — the fan-out target is "peer WebSocket
+//     connections", not "the HTTP responder".
+//
 // Disconnect semantics:
 //   - In single-instance mode, when the group has no local connections
 //     and no GroupActionBroadcaster is configured, TriggerAction returns

--- a/session_impl.go
+++ b/session_impl.go
@@ -1,0 +1,93 @@
+package livetemplate
+
+import (
+	"fmt"
+
+	"github.com/livetemplate/livetemplate/internal/session"
+	"github.com/livetemplate/livetemplate/pubsub"
+)
+
+// localSession is the concrete implementation of the Session interface.
+// It dispatches server-initiated actions to every connection in a specific
+// session group via the existing per-connection dispatch queue
+// (EnqueueDispatch), the same mechanism used by ctx.BroadcastAction. A
+// PubSubBroadcaster, when configured, is also notified so remote
+// instances can deliver to their own local connections.
+//
+// Scope is per-session-group, not per-user. A session group corresponds
+// to one browser session (all tabs share one group via cookie). Anonymous
+// and authenticated flows both work, because every connection has a
+// groupID assigned at mount time regardless of auth state.
+type localSession struct {
+	handler *liveHandler
+	groupID string
+	userID  string
+}
+
+// newLocalSession constructs a localSession scoped to a specific session
+// group. The returned value implements the Session interface and is safe
+// to store in a controller across goroutines.
+func newLocalSession(handler *liveHandler, groupID, userID string) *localSession {
+	return &localSession{handler: handler, groupID: groupID, userID: userID}
+}
+
+// TriggerAction dispatches a server-initiated action to every connection
+// in this session's group.
+//
+// Behavior:
+//   - Local delivery enqueues the action onto each local connection's
+//     event loop via EnqueueDispatch. Each connection processes the
+//     request serially, creating a fresh action context, running the
+//     controller method, and sending the resulting diff over WebSocket.
+//     This is the same machinery used by ctx.BroadcastAction.
+//   - If a PubSubBroadcaster implementing GroupActionBroadcaster is
+//     configured, the action is also published to Redis for remote
+//     instances. The RedisBroadcaster filters messages from its own
+//     instance ID, so local connections are not double-dispatched.
+//
+// Disconnect semantics:
+//   - In single-instance mode, when the group has no local connections
+//     and no GroupActionBroadcaster is configured, TriggerAction returns
+//     an error. Background goroutines using the recommended cancellation
+//     pattern (`if err := session.TriggerAction(...); err != nil { return }`)
+//     will exit cleanly.
+//   - In multi-instance mode (PubSub configured), TriggerAction returns
+//     nil even with zero local connections, because the user may be
+//     connected to another instance. Goroutines that need a hard lifetime
+//     bound in this mode should implement their own termination condition.
+func (s *localSession) TriggerAction(action string, data map[string]interface{}) error {
+	if s == nil || s.handler == nil {
+		return fmt.Errorf("livetemplate: session not initialized")
+	}
+	if s.groupID == "" {
+		return fmt.Errorf("livetemplate: session has no groupID")
+	}
+	if action == "" {
+		return fmt.Errorf("livetemplate: action cannot be empty")
+	}
+
+	connections := s.handler.registry.GetByGroup(s.groupID)
+	gab, hasRemote := s.handler.config.PubSubBroadcaster.(pubsub.GroupActionBroadcaster)
+
+	if len(connections) == 0 && !hasRemote {
+		return fmt.Errorf("livetemplate: no connected sessions for group %q", s.groupID)
+	}
+
+	// Local fan-out: enqueue the dispatch onto each connection's event
+	// loop. The connection's own goroutine dequeues, runs the controller
+	// method, and sends the diff back over WebSocket.
+	for _, conn := range connections {
+		conn.EnqueueDispatch(&session.DispatchRequest{Action: action, Data: data})
+	}
+
+	// Remote fan-out: publish to Redis for other instances. The local
+	// instance filters its own messages, so local connections are not
+	// double-dispatched.
+	if hasRemote {
+		if err := gab.PublishGroupAction(s.groupID, action, data); err != nil {
+			return fmt.Errorf("livetemplate: pubsub publish failed: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/session_impl.go
+++ b/session_impl.go
@@ -22,14 +22,13 @@ import (
 type localSession struct {
 	handler *liveHandler
 	groupID string
-	userID  string
 }
 
 // newLocalSession constructs a localSession scoped to a specific session
 // group. The returned value implements the Session interface and is safe
 // to store in a controller across goroutines.
-func newLocalSession(handler *liveHandler, groupID, userID string) *localSession {
-	return &localSession{handler: handler, groupID: groupID, userID: userID}
+func newLocalSession(handler *liveHandler, groupID string) *localSession {
+	return &localSession{handler: handler, groupID: groupID}
 }
 
 // TriggerAction dispatches a server-initiated action to every connection
@@ -59,15 +58,36 @@ func newLocalSession(handler *liveHandler, groupID, userID string) *localSession
 //     connections", not "the HTTP responder".
 //
 // Disconnect semantics:
+//
 //   - In single-instance mode, when the group has no local connections
 //     and no GroupActionBroadcaster is configured, TriggerAction returns
 //     an error. Background goroutines using the recommended cancellation
 //     pattern (`if err := session.TriggerAction(...); err != nil { return }`)
 //     will exit cleanly.
+//
 //   - In multi-instance mode (PubSub configured), TriggerAction returns
 //     nil even with zero local connections, because the user may be
 //     connected to another instance. Goroutines that need a hard lifetime
-//     bound in this mode should implement their own termination condition.
+//     bound in this mode should implement their own termination condition
+//     (a done channel, a context with cancellation, or a bounded
+//     iteration count).
+//
+// Important asymmetry for multi-instance users: a persistent PubSub
+// outage produces silent "pubsub publish failed" warnings (one per
+// call) and TriggerAction keeps returning nil. Goroutines that rely
+// on the error return as their only stop signal will loop forever in
+// this scenario. If you care about goroutine cleanup under a broken
+// PubSub, do not depend on the return value — use a context you
+// control, or the hard iteration bound pattern:
+//
+//	for i := 0; i < 100; i++ {
+//	    select {
+//	    case <-ctx.Done():
+//	        return
+//	    case <-time.After(interval):
+//	    }
+//	    _ = session.TriggerAction("tick", nil)
+//	}
 func (s *localSession) TriggerAction(action string, data map[string]interface{}) error {
 	// Callers obtain a Session via ctx.Session(), which returns a nil
 	// interface when WithSession was never called (and panics at the

--- a/session_impl_test.go
+++ b/session_impl_test.go
@@ -1,0 +1,172 @@
+package livetemplate
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// triggerActionTestState carries state for the TriggerAction lifecycle test.
+// The Pushed field is populated by the DataLoaded action, which is invoked
+// indirectly via session.TriggerAction from a background goroutine.
+type triggerActionTestState struct {
+	Pushed string
+}
+
+// triggerActionTestController exercises the OnConnect -> goroutine ->
+// TriggerAction -> action handler pipeline end-to-end. It captures the
+// TriggerAction error return so tests can assert disconnect semantics.
+type triggerActionTestController struct {
+	mu           sync.Mutex
+	triggered    int
+	triggerErr   error
+	gotSession   bool
+	done         chan struct{}
+	connectDelay time.Duration
+}
+
+func (c *triggerActionTestController) OnConnect(state triggerActionTestState, ctx *Context) (triggerActionTestState, error) {
+	sess := ctx.Session()
+	c.mu.Lock()
+	c.gotSession = sess != nil
+	c.mu.Unlock()
+	if sess == nil {
+		if c.done != nil {
+			close(c.done)
+		}
+		return state, nil
+	}
+	go func() {
+		time.Sleep(c.connectDelay)
+		err := sess.TriggerAction("dataLoaded", map[string]interface{}{
+			"data": "hello from goroutine",
+		})
+		c.mu.Lock()
+		c.triggered++
+		c.triggerErr = err
+		c.mu.Unlock()
+		if c.done != nil {
+			close(c.done)
+		}
+	}()
+	return state, nil
+}
+
+func (c *triggerActionTestController) DataLoaded(state triggerActionTestState, ctx *Context) (triggerActionTestState, error) {
+	state.Pushed = ctx.GetString("data")
+	return state, nil
+}
+
+// TestLocalSession_TriggerActionFromOnConnect verifies that when a controller
+// spawns a goroutine from OnConnect and calls session.TriggerAction, the
+// targeted action handler runs and the resulting state diff is pushed to
+// the connected WebSocket client.
+//
+// Before the localSession fix, ctx.Session() returned nil inside OnConnect
+// and the goroutine silently did nothing — so the client would only ever
+// see the initial render. This test would hang on readWSUpdate without the
+// fix.
+func TestLocalSession_TriggerActionFromOnConnect(t *testing.T) {
+	auth := &fixedUserAuth{groupID: "local-session-group", userID: "test-user"}
+
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>Pushed: {{.Pushed}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	ctrl := &triggerActionTestController{
+		done:         make(chan struct{}),
+		connectDelay: 100 * time.Millisecond,
+	}
+	handler := tmpl.Handle(ctrl, AsState(&triggerActionTestState{}))
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	// Initial render.
+	ws, initial := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+	if v := treeDynamic(t, initial, "0"); v != "" {
+		t.Fatalf("Expected empty initial Pushed, got dynamic 0=%q", v)
+	}
+
+	// Server push arrives. readWSUpdate has a 5s timeout and reads the next
+	// frame off the socket. A failure to receive it means OnConnect didn't
+	// get a session or the goroutine's TriggerAction was a no-op.
+	update := readWSUpdate(t, ws, 5*time.Second)
+	tree, ok := update["tree"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected tree in server-push update, got: %v", update)
+	}
+	if v := fmt.Sprintf("%v", tree["0"]); v != "hello from goroutine" {
+		t.Fatalf("Expected Pushed='hello from goroutine', got dynamic 0=%q", v)
+	}
+
+	// Wait for the goroutine to have recorded its result.
+	select {
+	case <-ctrl.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("goroutine did not signal completion")
+	}
+
+	ctrl.mu.Lock()
+	defer ctrl.mu.Unlock()
+	if !ctrl.gotSession {
+		t.Error("OnConnect received a nil session — WithSession wiring is broken")
+	}
+	if ctrl.triggered != 1 {
+		t.Errorf("Expected TriggerAction to be called once, got %d", ctrl.triggered)
+	}
+	if ctrl.triggerErr != nil {
+		t.Errorf("TriggerAction returned unexpected error: %v", ctrl.triggerErr)
+	}
+}
+
+// TestLocalSession_TriggerActionDisconnectedReturnsError verifies that a
+// TriggerAction call with no live connections and no PubSub broadcaster
+// returns an error — the signal that background goroutines use to exit
+// cleanly when their session ends.
+func TestLocalSession_TriggerActionDisconnectedReturnsError(t *testing.T) {
+	auth := &fixedUserAuth{groupID: "disconnect-group", userID: "disconnect-user"}
+
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Pushed}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&triggerActionTestController{done: make(chan struct{})}, AsState(&triggerActionTestState{}))
+
+	// Cast to *liveHandler so we can construct a localSession directly —
+	// the same code path that runs inside OnConnect.
+	h, ok := handler.(*liveHandler)
+	if !ok {
+		t.Fatalf("Handle() returned unexpected concrete type %T", handler)
+	}
+	sess := newLocalSession(h, "never-connected-group", "disconnect-user")
+
+	// No WebSocket has ever connected for this group, and there's no
+	// PubSubBroadcaster, so local+remote delivery both have nothing to do.
+	err = sess.TriggerAction("dataLoaded", map[string]interface{}{"data": "test"})
+	if err == nil {
+		t.Fatal("Expected TriggerAction to return an error when no connections exist, got nil")
+	}
+	if !strings.Contains(err.Error(), "no connected sessions") {
+		t.Errorf("Expected 'no connected sessions' in error, got: %v", err)
+	}
+}

--- a/session_impl_test.go
+++ b/session_impl_test.go
@@ -1,6 +1,7 @@
 package livetemplate
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"strings"
@@ -19,6 +20,12 @@ type triggerActionTestState struct {
 // triggerActionTestController exercises the OnConnect -> goroutine ->
 // TriggerAction -> action handler pipeline end-to-end. It captures the
 // TriggerAction error return so tests can assert disconnect semantics.
+//
+// The goroutine spawned in OnConnect honours a cancel context so that
+// test teardown (via t.Fatal or normal exit) cancels the sleep and
+// skips the TriggerAction call. Without this, a test failure before
+// the sleep elapses would leave the goroutine asleep while defers
+// tore down the server, producing a race under `go test -race`.
 type triggerActionTestController struct {
 	mu           sync.Mutex
 	triggered    int
@@ -26,6 +33,7 @@ type triggerActionTestController struct {
 	gotSession   bool
 	done         chan struct{}
 	connectDelay time.Duration
+	cancelCtx    context.Context
 }
 
 func (c *triggerActionTestController) OnConnect(state triggerActionTestState, ctx *Context) (triggerActionTestState, error) {
@@ -40,7 +48,16 @@ func (c *triggerActionTestController) OnConnect(state triggerActionTestState, ct
 		return state, nil
 	}
 	go func() {
-		time.Sleep(c.connectDelay)
+		select {
+		case <-time.After(c.connectDelay):
+		case <-c.cancelCtx.Done():
+			// Test is tearing down — skip TriggerAction on the stale
+			// server and signal completion so the test drain can exit.
+			if c.done != nil {
+				close(c.done)
+			}
+			return
+		}
 		err := sess.TriggerAction("dataLoaded", map[string]interface{}{
 			"data": "hello from goroutine",
 		})
@@ -81,9 +98,16 @@ func TestLocalSession_TriggerActionFromOnConnect(t *testing.T) {
 		t.Fatalf("Parse failed: %v", err)
 	}
 
+	// Cancel context that the spawned OnConnect goroutine honours so
+	// test teardown aborts the TriggerAction call instead of racing
+	// against server.Close().
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
 	ctrl := &triggerActionTestController{
 		done:         make(chan struct{}),
 		connectDelay: 100 * time.Millisecond,
+		cancelCtx:    cancelCtx,
 	}
 	handler := tmpl.Handle(ctrl, AsState(&triggerActionTestState{}))
 
@@ -150,7 +174,16 @@ func TestLocalSession_TriggerActionDisconnectedReturnsError(t *testing.T) {
 		t.Fatalf("Parse failed: %v", err)
 	}
 
-	handler := tmpl.Handle(&triggerActionTestController{done: make(chan struct{})}, AsState(&triggerActionTestState{}))
+	// cancelCtx is unused in this test (no OnConnect goroutine is
+	// spawned because no WebSocket is ever connected), but must be
+	// non-nil to avoid panicking if OnConnect is accidentally called.
+	handler := tmpl.Handle(
+		&triggerActionTestController{
+			done:      make(chan struct{}),
+			cancelCtx: context.Background(),
+		},
+		AsState(&triggerActionTestState{}),
+	)
 
 	// Cast to *liveHandler so we can construct a localSession directly —
 	// the same code path that runs inside OnConnect.
@@ -158,7 +191,7 @@ func TestLocalSession_TriggerActionDisconnectedReturnsError(t *testing.T) {
 	if !ok {
 		t.Fatalf("Handle() returned unexpected concrete type %T", handler)
 	}
-	sess := newLocalSession(h, "never-connected-group", "disconnect-user")
+	sess := newLocalSession(h, "never-connected-group")
 
 	// No WebSocket has ever connected for this group, and there's no
 	// PubSubBroadcaster, so local+remote delivery both have nothing to do.

--- a/session_test.go
+++ b/session_test.go
@@ -479,22 +479,3 @@ func TestSession_Interface(t *testing.T) {
 	// Verify Session interface exists
 	var _ = (Session)(nil)
 }
-
-func TestSessionAware_Interface(t *testing.T) {
-	// Verify SessionAware interface exists
-	var _ SessionAware = (*testSessionAwareStore)(nil)
-}
-
-// testSessionAwareStore implements SessionAware for testing
-type testSessionAwareStore struct {
-	session Session
-}
-
-func (s *testSessionAwareStore) OnConnect(ctx context.Context, sess Session) error {
-	s.session = sess
-	return nil
-}
-
-func (s *testSessionAwareStore) OnDisconnect() {
-	s.session = nil
-}


### PR DESCRIPTION
## Summary

The `Session` interface and `ctx.Session()` / `ctx.WithSession()` accessors existed in the API surface but `WithSession` was never called in any production `mount.go` code path, so `ctx.Session()` always returned `nil`.

This meant:
- The [`login/` example](https://github.com/livetemplate/examples/blob/main/login/main.go)'s server welcome message silently no-op'd (no test existed to catch it).
- The goroutine + `TriggerAction` pattern documented in `docs/references/server-actions.md` did not work at runtime.
- Patterns #14 (Lazy Loading), #15 (Progress Bar), #16 (Async Operations), and #31 (Server Push) in the patterns example proposal (#333) could not be implemented against the shipping library.

Discovered while trying to implement Session 3 of the patterns example — all three patterns in that session rely on `session.TriggerAction` from a background goroutine, and none of them worked until this fix landed.

## Changes

**Core fix:**
- New `localSession` in `session_impl.go` as the concrete `Session` implementation. Scope is per-session-group (not per-user) so anonymous and authenticated flows both work. Dispatches via the existing `conn.EnqueueDispatch` path used by `ctx.BroadcastAction`. Publishes to `pubsub.GroupActionBroadcaster` for remote instances when configured. Returns an error when there are no local connections and no broadcaster — the cancellation signal background goroutines use to exit cleanly after disconnect.
- Wire `ctx.WithSession(newLocalSession(h, groupID, userID))` at 5 `NewContext` call sites in `mount.go` (WS lifecycle, WS action, HTTP lifecycle, HTTP action, PubSub server-action dispatch).

**Numeric type coercion:**
- Extend `ActionData.GetIntOk` / `GetFloatOk` to accept native Go numeric types (`int`, `int8-64`, `uint8-64`, `float32`, `float64`) in addition to the existing `float64`-from-JSON and `string`-from-form cases. `Session.TriggerAction` is a Go-native dispatch path — callers pass native Go values into `map[string]interface{}`, not JSON-unmarshaled ones. Without this, `ctx.GetInt("progress")` returned 0 for `TriggerAction("tick", {"progress": 10})` because the raw value was a Go `int`, not `float64` or `string`. (`GetBoolOk` already handled native `bool`, so only Int/Float were missing.)

**Silent-drop gap:**
- In `handleServerActionMessage` (PubSub server-action path), log dropped `pendingBroadcasts` at `Error` level to match `handleDispatchedAction`'s existing storm-prevention behavior. Previously the drop was silent, which masked the same class of bug (broadcasts queued but never delivered).

**Dead-code cleanup:**
- Remove `SessionAware`, `BroadcastAware`, and `Broadcaster` interface declarations from `mount.go`. Grepping the entire module found **zero** production type assertions against any of them — they were declared but never dispatched. Their presence misled documentation and example code into assuming there was a working `OnConnect(ctx, Session)` entry point, which is the confusion that made the `TriggerAction` gap latent for so long. The reflection-based `OnConnect(state, ctx) (state, error)` lifecycle method in `lifecycle.go` is the real entry point and remains.
- Update `docs/references/api-reference.md` to describe the lifecycle-method access pattern instead of referencing the removed `SessionAware.OnConnect(ctx, session)`.

## Tests added

- `TestLocalSession_TriggerActionFromOnConnect` — end-to-end WebSocket server push: `OnConnect` captures the session, a goroutine sleeps then calls `TriggerAction`, the client receives the diff.
- `TestLocalSession_TriggerActionDisconnectedReturnsError` — verifies the cancellation signal for background goroutines.
- `TestContext_GetInt_NativeTypes` — `int`, `int32`, `int64`, `uint`, `float32`, `float64`, and numeric string coverage.
- `TestOnDisconnect_FiresOnWebSocketClose` — clean close path.
- `TestOnDisconnect_FiresOnAbruptClose` — abrupt TCP drop (required for the Presence Tracking pattern #28 to work reliably).
- `TestBroadcastAction_PeerCanSetFlash` — verifies `ctx.SetFlash` is wired in the peer's dispatched action context, not just the initiator's. Before this test, `broadcast_test.go` covered `BroadcastAction` dispatch but nothing verified that `FlashSetter` was available on peer connections.

Full library test suite (`go test -race -timeout=5m ./...`) passes, including Redis PubSub integration tests.

## Follow-up (separate PR in examples repo)

The `login/` example had this latent bug — `sendWelcomeMessage` spawned a goroutine calling `session.TriggerAction` that silently no-op'd. A regression test for the server welcome message (`TestLoginE2E / Server Welcome Message via WebSocket Push`) will land in the examples repo's Session 3 PR once this fix is released, since it needs the fix to pass.

## Breaking changes

Removing `SessionAware`, `BroadcastAware`, and `Broadcaster` interface declarations is technically a breaking API change. However, grep confirms they were never dispatched or type-asserted in production code, so no working user code should depend on them. Any code that implemented `SessionAware.OnConnect(ctx, Session)` was already silently broken and needs to migrate to the `OnConnect(state, ctx) (state, error)` lifecycle method pattern documented in `docs/references/server-actions.md` (which is now the only remaining pattern).

## Test plan

- [x] `go test -race -timeout=5m ./...` passes on library worktree
- [x] Pre-commit hook (auto-format + full test suite) passes
- [x] Session 3 patterns (`TestLazyLoading`, `TestProgressBar`, `TestAsyncOperations`) pass against the patched library
- [x] Login example manually verified — server welcome message appears within ~500ms of login
- [x] `TestLoginE2E` with new `Server Welcome Message via WebSocket Push` subtest passes against the patched library

🤖 Generated with [Claude Code](https://claude.com/claude-code)