### PR TITLE
feat: __navigate__ action + flash persist-until-cleared lifecycle

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -61,7 +61,7 @@ jobs:
         npm ci
         echo "Building client library..."
         npm run build
-        echo "✓ Client library built successfully"
+        echo "OK: Client library built successfully"
         ls -la dist/
 
     - name: Run core library unit tests (with race detector)
@@ -88,7 +88,7 @@ jobs:
         echo "Adding replace directive to use local core library..."
         go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
         go mod tidy
-        echo "✓ Replace directive added"
+        echo "OK: Replace directive added"
 
     - name: Run LVT unit tests
       working-directory: lvt
@@ -153,7 +153,7 @@ jobs:
         npm ci
         echo "Building client library..."
         npm run build
-        echo "✓ Client library built successfully"
+        echo "OK: Client library built successfully"
         ls -la dist/
 
     - name: Install sqlc
@@ -168,7 +168,7 @@ jobs:
         go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
         go mod edit -replace=github.com/livetemplate/lvt/components=../lvt/components
         go mod tidy
-        echo "✓ Replace directives added"
+        echo "OK: Replace directives added"
 
     - name: Run examples test suite
       working-directory: examples
@@ -220,7 +220,7 @@ jobs:
         npm install @livetemplate/client@latest
         echo "Building client library..."
         npm run build
-        echo "✓ Tinkerdown client built successfully"
+        echo "OK: Tinkerdown client built successfully"
 
     - name: Add replace directives to Tinkerdown
       working-directory: tinkerdown
@@ -229,7 +229,7 @@ jobs:
         go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
         go mod edit -replace=github.com/livetemplate/lvt/components=../lvt/components
         go mod tidy
-        echo "✓ Replace directives added"
+        echo "OK: Replace directives added"
 
     - name: Build Tinkerdown binary
       working-directory: tinkerdown
@@ -256,7 +256,7 @@ jobs:
         # Verify the binary is an executable, not an archive
         file tinkerdown
         if file tinkerdown | grep -q "ELF"; then
-          echo "✓ Binary is ELF executable"
+          echo "OK: Binary is ELF executable"
         else
           echo "ERROR: Binary is not an ELF executable!"
           file tinkerdown
@@ -272,7 +272,7 @@ jobs:
             echo "  → Created symlink in $dir"
           fi
         done
-        echo "✓ Binary installed and symlinked"
+        echo "OK: Binary installed and symlinked"
 
     - name: Run Tinkerdown unit tests
       working-directory: tinkerdown

--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -128,10 +128,33 @@ jobs:
         repository: livetemplate/examples
         path: examples
 
+    - name: Checkout client library
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/client
+        path: livetemplate/client
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: '1.26'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: livetemplate/client/package-lock.json
+
+    - name: Build client library
+      working-directory: livetemplate/client
+      run: |
+        echo "Installing client dependencies..."
+        npm ci
+        echo "Building client library..."
+        npm run build
+        echo "✓ Client library built successfully"
+        ls -la dist/
 
     - name: Install sqlc
       run: |
@@ -152,6 +175,7 @@ jobs:
       run: ./test-all.sh --skip-disabled
       env:
         CGO_ENABLED: 1
+        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
 
   test-tinkerdown:
     name: Test Tinkerdown against Core Changes

--- a/action.go
+++ b/action.go
@@ -43,51 +43,17 @@ const defaultFormAction = "submit"
 
 // actionNavigate is a reserved action name. When the client sends
 // {action: "__navigate__", data: {k: v, ...}} over an existing WebSocket
-// connection, the event loop re-runs Mount on the controller with the
-// given data as query params — without reconnecting the WebSocket. This
-// is the in-band equivalent of Phoenix LiveView's live_patch /
-// handle_params: query-param changes on the SAME handler don't tear down
-// the socket, they re-run the Mount-time projection.
+// connection, the event loop re-runs Mount with the given data as query
+// params — without reconnecting. Intercepted before DispatchWithState, so
+// no controller method-name collision is possible.
 //
-// Rationale: the WebSocket's connection identity is handler-path based,
-// not (path+query) based. Query params are Mount-time input data, not
-// part of the handler address. Without this message, changing the query
-// string on a same-handler SPA navigation left the server's connSt.state
-// pinned to the initial query params and every subsequent server-driven
-// refresh clobbered the DOM with stale data.
-//
-// Controllers cannot define a method named Navigate that takes this
-// reserved action — the event loop intercepts it before DispatchWithState
-// ever runs. If a controller does define such a method, the event loop
-// short-circuit takes precedence.
-//
-// ctx.Action() == "" guard: the navigate path uses actionCtx.WithAction("")
-// so Mount's if ctx.Action() == "" { ... } guard fires on navigate — same
-// as the initial HTTP connect. This is intentional: navigate is a re-mount,
-// not a form action. Existing controllers that guard analytics or one-time
-// side-effects with ctx.Action() == "" will fire on every navigate. If you
-// need initial-connect-only behaviour, use OnConnect instead of Mount.
-//
-// State note: Mount receives the current session state, not a fresh
-// zero-value state. This preserves unrelated per-connection fields (e.g.,
-// pagination cursors, expanded panels) across navigations. To reset
-// specific fields on navigate, zero them explicitly inside Mount.
-//
-// Reconnect note: the WebSocket's connection identity is based on the
-// handler path, not the query string. After a navigate action, if the
-// socket disconnects and reconnects, the client reconnects to the original
-// URL — Mount re-runs with the initial query params, not the navigated-to
-// params. The client is responsible for updating window.location and
-// using the updated URL on reconnect so that post-reconnect Mounts see
-// the latest query params.
-//
-// Query param note: msg.Data fully replaces the query params for the
-// Mount call — the original connection query string is not merged. If
-// your Mount reads multiple params (e.g., ?tab=settings&s=alpha), you
-// must include all of them in every navigate payload or Mount will see
-// missing keys as empty strings. Sending __navigate__ with no data field
-// (or an empty data map) is equivalent to navigating to the base path
-// with no query params — all ctx.GetString / GetInt calls return zero values.
+// Three non-obvious invariants:
+//  1. ctx.Action() == "" fires on navigate (uses WithAction("")) — use
+//     OnConnect instead of Mount for initial-connect-only side-effects.
+//  2. msg.Data fully replaces query params (no merge with original URL);
+//     nil data means all ctx.GetString / GetInt calls return zero values.
+//  3. Mount receives the current session state, not a zero-value state —
+//     unrelated fields are preserved across navigations.
 const actionNavigate = "__navigate__"
 
 // applyDefaultAction sets the action to defaultFormAction for forms that

--- a/action.go
+++ b/action.go
@@ -41,28 +41,9 @@ type message = send.ActionMessage
 // Maps to the Submit() method on the controller via methodNameToActions().
 const defaultFormAction = "submit"
 
-// actionNavigate is a reserved action name. When the client sends
-// {action: "__navigate__", data: {k: v, ...}} over an existing WebSocket
-// connection, the event loop re-runs Mount with the given data as query
-// params — without reconnecting. Intercepted before DispatchWithState, so
-// no controller method-name collision is possible.
-//
-// Four non-obvious invariants:
-//  1. ctx.Action() == "" fires on navigate (uses WithAction("")) — use
-//     OnConnect instead of Mount for initial-connect-only side-effects.
-//  2. msg.Data fully replaces query params (no merge with original URL);
-//     nil data means all ctx.GetString / GetInt calls return zero values.
-//  3. Mount receives the current session state, not a zero-value state —
-//     unrelated fields are preserved across navigations.
-//  4. ctx.Redirect() inside Mount on a WebSocket connection always returns
-//     ErrNoHTTPContext — the redirect has no effect and the response is a
-//     normal tree update.
-//
-// If the controller has no Mount method, __navigate__ is a no-op re-render
-// (state unchanged, success=true response).
-//
-// HTTP note: sending __navigate__ over HTTP (progressive enhancement or JSON
-// form submission) returns 400 Bad Request — it is a WebSocket-only action.
+// actionNavigate is a reserved WebSocket-only action name. The event loop
+// re-runs Mount with msg.Data as query params instead of routing through
+// DispatchWithState, so no controller method named "__navigate__" is required.
 const actionNavigate = "__navigate__"
 
 // applyDefaultAction sets the action to defaultFormAction for forms that

--- a/action.go
+++ b/action.go
@@ -60,6 +60,19 @@ const defaultFormAction = "submit"
 // reserved action — the event loop intercepts it before DispatchWithState
 // ever runs. If a controller does define such a method, the event loop
 // short-circuit takes precedence.
+//
+// State note: Mount receives the current session state, not a fresh
+// zero-value state. This preserves unrelated per-connection fields (e.g.,
+// pagination cursors, expanded panels) across navigations. To reset
+// specific fields on navigate, zero them explicitly inside Mount.
+//
+// Reconnect note: the WebSocket's connection identity is based on the
+// handler path, not the query string. After a navigate action, if the
+// socket disconnects and reconnects, the client reconnects to the original
+// URL — Mount re-runs with the initial query params, not the navigated-to
+// params. The client is responsible for updating window.location and
+// using the updated URL on reconnect so that post-reconnect Mounts see
+// the latest query params.
 const actionNavigate = "__navigate__"
 
 // applyDefaultAction sets the action to defaultFormAction for forms that

--- a/action.go
+++ b/action.go
@@ -54,6 +54,9 @@ const defaultFormAction = "submit"
 //     nil data means all ctx.GetString / GetInt calls return zero values.
 //  3. Mount receives the current session state, not a zero-value state —
 //     unrelated fields are preserved across navigations.
+//  4. ctx.Redirect() inside Mount on a WebSocket connection always returns
+//     ErrNoHTTPContext — the redirect has no effect and the response is a
+//     normal tree update.
 const actionNavigate = "__navigate__"
 
 // applyDefaultAction sets the action to defaultFormAction for forms that

--- a/action.go
+++ b/action.go
@@ -47,7 +47,7 @@ const defaultFormAction = "submit"
 // params — without reconnecting. Intercepted before DispatchWithState, so
 // no controller method-name collision is possible.
 //
-// Three non-obvious invariants:
+// Four non-obvious invariants:
 //  1. ctx.Action() == "" fires on navigate (uses WithAction("")) — use
 //     OnConnect instead of Mount for initial-connect-only side-effects.
 //  2. msg.Data fully replaces query params (no merge with original URL);

--- a/action.go
+++ b/action.go
@@ -61,6 +61,13 @@ const defaultFormAction = "submit"
 // ever runs. If a controller does define such a method, the event loop
 // short-circuit takes precedence.
 //
+// ctx.Action() == "" guard: the navigate path uses actionCtx.WithAction("")
+// so Mount's if ctx.Action() == "" { ... } guard fires on navigate — same
+// as the initial HTTP connect. This is intentional: navigate is a re-mount,
+// not a form action. Existing controllers that guard analytics or one-time
+// side-effects with ctx.Action() == "" will fire on every navigate. If you
+// need initial-connect-only behaviour, use OnConnect instead of Mount.
+//
 // State note: Mount receives the current session state, not a fresh
 // zero-value state. This preserves unrelated per-connection fields (e.g.,
 // pagination cursors, expanded panels) across navigations. To reset

--- a/action.go
+++ b/action.go
@@ -73,6 +73,12 @@ const defaultFormAction = "submit"
 // params. The client is responsible for updating window.location and
 // using the updated URL on reconnect so that post-reconnect Mounts see
 // the latest query params.
+//
+// Query param note: msg.Data fully replaces the query params for the
+// Mount call — the original connection query string is not merged. If
+// your Mount reads multiple params (e.g., ?tab=settings&s=alpha), you
+// must include all of them in every navigate payload or Mount will see
+// missing keys as empty strings.
 const actionNavigate = "__navigate__"
 
 // applyDefaultAction sets the action to defaultFormAction for forms that

--- a/action.go
+++ b/action.go
@@ -78,7 +78,9 @@ const defaultFormAction = "submit"
 // Mount call — the original connection query string is not merged. If
 // your Mount reads multiple params (e.g., ?tab=settings&s=alpha), you
 // must include all of them in every navigate payload or Mount will see
-// missing keys as empty strings.
+// missing keys as empty strings. Sending __navigate__ with no data field
+// (or an empty data map) is equivalent to navigating to the base path
+// with no query params — all ctx.GetString / GetInt calls return zero values.
 const actionNavigate = "__navigate__"
 
 // applyDefaultAction sets the action to defaultFormAction for forms that

--- a/action.go
+++ b/action.go
@@ -57,6 +57,9 @@ const defaultFormAction = "submit"
 //  4. ctx.Redirect() inside Mount on a WebSocket connection always returns
 //     ErrNoHTTPContext — the redirect has no effect and the response is a
 //     normal tree update.
+//
+// If the controller has no Mount method, __navigate__ is a no-op re-render
+// (state unchanged, success=true response).
 const actionNavigate = "__navigate__"
 
 // applyDefaultAction sets the action to defaultFormAction for forms that

--- a/action.go
+++ b/action.go
@@ -41,6 +41,27 @@ type message = send.ActionMessage
 // Maps to the Submit() method on the controller via methodNameToActions().
 const defaultFormAction = "submit"
 
+// actionNavigate is a reserved action name. When the client sends
+// {action: "__navigate__", data: {k: v, ...}} over an existing WebSocket
+// connection, the event loop re-runs Mount on the controller with the
+// given data as query params — without reconnecting the WebSocket. This
+// is the in-band equivalent of Phoenix LiveView's live_patch /
+// handle_params: query-param changes on the SAME handler don't tear down
+// the socket, they re-run the Mount-time projection.
+//
+// Rationale: the WebSocket's connection identity is handler-path based,
+// not (path+query) based. Query params are Mount-time input data, not
+// part of the handler address. Without this message, changing the query
+// string on a same-handler SPA navigation left the server's connSt.state
+// pinned to the initial query params and every subsequent server-driven
+// refresh clobbered the DOM with stale data.
+//
+// Controllers cannot define a method named Navigate that takes this
+// reserved action — the event loop intercepts it before DispatchWithState
+// ever runs. If a controller does define such a method, the event loop
+// short-circuit takes precedence.
+const actionNavigate = "__navigate__"
+
 // applyDefaultAction sets the action to defaultFormAction for forms that
 // submitted without explicit action routing. Called only for browser form
 // submissions (not JSON action requests).

--- a/action.go
+++ b/action.go
@@ -60,6 +60,9 @@ const defaultFormAction = "submit"
 //
 // If the controller has no Mount method, __navigate__ is a no-op re-render
 // (state unchanged, success=true response).
+//
+// HTTP note: sending __navigate__ over HTTP (progressive enhancement or JSON
+// form submission) returns 400 Bad Request — it is a WebSocket-only action.
 const actionNavigate = "__navigate__"
 
 // applyDefaultAction sets the action to defaultFormAction for forms that

--- a/context.go
+++ b/context.go
@@ -314,6 +314,9 @@ type flashConfig struct {
 // acknowledgement. Messages without an expiry persist until explicitly
 // cleared via ClearFlash.
 //
+// A duration of 0 or less disables auto-expiry — the message behaves as if
+// FlashExpiry were not provided and persists until ClearFlash is called.
+//
 // Note: FlashExpiry has no observable effect on HTTP connections — HTTP
 // flash is inherently one-shot (per-request connSt is GC'd after the
 // handler returns) regardless of the expiry duration set here.

--- a/context.go
+++ b/context.go
@@ -336,11 +336,13 @@ func FlashExpiry(d time.Duration) FlashOption {
 // cleared after each render (one-shot). Flash now persists on WebSocket
 // connections until ClearFlash is explicitly called or FlashExpiry elapses.
 // Existing handlers that relied on the auto-clear behavior and do not call
-// ClearFlash will accumulate flash across re-renders. Add an explicit
-// ClearFlash call (or FlashExpiry) to preserve one-shot behavior:
+// ClearFlash will accumulate flash across re-renders. To restore one-shot
+// behavior, either call ClearFlash in the next handler, or use FlashExpiry:
 //
-//	ctx.SetFlash("success", "Saved!", livetemplate.FlashExpiry(0)) // one-shot: use ClearFlash in next handler
-//	ctx.SetFlash("success", "Saved!", livetemplate.FlashExpiry(5*time.Second)) // auto-expire after 5s
+//	// Option A: persist and clear explicitly in the follow-up handler
+//	ctx.SetFlash("success", "Saved!") // call ctx.ClearFlash("success") in the next handler
+//	// Option B: auto-expire after a fixed duration (e.g., after 5 seconds)
+//	ctx.SetFlash("success", "Saved!", livetemplate.FlashExpiry(5*time.Second))
 //
 // Transport lifetime note: On WebSocket connections the flash store survives
 // across renders — messages persist until ClearFlash is called. On HTTP

--- a/context.go
+++ b/context.go
@@ -321,6 +321,10 @@ type flashConfig struct {
 // flash is inherently one-shot (per-request connSt is GC'd after the
 // handler returns) regardless of the expiry duration set here.
 //
+// Note: The expiry timer is only checked before successful renders. If
+// a connection receives only error responses after the expiry elapses,
+// the expired flash remains visible until the next successful render.
+//
 // Example:
 //
 //	ctx.SetFlash("success", "Saved!", livetemplate.FlashExpiry(5*time.Second))

--- a/context.go
+++ b/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/livetemplate/livetemplate/internal/uploadtypes"
@@ -19,11 +20,14 @@ type UploadAccessor interface {
 // Flash messages are page-level notifications (success, info, warning, error)
 // that don't affect ResponseMetadata.Success (unlike field validation errors).
 //
-// The setFlash method is intentionally unexported to ensure flash messages
-// are only set through the Context.SetFlash() public API, maintaining
-// consistent behavior and preventing direct message map manipulation.
+// FlashSetter is the internal interface for flash message operations.
+// The methods are intentionally unexported to ensure flash messages
+// are only managed through the Context.SetFlash() / ClearFlash() public
+// API, maintaining consistent behavior and preventing direct message
+// map manipulation.
 type FlashSetter interface {
-	setFlash(key, message string)
+	setFlash(key, message string, expiry time.Duration)
+	clearFlashKey(key string)
 }
 
 // broadcastRequest represents a deferred broadcast action to be dispatched
@@ -296,10 +300,37 @@ func (c *Context) WithFlashSetter(setter FlashSetter) *Context {
 	return &newCtx
 }
 
+// FlashOption configures optional behavior for SetFlash.
+type FlashOption func(*flashConfig)
+
+type flashConfig struct {
+	expiry time.Duration // 0 = no auto-expiry, persist until ClearFlash
+}
+
+// FlashExpiry sets an auto-expiry duration for the flash message. After
+// the duration elapses, the message is pruned from the flash store on
+// the next render. Use this for transient feedback ("Settings saved")
+// that doesn't need explicit acknowledgement. Messages without an
+// expiry persist until explicitly cleared via ClearFlash.
+//
+// Example:
+//
+//	ctx.SetFlash("success", "Saved!", livetemplate.FlashExpiry(5*time.Second))
+func FlashExpiry(d time.Duration) FlashOption {
+	return func(c *flashConfig) { c.expiry = d }
+}
+
 // SetFlash sets a flash message that will be available in templates via .lvt.Flash(key).
 // Flash messages are page-level notifications (success, info, warning, error).
 // Unlike field errors, flash messages don't affect ResponseMetadata.Success.
-// Flash messages are cleared after each render, so they appear only once.
+//
+// Flash messages persist until explicitly cleared via ClearFlash or until
+// their optional expiry duration elapses. This matches the Phoenix LiveView
+// model where flash is a separate namespace from assigns — background
+// updates (TriggerAction / scan-loop Refresh) that modify state fields
+// do not touch flash messages. Use ClearFlash in your action handlers
+// when the user has acknowledged the message (e.g., after a navigation
+// or a follow-up action).
 //
 // Common keys: "success", "error", "info", "warning"
 //
@@ -312,9 +343,33 @@ func (c *Context) WithFlashSetter(setter FlashSetter) *Context {
 //
 //	ctx.SetFlash("success", "Changes saved successfully!")
 //	ctx.SetFlash("error", "Failed to process your request.")
-func (c *Context) SetFlash(key, message string) {
+//	ctx.SetFlash("info", "Uploading...", livetemplate.FlashExpiry(3*time.Second))
+func (c *Context) SetFlash(key, message string, opts ...FlashOption) {
+	if c.flashSetter == nil {
+		return
+	}
+	var cfg flashConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	c.flashSetter.setFlash(key, message, cfg.expiry)
+}
+
+// ClearFlash explicitly removes a flash message by key. Use this when
+// the user has acknowledged the message (e.g., after navigating away
+// or completing a follow-up action). Flash messages without an expiry
+// persist until ClearFlash is called — the framework does not auto-clear
+// them after render.
+//
+// Example:
+//
+//	func (c *MyController) Acknowledge(state MyState, ctx *livetemplate.Context) (MyState, error) {
+//	    ctx.ClearFlash("error")
+//	    return state, nil
+//	}
+func (c *Context) ClearFlash(key string) {
 	if c.flashSetter != nil {
-		c.flashSetter.setFlash(key, message)
+		c.flashSetter.clearFlashKey(key)
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -20,10 +20,10 @@ type UploadAccessor interface {
 // Flash messages are page-level notifications (success, info, warning, error)
 // that don't affect ResponseMetadata.Success (unlike field validation errors).
 //
-// FlashSetter is the internal interface for flash message operations.
-// The methods are intentionally unexported to ensure flash messages
-// are only managed through the Context.SetFlash() / ClearFlash() public
-// API, maintaining consistent behavior and preventing direct message
+// FlashSetter is the interface implemented by connState for flash message
+// operations. The methods are intentionally unexported to ensure flash
+// messages are only managed through the Context.SetFlash() / ClearFlash()
+// public API, maintaining consistent behavior and preventing direct message
 // map manipulation.
 type FlashSetter interface {
 	setFlash(key, message string, expiry time.Duration)

--- a/context.go
+++ b/context.go
@@ -332,6 +332,16 @@ func FlashExpiry(d time.Duration) FlashOption {
 // when the user has acknowledged the message (e.g., after a navigation
 // or a follow-up action).
 //
+// Migration note (v0.8 → v0.9): In earlier releases, flash was automatically
+// cleared after each render (one-shot). Flash now persists on WebSocket
+// connections until ClearFlash is explicitly called or FlashExpiry elapses.
+// Existing handlers that relied on the auto-clear behavior and do not call
+// ClearFlash will accumulate flash across re-renders. Add an explicit
+// ClearFlash call (or FlashExpiry) to preserve one-shot behavior:
+//
+//	ctx.SetFlash("success", "Saved!", livetemplate.FlashExpiry(0)) // one-shot: use ClearFlash in next handler
+//	ctx.SetFlash("success", "Saved!", livetemplate.FlashExpiry(5*time.Second)) // auto-expire after 5s
+//
 // Transport lifetime note: On WebSocket connections the flash store survives
 // across renders — messages persist until ClearFlash is called. On HTTP
 // connections (form submissions with progressive enhancement) the flash

--- a/context.go
+++ b/context.go
@@ -308,10 +308,11 @@ type flashConfig struct {
 }
 
 // FlashExpiry sets an auto-expiry duration for the flash message. After
-// the duration elapses, the message is pruned from the flash store on
-// the next render. Use this for transient feedback ("Settings saved")
-// that doesn't need explicit acknowledgement. Messages without an
-// expiry persist until explicitly cleared via ClearFlash.
+// the duration elapses, the message is pruned on the next action or server
+// push that triggers a render — there is no background timer. Use this for
+// transient feedback ("Settings saved") that doesn't need explicit
+// acknowledgement. Messages without an expiry persist until explicitly
+// cleared via ClearFlash.
 //
 // Note: FlashExpiry has no observable effect on HTTP connections — HTTP
 // flash is inherently one-shot (per-request connSt is GC'd after the

--- a/context.go
+++ b/context.go
@@ -332,6 +332,17 @@ func FlashExpiry(d time.Duration) FlashOption {
 // when the user has acknowledged the message (e.g., after a navigation
 // or a follow-up action).
 //
+// Transport lifetime note: On WebSocket connections the flash store survives
+// across renders — messages persist until ClearFlash is called. On HTTP
+// connections (form submissions with progressive enhancement) the flash
+// store is per-request, so flash is inherently one-shot regardless of
+// whether ClearFlash is called.
+//
+// Redirect note: Flash set in a handler that also calls ctx.Redirect()
+// does not survive the redirect — no flash cookie is written before the
+// redirect response, so the message is lost. Use session-backed flash
+// (or a query param) if you need flash to survive an HTTP redirect.
+//
 // Common keys: "success", "error", "info", "warning"
 //
 // Key conventions:

--- a/context.go
+++ b/context.go
@@ -313,6 +313,10 @@ type flashConfig struct {
 // that doesn't need explicit acknowledgement. Messages without an
 // expiry persist until explicitly cleared via ClearFlash.
 //
+// Note: FlashExpiry has no observable effect on HTTP connections — HTTP
+// flash is inherently one-shot (per-request connSt is GC'd after the
+// handler returns) regardless of the expiry duration set here.
+//
 // Example:
 //
 //	ctx.SetFlash("success", "Saved!", livetemplate.FlashExpiry(5*time.Second))

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -135,6 +135,26 @@ func TestFlashSetThenClearThenSetAgain(t *testing.T) {
 	}
 }
 
+// TestFlashExpiryOverwrittenByNoExpiry guards against a stale-deadline bug:
+// if setFlash("key", msg, d) is called with d>0 and then the same key is
+// overwritten with setFlash("key", msg2, 0) (no expiry), the prior deadline
+// must be removed from flashExpiry. A rogue deadline would cause the key to
+// be pruned on the next pruneExpiredFlash call even though the latest setFlash
+// call intended for it to persist until ClearFlash.
+func TestFlashExpiryOverwrittenByNoExpiry(t *testing.T) {
+	cs := newFlashState()
+	cs.setFlash("key", "first", time.Hour)
+	// Backdate the expiry to force it to appear past-due. Direct map write is
+	// safe here: sequential single-goroutine test, map initialised above.
+	cs.flashExpiry["key"] = time.Now().Add(-1 * time.Second)
+	// Overwrite with no expiry — prior deadline must be deleted from flashExpiry.
+	cs.setFlash("key", "updated", 0)
+	cs.pruneExpiredFlash()
+	if !flashPresent(cs, "key") {
+		t.Error("flash incorrectly pruned after expiry was overwritten with no-expiry setFlash")
+	}
+}
+
 // flashIntegState is the per-connection state for the flash event loop
 // integration test. It carries a Counter so that Increment always produces a
 // state change — forcing the diff engine to emit a tree update that would

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -1,6 +1,7 @@
 package livetemplate
 
 import (
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"strings"
@@ -178,6 +179,90 @@ func (c *flashIntegController) Increment(state flashIntegState, ctx *Context) (f
 func (c *flashIntegController) SetTransientFlash(state flashIntegState, ctx *Context) (flashIntegState, error) {
 	ctx.SetFlash("status", "transient", FlashExpiry(time.Millisecond))
 	return state, nil
+}
+
+func (c *flashIntegController) FailAction(state flashIntegState, _ *Context) (flashIntegState, error) {
+	return state, errors.New("intentional error for testing")
+}
+
+// TestFlashExpiryNotPrunedOnErrorRender verifies the "success-path-only"
+// pruning invariant: when an action returns an error, pruneExpiredFlash is
+// NOT called, so expired flash survives the error render and persists until
+// the next SUCCESSFUL render.
+//
+// Test flow:
+//  1. "SetTransientFlash" sets flash "status"="transient" with 1ms expiry.
+//     The first render includes slot 0 = "transient".
+//  2. Sleep 10ms to guarantee the 1ms expiry has elapsed.
+//  3. "FailAction" returns an error → error render (meta.success=false).
+//     pruneExpiredFlash is NOT called, so flash stays in connSt.messages.
+//  4. "Increment" succeeds → render. Flash is still "transient" (unchanged
+//     from the error render in step 3), so slot 0 is ABSENT from the diff.
+//     If flash were pruned in step 3, slot 0 would appear as "" (changed).
+//
+// This test catches a regression where pruneExpiredFlash is called
+// unconditionally after every render instead of only on success renders.
+func TestFlashExpiryNotPrunedOnErrorRender(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Template slot 0 = Flash("status"), slot 1 = Counter.
+	tmpl, err = tmpl.Parse(`<span class="flash">{{.lvt.Flash "status"}}</span><span class="count">{{.Counter}}</span>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	handler := tmpl.Handle(&flashIntegController{}, AsState(&flashIntegState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Step 1: Set transient flash with 1ms expiry.
+	sendWSAction(t, ws, "SetTransientFlash", nil)
+	resp1 := readWSUpdate(t, ws, 2*time.Second)
+	tree1, ok := resp1["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("SetTransientFlash response has no tree: %#v", resp1)
+	}
+	if v := fmt.Sprintf("%v", tree1["0"]); v != "transient" {
+		t.Fatalf("SetTransientFlash: flash slot = %q, want %q", v, "transient")
+	}
+
+	// Step 2: Wait for the 1ms expiry to definitely elapse.
+	time.Sleep(10 * time.Millisecond)
+
+	// Step 3: Trigger an error render. pruneExpiredFlash must NOT fire here.
+	sendWSAction(t, ws, "FailAction", nil)
+	respErr := readWSUpdate(t, ws, 2*time.Second)
+	meta, ok := respErr["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("FailAction response has no meta: %#v", respErr)
+	}
+	if success, _ := meta["success"].(bool); success {
+		t.Fatalf("FailAction: meta.success = true, want false")
+	}
+
+	// Step 4: Succeed action. Flash survives because step 3 did not prune it.
+	// Slot 0 must be ABSENT (flash unchanged: "transient" in both step 3 and step 4
+	// renders). If pruneExpiredFlash had fired in step 3, flash would be "" here —
+	// a change from "transient" — and slot 0 would appear in the diff.
+	sendWSAction(t, ws, "Increment", nil)
+	resp4 := readWSUpdate(t, ws, 2*time.Second)
+	tree4, ok := resp4["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("Increment response has no tree: %#v", resp4)
+	}
+	if flashVal, present := tree4["0"]; present {
+		t.Errorf("flash slot appeared in diff after error render: got %q — pruneExpiredFlash was incorrectly called on the error render (flash should survive until the next successful render)", flashVal)
+	}
 }
 
 // TestFlashSurvivesSubsequentWSAction is a full-stack regression test for the

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -74,7 +74,9 @@ func TestFlashExpiryPrunesAfterDeadline(t *testing.T) {
 		t.Fatal("flash not set")
 	}
 
-	// Backdate the expiry to force it to be past-due.
+	// Backdate the expiry to force it to be past-due. Direct map write is safe
+	// here: these are sequential single-goroutine tests; setFlash initialized
+	// the map above so the nil-map panic path is excluded.
 	cs.flashExpiry["info"] = time.Now().Add(-1 * time.Second)
 
 	cs.pruneExpiredFlash()
@@ -91,7 +93,7 @@ func TestFlashExpiryDoesNotAffectNonExpiredMessages(t *testing.T) {
 	cs.setFlash("success", "Done!", 0)               // no expiry — persists forever
 	cs.setFlash("info", "Transient...", time.Minute) // expires in 1 minute (not yet)
 
-	// Manually backdate only the "info" key to be past-due.
+	// Manually backdate only the "info" key to be past-due (sequential test, safe).
 	cs.flashExpiry["info"] = time.Now().Add(-1 * time.Second)
 
 	cs.pruneExpiredFlash()

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -222,3 +222,88 @@ func TestFlashSurvivesSubsequentWSAction(t *testing.T) {
 		t.Errorf("Increment diff contains flash slot: got %q — flash was incorrectly cleared between renders (regression: old clearFlash bug)", flashVal)
 	}
 }
+
+// flashNavTestState is per-connection state for the navigate + flash interaction
+// test. Selected is set by Mount from the "s" query param.
+type flashNavTestState struct {
+	Selected string
+}
+
+type flashNavTestController struct{}
+
+func (c *flashNavTestController) Mount(state flashNavTestState, ctx *Context) (flashNavTestState, error) {
+	if s := ctx.GetString("s"); s != "" {
+		state.Selected = s
+	}
+	return state, nil
+}
+
+func (c *flashNavTestController) ShowFlash(state flashNavTestState, ctx *Context) (flashNavTestState, error) {
+	ctx.SetFlash("info", "persistent")
+	return state, nil
+}
+
+// TestFlashSurvivesNavigateAction verifies that flash set before a
+// __navigate__ action survives the navigate's callMount path. The navigate
+// path is a distinct code branch from DispatchWithState (it calls callMount
+// directly), so it needs its own coverage.
+//
+// Test flow:
+//  1. "ShowFlash" action stores flash "info"="persistent" in connSt.
+//  2. "__navigate__" fires → callMount runs, Selected changes "alpha"→"beta".
+//  3. The navigate diff must include slot 1 (Selected changed) and must NOT
+//     include slot 0 (flash unchanged). A slot-0 entry in the navigate diff
+//     would mean flash was cleared by the navigate path — the regression.
+func TestFlashSurvivesNavigateAction(t *testing.T) {
+	auth := &fixedGroupAuth{groupID: "flash-nav-group"}
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Template slot 0 = Flash("info"), slot 1 = Selected.
+	tmpl, err = tmpl.Parse(`<span class="flash">{{.lvt.Flash "info"}}</span><span class="sel">{{.Selected}}</span>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	handler := tmpl.Handle(&flashNavTestController{}, AsState(&flashNavTestState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/?s=alpha"
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Step 1: ShowFlash — flash "info" = "persistent" stored in connSt.
+	sendWSAction(t, ws, "ShowFlash", nil)
+	resp1 := readWSUpdate(t, ws, 2*time.Second)
+	tree1, ok := resp1["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("ShowFlash response has no tree: %#v", resp1)
+	}
+	if v := fmt.Sprintf("%v", tree1["0"]); v != "persistent" {
+		t.Fatalf("ShowFlash: flash slot = %q, want %q", v, "persistent")
+	}
+
+	// Step 2: Navigate with new param. callMount runs, Selected changes.
+	// Flash must survive the navigate's callMount path unchanged.
+	sendWSAction(t, ws, actionNavigate, map[string]any{"s": "beta"})
+	resp2 := readWSUpdate(t, ws, 2*time.Second)
+	tree2, ok := resp2["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("navigate response has no tree: %#v", resp2)
+	}
+	// Selected slot must show the navigated-to value.
+	if v := fmt.Sprintf("%v", tree2["1"]); v != "beta" {
+		t.Errorf("navigate: Selected slot = %q, want %q", v, "beta")
+	}
+	// Flash slot must be absent (unchanged). Its presence means flash was
+	// cleared by the navigate's callMount path — the regression.
+	if flashVal, present := tree2["0"]; present {
+		t.Errorf("navigate diff contains flash slot: got %q — flash was incorrectly cleared by navigate (callMount path regression)", flashVal)
+	}
+}

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -207,7 +207,8 @@ func TestFlashExpiryNotPrunedOnErrorRender(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	// Template slot 0 = Flash("status"), slot 1 = Counter.
+	// Slot 0 = Flash("status"), slot 1 = Counter. Positions are stable because
+	// the template string is defined inline here and won't drift independently.
 	tmpl, err = tmpl.Parse(`<span class="flash">{{.lvt.Flash "status"}}</span><span class="count">{{.Counter}}</span>`)
 	if err != nil {
 		t.Fatalf("Parse: %v", err)

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -185,6 +185,11 @@ func (c *flashIntegController) FailAction(state flashIntegState, _ *Context) (fl
 	return state, errors.New("intentional error for testing")
 }
 
+func (c *flashIntegController) ClearFlashAction(state flashIntegState, ctx *Context) (flashIntegState, error) {
+	ctx.ClearFlash("info")
+	return state, nil
+}
+
 // TestFlashExpiryNotPrunedOnErrorRender verifies the "success-path-only"
 // pruning invariant: when an action returns an error, pruneExpiredFlash is
 // NOT called, so expired flash survives the error render and persists until
@@ -483,5 +488,66 @@ func TestFlashExpiryThroughPublicAPI(t *testing.T) {
 	}
 	if flashVal, present := tree2["0"]; present {
 		t.Errorf("flash slot present after 1ms expiry: got %q — FlashExpiry not enforced through public ctx.SetFlash API", flashVal)
+	}
+}
+
+// TestClearFlashThroughPublicAPI verifies the full path from ctx.ClearFlash(key)
+// through the WS event loop to the diff engine. TestClearFlashRemovesMessage
+// calls connState.clearFlashKey directly; this test exercises the public API
+// wiring (flashSetter must be set, ClearFlash must route to clearFlashKey).
+//
+// Flow: ShowFlash sets flash → slot 0 appears in diff.
+// ClearFlashAction calls ctx.ClearFlash("info") → slot 0 appears as "" (cleared).
+func TestClearFlashThroughPublicAPI(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Slot 0 = Flash("info"), slot 1 = Counter. Template defined inline — positions stable.
+	tmpl, err = tmpl.Parse(`<span class="flash">{{.lvt.Flash "info"}}</span><span class="count">{{.Counter}}</span>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	handler := tmpl.Handle(&flashIntegController{}, AsState(&flashIntegState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Step 1: ShowFlash — flash "info" = "persistent" set in connSt.
+	sendWSAction(t, ws, "ShowFlash", nil)
+	resp1 := readWSUpdate(t, ws, 2*time.Second)
+	tree1, ok := resp1["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("ShowFlash response has no tree: %#v", resp1)
+	}
+	if v := fmt.Sprintf("%v", tree1["0"]); v != "persistent" {
+		t.Fatalf("ShowFlash: flash slot = %q, want %q", v, "persistent")
+	}
+
+	// Step 2: ClearFlashAction calls ctx.ClearFlash("info").
+	// Flash becomes "" — a change from "persistent" — so slot 0 must appear in
+	// the diff. If ctx.ClearFlash is silently no-oping (e.g. nil flashSetter),
+	// flash stays "persistent" and slot 0 is absent from the diff (test fails).
+	sendWSAction(t, ws, "ClearFlashAction", nil)
+	resp2 := readWSUpdate(t, ws, 2*time.Second)
+	tree2, ok := resp2["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("ClearFlashAction response has no tree: %#v", resp2)
+	}
+	v, present := tree2["0"]
+	if !present {
+		t.Error("ClearFlashAction: flash slot absent from diff — ctx.ClearFlash had no effect (wiring bug: flashSetter may be nil)")
+		return
+	}
+	if got := fmt.Sprintf("%v", v); got != "" {
+		t.Errorf("ClearFlashAction: flash slot = %q, want %q (empty after clear)", got, "")
 	}
 }

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -383,10 +383,10 @@ func TestFlashExpiryThroughPublicAPI(t *testing.T) {
 	}
 
 	// Step 2: Increment — Counter changes (0→1), expiry has elapsed.
-	// Sleep 5ms to guarantee the 1ms expiry has elapsed even on a loaded CI
-	// machine; the WS round-trip alone is usually sufficient, but this makes
-	// the test reliable under -race and heavy load without a meaningful slowdown.
-	time.Sleep(5 * time.Millisecond)
+	// Sleep 10ms to guarantee the 1ms expiry has elapsed even on a loaded CI
+	// machine under -race; the WS round-trip alone is usually sufficient, but
+	// 10x margin makes the test reliable without a meaningful slowdown.
+	time.Sleep(10 * time.Millisecond)
 	// pruneExpiredFlash removes the lapsed flash before the render,
 	// so slot 0 must be absent from the diff.
 	sendWSAction(t, ws, "Increment", nil)

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -14,7 +14,8 @@ import (
 // messages map initialised, ready for flash lifecycle tests.
 func newFlashState() *connState {
 	return &connState{
-		messages: make(map[string]string),
+		messages:    make(map[string]string),
+		flashExpiry: make(map[string]time.Time),
 	}
 }
 
@@ -149,6 +150,11 @@ func (c *flashIntegController) ShowFlash(state flashIntegState, ctx *Context) (f
 
 func (c *flashIntegController) Increment(state flashIntegState, ctx *Context) (flashIntegState, error) {
 	state.Counter++
+	return state, nil
+}
+
+func (c *flashIntegController) SetTransientFlash(state flashIntegState, ctx *Context) (flashIntegState, error) {
+	ctx.SetFlash("status", "transient", FlashExpiry(time.Millisecond))
 	return state, nil
 }
 
@@ -305,5 +311,65 @@ func TestFlashSurvivesNavigateAction(t *testing.T) {
 	// cleared by the navigate's callMount path — the regression.
 	if flashVal, present := tree2["0"]; present {
 		t.Errorf("navigate diff contains flash slot: got %q — flash was incorrectly cleared by navigate (callMount path regression)", flashVal)
+	}
+}
+
+// TestFlashExpiryThroughPublicAPI exercises the full path from
+// ctx.SetFlash(key, msg, FlashExpiry(d)) through the event loop to the diff
+// engine. Unit tests in this file call connState.setFlash() directly; this
+// test verifies that FlashExpiry flows correctly through the public API and
+// that pruneExpiredFlash removes the flash entry before the next render.
+//
+// Test flow:
+//  1. "SetTransientFlash" action sets flash "status"="transient" with 1ms expiry.
+//     The first render includes slot 0 = "transient".
+//  2. After the 1ms expiry elapses, "Increment" changes state (Counter 0→1).
+//     pruneExpiredFlash removes the lapsed flash; slot 0 is absent from the diff.
+func TestFlashExpiryThroughPublicAPI(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Template slot 0 = Flash("status"), slot 1 = Counter.
+	tmpl, err = tmpl.Parse(`<span class="flash">{{.lvt.Flash "status"}}</span><span class="count">{{.Counter}}</span>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	handler := tmpl.Handle(&flashIntegController{}, AsState(&flashIntegState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Step 1: SetTransientFlash via ctx.SetFlash(..., FlashExpiry(1ms)).
+	// The first render includes the flash slot.
+	sendWSAction(t, ws, "SetTransientFlash", nil)
+	resp1 := readWSUpdate(t, ws, 2*time.Second)
+	tree1, ok := resp1["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("SetTransientFlash response has no tree: %#v", resp1)
+	}
+	if v := fmt.Sprintf("%v", tree1["0"]); v != "transient" {
+		t.Fatalf("SetTransientFlash: flash slot = %q, want %q", v, "transient")
+	}
+
+	// Step 2: Increment — Counter changes (0→1), expiry has elapsed.
+	// pruneExpiredFlash removes the lapsed flash before the render,
+	// so slot 0 must be absent from the diff.
+	sendWSAction(t, ws, "Increment", nil)
+	resp2 := readWSUpdate(t, ws, 2*time.Second)
+	tree2, ok := resp2["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("Increment response has no tree: %#v", resp2)
+	}
+	if flashVal, present := tree2["0"]; present {
+		t.Errorf("flash slot present after 1ms expiry: got %q — FlashExpiry not enforced through public ctx.SetFlash API", flashVal)
 	}
 }

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -1,0 +1,130 @@
+package livetemplate
+
+import (
+	"testing"
+	"time"
+
+	lvtcontext "github.com/livetemplate/livetemplate/internal/context"
+)
+
+// newFlashState is a test helper that returns a minimal connState with the
+// messages map initialised, ready for flash lifecycle tests.
+func newFlashState() *connState {
+	return &connState{
+		messages: make(map[string]string),
+	}
+}
+
+// flashPresent returns true if the given key is in cs.getMessages().
+func flashPresent(cs *connState, key string) bool {
+	_, ok := cs.getMessages()[lvtcontext.FlashPrefix+key]
+	return ok
+}
+
+// TestFlashPersistsAcrossRenders verifies that non-expiry flash survives
+// repeated pruneExpiredFlash calls. This guards against the regression where
+// background Refresh ticks cleared flash by calling the old clearFlash()
+// (which removed ALL flash). Under the new lifecycle, pruneExpiredFlash only
+// removes messages whose expiry has elapsed; non-expiry flash stays until
+// ClearFlash is explicitly called.
+func TestFlashPersistsAcrossRenders(t *testing.T) {
+	cs := newFlashState()
+	cs.setFlash("success", "Saved!", 0)
+	if !flashPresent(cs, "success") {
+		t.Fatal("flash not set")
+	}
+
+	// Simulate several render cycles — pruneExpiredFlash runs after each render.
+	for i := 0; i < 5; i++ {
+		cs.pruneExpiredFlash()
+		if !flashPresent(cs, "success") {
+			t.Fatalf("flash cleared after render %d, want it to persist until ClearFlash", i+1)
+		}
+	}
+}
+
+// TestClearFlashRemovesMessage verifies that clearFlashKey removes the flash
+// message immediately, regardless of any expiry setting.
+func TestClearFlashRemovesMessage(t *testing.T) {
+	cs := newFlashState()
+	cs.setFlash("error", "Something went wrong", 0)
+	if !flashPresent(cs, "error") {
+		t.Fatal("flash not set")
+	}
+
+	cs.clearFlashKey("error")
+
+	if flashPresent(cs, "error") {
+		t.Error("flash still present after clearFlashKey, want it removed")
+	}
+}
+
+// TestFlashExpiryPrunesAfterDeadline verifies that flash set with a non-zero
+// expiry is removed by pruneExpiredFlash once the deadline has passed.
+func TestFlashExpiryPrunesAfterDeadline(t *testing.T) {
+	cs := newFlashState()
+	// Set flash with a real expiry, then manually backdate the deadline so
+	// it appears already elapsed — avoids real time.Sleep in tests.
+	cs.setFlash("info", "Processing...", time.Hour)
+	if !flashPresent(cs, "info") {
+		t.Fatal("flash not set")
+	}
+
+	// Backdate the expiry to force it to be past-due.
+	cs.flashExpiry["info"] = time.Now().Add(-1 * time.Second)
+
+	cs.pruneExpiredFlash()
+
+	if flashPresent(cs, "info") {
+		t.Error("flash still present after expiry deadline, want it pruned")
+	}
+}
+
+// TestFlashExpiryDoesNotAffectNonExpiredMessages verifies that pruneExpiredFlash
+// only removes expired entries and leaves non-expired flash intact.
+func TestFlashExpiryDoesNotAffectNonExpiredMessages(t *testing.T) {
+	cs := newFlashState()
+	cs.setFlash("success", "Done!", 0)               // no expiry — persists forever
+	cs.setFlash("info", "Transient...", time.Minute) // expires in 1 minute (not yet)
+
+	// Manually backdate only the "info" key to be past-due.
+	cs.flashExpiry["info"] = time.Now().Add(-1 * time.Second)
+
+	cs.pruneExpiredFlash()
+
+	if !flashPresent(cs, "success") {
+		t.Error("non-expiry flash 'success' was incorrectly pruned")
+	}
+	if flashPresent(cs, "info") {
+		t.Error("expired flash 'info' still present after prune")
+	}
+}
+
+// TestFlashSetThenClearThenSetAgain verifies that clearFlashKey followed by
+// a new setFlash for the same key works correctly — the new message replaces
+// the cleared one, and subsequent pruneExpiredFlash calls leave it intact.
+func TestFlashSetThenClearThenSetAgain(t *testing.T) {
+	cs := newFlashState()
+	cs.setFlash("status", "first", 0)
+	cs.clearFlashKey("status")
+	if flashPresent(cs, "status") {
+		t.Fatal("flash not cleared")
+	}
+
+	cs.setFlash("status", "second", 0)
+	if !flashPresent(cs, "status") {
+		t.Fatal("flash not re-set after clear")
+	}
+
+	// Verify value is the new one.
+	msgs := cs.getMessages()
+	if v := msgs[lvtcontext.FlashPrefix+"status"]; v != "second" {
+		t.Errorf("flash value = %q, want %q", v, "second")
+	}
+
+	// Pruning should leave it in place (no expiry set).
+	cs.pruneExpiredFlash()
+	if !flashPresent(cs, "status") {
+		t.Error("re-set flash was incorrectly pruned")
+	}
+}

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -1,6 +1,9 @@
 package livetemplate
 
 import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -126,5 +129,96 @@ func TestFlashSetThenClearThenSetAgain(t *testing.T) {
 	cs.pruneExpiredFlash()
 	if !flashPresent(cs, "status") {
 		t.Error("re-set flash was incorrectly pruned")
+	}
+}
+
+// flashIntegState is the per-connection state for the flash event loop
+// integration test. It carries a Counter so that Increment always produces a
+// state change — forcing the diff engine to emit a tree update that would
+// reveal an absent flash slot if flash were incorrectly cleared between renders.
+type flashIntegState struct {
+	Counter int
+}
+
+type flashIntegController struct{}
+
+func (c *flashIntegController) ShowFlash(state flashIntegState, ctx *Context) (flashIntegState, error) {
+	ctx.SetFlash("info", "persistent")
+	return state, nil
+}
+
+func (c *flashIntegController) Increment(state flashIntegState, ctx *Context) (flashIntegState, error) {
+	state.Counter++
+	return state, nil
+}
+
+// TestFlashSurvivesSubsequentWSAction is a full-stack regression test for the
+// old clearFlash() bug. The old event loop called clearFlash() after every
+// successful render, including server-driven refreshes, so flash set by one
+// action was silently cleared before the next render.
+//
+// This test exercises the event loop integration:
+//  1. "ShowFlash" action sets flash "info" = "persistent" (slot 0 changes).
+//  2. "Increment" action mutates state (Counter 0→1, slot 1 changes).
+//
+// With the old clearFlash() bug, the Increment render would see flash="" (a
+// change from "persistent") and include slot 0 in the diff with value "".
+// With the fix (pruneExpiredFlash), flash is unchanged — slot 0 does NOT
+// appear in the Increment diff. The test asserts slot 0 is absent from the
+// Increment response, which fails if flash was cleared between renders.
+func TestFlashSurvivesSubsequentWSAction(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Template slot 0 = Flash("info"), slot 1 = Counter.
+	tmpl, err = tmpl.Parse(`<span class="flash">{{.lvt.Flash "info"}}</span><span class="count">{{.Counter}}</span>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	handler := tmpl.Handle(&flashIntegController{}, AsState(&flashIntegState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Step 1: SetFlash — flash "info" = "persistent" stored in connSt.
+	sendWSAction(t, ws, "ShowFlash", nil)
+	resp1 := readWSUpdate(t, ws, 2*time.Second)
+	// Slot 0 = flash value must be "persistent".
+	tree1, ok := resp1["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("ShowFlash response has no tree: %#v", resp1)
+	}
+	if v := fmt.Sprintf("%v", tree1["0"]); v != "persistent" {
+		t.Fatalf("ShowFlash: tree slot 0 = %q, want %q", v, "persistent")
+	}
+
+	// Step 2: Increment — Counter changes (0→1), flash unchanged.
+	// The diff engine ONLY sends changed dynamics. With the fix, flash slot 0
+	// is unchanged ("persistent") so it must NOT appear in the diff.
+	// With the old clearFlash() bug, flash was cleared after Step 1's render,
+	// so slot 0 would appear in this diff with value "" — detectable here.
+	sendWSAction(t, ws, "Increment", nil)
+	resp2 := readWSUpdate(t, ws, 2*time.Second)
+	tree2, ok := resp2["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("Increment response has no tree: %#v", resp2)
+	}
+	// Counter slot must show the new value.
+	if v := fmt.Sprintf("%v", tree2["1"]); v != "1" {
+		t.Errorf("Increment: Counter slot = %q, want %q", v, "1")
+	}
+	// Flash slot must be absent (unchanged). If it appears, it means flash was
+	// cleared between renders — the old clearFlash() regression.
+	if flashVal, present := tree2["0"]; present {
+		t.Errorf("Increment diff contains flash slot: got %q — flash was incorrectly cleared between renders (regression: old clearFlash bug)", flashVal)
 	}
 }

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -361,6 +361,10 @@ func TestFlashExpiryThroughPublicAPI(t *testing.T) {
 	}
 
 	// Step 2: Increment — Counter changes (0→1), expiry has elapsed.
+	// Sleep 5ms to guarantee the 1ms expiry has elapsed even on a loaded CI
+	// machine; the WS round-trip alone is usually sufficient, but this makes
+	// the test reliable under -race and heavy load without a meaningful slowdown.
+	time.Sleep(5 * time.Millisecond)
 	// pruneExpiredFlash removes the lapsed flash before the render,
 	// so slot 0 must be absent from the diff.
 	sendWSAction(t, ws, "Increment", nil)

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -263,7 +263,7 @@ func (c *flashNavTestController) ShowFlash(state flashNavTestState, ctx *Context
 //     include slot 0 (flash unchanged). A slot-0 entry in the navigate diff
 //     would mean flash was cleared by the navigate path — the regression.
 func TestFlashSurvivesNavigateAction(t *testing.T) {
-	auth := &fixedGroupAuth{groupID: "flash-nav-group"}
+	auth := &fixedGroupAuth{groupID: t.Name()}
 	tmpl, err := New("test", WithAuthenticator(auth))
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/mount.go
+++ b/mount.go
@@ -175,8 +175,8 @@ type wsReadMessage struct {
 
 type connState struct {
 	state       interface{}          // Typed state (cloned per session)
-	messages    map[string]string    // Unified map: field errors + flash (prefixed with "_flash:"); note: flashExpiry uses bare keys (no prefix)
-	flashExpiry map[string]time.Time // Per-key expiry for flash; keys WITHOUT FlashPrefix (unlike the messages map above)
+	messages    map[string]string    // keys: field errors (plain) + flash (prefixed with "_flash:"); note: flashExpiry below uses bare keys
+	flashExpiry map[string]time.Time // keys: bare flash key WITHOUT "_flash:" prefix (unlike messages above)
 	messagesMu  sync.RWMutex         // Mutex for thread-safe message access
 	groupID     string               // Session/group ID for this connection
 }

--- a/mount.go
+++ b/mount.go
@@ -1567,6 +1567,8 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 			slog.Any("error", err))
 	}
 
+	// Prune flash messages whose expiry has elapsed; non-expiry flash
+	// persists until ClearFlash is called.
 	connSt.pruneExpiredFlash()
 }
 

--- a/mount.go
+++ b/mount.go
@@ -233,6 +233,7 @@ func (c *connState) setFlash(key, message string, expiry time.Duration) {
 		c.flashExpiry[key] = time.Now().Add(expiry)
 	} else {
 		// No expiry — persist until ClearFlash. Remove any prior expiry.
+		// delete on a nil map is a safe no-op in Go, so no nil guard needed.
 		delete(c.flashExpiry, key)
 	}
 }
@@ -268,7 +269,9 @@ func (c *connState) pruneExpiredFlash() {
 	c.messagesMu.Lock()
 	defer c.messagesMu.Unlock()
 	// Re-check under the write lock: another goroutine may have emptied
-	// flashExpiry between the read-unlock and the write-lock above.
+	// flashExpiry between the read-unlock and the write-lock above. A goroutine
+	// that added entries is also fine to miss — newly-set flash can't be expired
+	// yet, so skipping one prune cycle for new entries is safe.
 	if len(c.flashExpiry) == 0 {
 		return
 	}

--- a/mount.go
+++ b/mount.go
@@ -175,8 +175,8 @@ type wsReadMessage struct {
 
 type connState struct {
 	state       interface{}          // Typed state (cloned per session)
-	messages    map[string]string    // Unified map: field errors + flash (prefixed with "_flash:")
-	flashExpiry map[string]time.Time // Per-key expiry for flash; keys WITHOUT FlashPrefix (unlike the messages map)
+	messages    map[string]string    // Unified map: field errors + flash (prefixed with "_flash:"); note: flashExpiry uses bare keys (no prefix)
+	flashExpiry map[string]time.Time // Per-key expiry for flash; keys WITHOUT FlashPrefix (unlike the messages map above)
 	messagesMu  sync.RWMutex         // Mutex for thread-safe message access
 	groupID     string               // Session/group ID for this connection
 }
@@ -1290,10 +1290,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		// If the action handler already sent a redirect (via ctx.Redirect()),
 		// skip the PRG redirect to avoid a superfluous redirect response.
 		// Flash set before the redirect is lost — no cookie is written here.
-		// HTTP: connSt is per-request and GC'd after this handler returns;
-		// pruneExpiredFlash is a no-op with no observable effect here.
 		if actionCtx.redirected != nil && *actionCtx.redirected {
-			connSt.pruneExpiredFlash()
 			return
 		}
 
@@ -1337,9 +1334,6 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
-		// HTTP: connSt is per-request and GC'd after this handler returns;
-		// pruneExpiredFlash is a no-op with no observable effect here.
-		connSt.pruneExpiredFlash()
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther) // 303 See Other
 		return
 	}
@@ -1372,9 +1366,6 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// HTTP: connSt is per-request and GC'd after this handler returns;
-	// pruneExpiredFlash is a no-op with no observable effect here.
-	connSt.pruneExpiredFlash()
 }
 
 // newUploadRegistry creates a new upload registry instance.

--- a/mount.go
+++ b/mount.go
@@ -724,16 +724,20 @@ eventLoop:
 			// new params without needing to know the navigate came over
 			// an open socket.
 			//
-			// We reuse actionCtx (with the action name cleared via
-			// WithAction("")) so flash/broadcast plumbing routes through
-			// one context for both dispatch paths. The empty action name
-			// matches the convention used by the initial connect-time
-			// Mount at mount.go:503 so controllers can uniformly write
-			// `if ctx.Action() == "" { /* GET or nav */ }`.
+			// We rebind actionCtx itself (not a discarded copy) with the
+			// action name cleared so that any BroadcastAction calls inside
+			// Mount are queued on the same *Context that processBroadcastsAndSync
+			// reads via actionCtx.pendingBroadcasts() below. WithAction returns
+			// a shallow copy — if callMount appended to a discarded copy,
+			// pendingBroadcasts() on the original actionCtx would see nothing.
+			// The empty action name matches the convention used by the initial
+			// connect-time Mount at mount.go:503 so controllers can uniformly
+			// write `if ctx.Action() == "" { /* GET or nav */ }`.
 			var newState interface{}
 			var actionErr error
 			if msg.Action == actionNavigate {
-				newState, actionErr = callMount(h.config.Controller, connSt.state, actionCtx.WithAction(""))
+				actionCtx = actionCtx.WithAction("")
+				newState, actionErr = callMount(h.config.Controller, connSt.state, actionCtx)
 			} else {
 				newState, actionErr = DispatchWithState(h.config.Controller, connSt.state, actionCtx)
 			}
@@ -802,7 +806,8 @@ eventLoop:
 				break eventLoop
 			}
 
-			// Clear flash messages after successful render (flash shows once per action)
+			// Prune flash messages whose expiry has elapsed; non-expiry flash
+			// persists until ClearFlash is called.
 			connSt.pruneExpiredFlash()
 
 		case req := <-connection.DispatchChan:
@@ -1273,9 +1278,10 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.config.ProgressiveEnhancement && !wantsJSON(r) {
 		// If the action handler already sent a redirect (via ctx.Redirect()),
 		// skip the PRG redirect to avoid a superfluous redirect response.
-		// The action's redirect response is already sent to the client, so
-		// flash state in connSt is stale — clear it to prevent leakage into
-		// subsequent responses for this session/group.
+		// The action's redirect response is already sent to the client. For
+		// HTTP (per-request connSt), flash set before the redirect is lost
+		// because no flash cookie is written here; pruneExpiredFlash removes
+		// any flash whose expiry has elapsed, and the connSt is GC'd.
 		if actionCtx.redirected != nil && *actionCtx.redirected {
 			connSt.pruneExpiredFlash()
 			return
@@ -1354,7 +1360,8 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Clear flash messages after successful render (flash shows once per action)
+	// Prune flash messages whose expiry has elapsed; non-expiry flash
+	// persists until ClearFlash is called.
 	connSt.pruneExpiredFlash()
 }
 

--- a/mount.go
+++ b/mount.go
@@ -726,36 +726,13 @@ eventLoop:
 			actionCtx = actionCtx.WithFlashSetter(connSt)
 			actionCtx = actionCtx.WithSession(newLocalSession(h, groupID))
 
-			// Dispatch action using Controller+State pattern.
-			//
-			// Reserved action actionNavigate ("__navigate__") re-runs
-			// Mount on the existing connection with fresh query data
-			// passed in msg.Data. This is the in-band equivalent of
-			// Phoenix LiveView's live_patch / handle_params: query-param
-			// changes on the SAME handler do NOT reconnect the WebSocket
-			// — the server just re-projects state from the new data via
-			// the controller's Mount method. Controllers that read
-			// `ctx.GetString("...")` in Mount transparently pick up the
-			// new params without needing to know the navigate came over
-			// an open socket.
-			//
-			// We rebind actionCtx itself (not a discarded copy) with the
-			// action name cleared so that any BroadcastAction calls inside
-			// Mount are queued on the same *Context that processBroadcastsAndSync
-			// reads via actionCtx.pendingBroadcasts() below. WithAction returns
-			// a shallow copy — if callMount appended to a discarded copy,
-			// pendingBroadcasts() on the original actionCtx would see nothing.
-			// The empty action name matches the convention used by the initial
-			// connect-time Mount at mount.go:503 so controllers can uniformly
-			// write `if ctx.Action() == "" { /* GET or nav */ }`.
+			// actionNavigate re-runs Mount with msg.Data as query params. Rebind
+			// actionCtx itself (not a discarded copy) so BroadcastAction calls
+			// inside Mount land on the context that processBroadcastsAndSync reads.
 			var newState interface{}
 			var actionErr error
 			if msg.Action == actionNavigate {
-				// msg.Data flows through actionCtx as query params: ctx.GetString/GetInt
-				// reads from actionCtx.data, so no explicit param-injection step is needed.
-				actionCtx = actionCtx.WithAction("")
-				// callMount receives connSt.state as a read-only input; newState is the
-				// returned copy. If actionErr != nil, connSt.state is NOT updated below.
+				actionCtx = actionCtx.WithAction("") // ctx.Action()=="" matches connect-time Mount
 				newState, actionErr = callMount(h.config.Controller, connSt.state, actionCtx)
 			} else {
 				newState, actionErr = DispatchWithState(h.config.Controller, connSt.state, actionCtx)
@@ -1582,8 +1559,7 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 			slog.Any("error", err))
 	}
 
-	// Prune flash messages whose expiry has elapsed; non-expiry flash
-	// persists until ClearFlash is called.
+	// Only reached on dispatch success (err != nil returns early above).
 	connSt.pruneExpiredFlash()
 }
 
@@ -1956,8 +1932,7 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 			continue
 		}
 
-		// Prune flash messages whose expiry has elapsed; non-expiry flash
-		// persists until ClearFlash is called.
+		// Only reached after sendUpdate succeeds (continue on error above).
 		state.pruneExpiredFlash()
 	}
 

--- a/mount.go
+++ b/mount.go
@@ -1289,10 +1289,9 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.config.ProgressiveEnhancement && !wantsJSON(r) {
 		// If the action handler already sent a redirect (via ctx.Redirect()),
 		// skip the PRG redirect to avoid a superfluous redirect response.
-		// The action's redirect response is already sent to the client. For
-		// HTTP (per-request connSt), flash set before the redirect is lost
-		// because no flash cookie is written here; pruneExpiredFlash removes
-		// any flash whose expiry has elapsed, and the connSt is GC'd.
+		// Flash set before the redirect is lost — no cookie is written here.
+		// HTTP: connSt is per-request and GC'd after this handler returns;
+		// pruneExpiredFlash is a no-op with no observable effect here.
 		if actionCtx.redirected != nil && *actionCtx.redirected {
 			connSt.pruneExpiredFlash()
 			return
@@ -1373,8 +1372,8 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// HTTP: connSt is per-request (GC'd after response); pruneExpiredFlash is
-	// a no-op here unless an expiry-based message has already lapsed this request.
+	// HTTP: connSt is per-request and GC'd after this handler returns;
+	// pruneExpiredFlash is a no-op with no observable effect here.
 	connSt.pruneExpiredFlash()
 }
 

--- a/mount.go
+++ b/mount.go
@@ -750,6 +750,8 @@ eventLoop:
 				// msg.Data flows through actionCtx as query params: ctx.GetString/GetInt
 				// reads from actionCtx.data, so no explicit param-injection step is needed.
 				actionCtx = actionCtx.WithAction("")
+				// callMount receives connSt.state as a read-only input; newState is the
+				// returned copy. If actionErr != nil, connSt.state is NOT updated below.
 				newState, actionErr = callMount(h.config.Controller, connSt.state, actionCtx)
 			} else {
 				newState, actionErr = DispatchWithState(h.config.Controller, connSt.state, actionCtx)
@@ -820,7 +822,9 @@ eventLoop:
 			}
 
 			// Prune flash messages whose expiry has elapsed; non-expiry flash
-			// persists until ClearFlash is called.
+			// persists until ClearFlash is called. Only reached on the success
+			// path — on error, expired entries remain until the next successful
+			// render (non-expiry flash is unaffected by error paths).
 			connSt.pruneExpiredFlash()
 
 		case req := <-connection.DispatchChan:

--- a/mount.go
+++ b/mount.go
@@ -1327,8 +1327,8 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
-		// HTTP: connSt is per-request (GC'd after response); pruneExpiredFlash is
-		// a no-op here unless an expiry-based message has already lapsed this request.
+		// HTTP: connSt is per-request and GC'd after this handler returns;
+		// pruneExpiredFlash is a no-op with no observable effect here.
 		connSt.pruneExpiredFlash()
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther) // 303 See Other
 		return

--- a/mount.go
+++ b/mount.go
@@ -176,7 +176,7 @@ type wsReadMessage struct {
 type connState struct {
 	state       interface{}          // Typed state (cloned per session)
 	messages    map[string]string    // Unified map: field errors + flash (prefixed with "_flash:")
-	flashExpiry map[string]time.Time // Optional per-key expiry for flash (key WITHOUT prefix)
+	flashExpiry map[string]time.Time // Per-key expiry for flash; keys WITHOUT FlashPrefix (unlike the messages map)
 	messagesMu  sync.RWMutex         // Mutex for thread-safe message access
 	groupID     string               // Session/group ID for this connection
 }
@@ -256,8 +256,19 @@ func (c *connState) clearFlashKey(key string) {
 // is a separate namespace that survives renders and background updates
 // until the developer (or an expiry timer) explicitly clears it.
 func (c *connState) pruneExpiredFlash() {
+	// Fast path: skip write lock when no expiry entries exist (common case
+	// for controllers that don't use FlashExpiry). The read lock avoids
+	// unnecessary write-lock contention on every render site.
+	c.messagesMu.RLock()
+	empty := len(c.flashExpiry) == 0
+	c.messagesMu.RUnlock()
+	if empty {
+		return
+	}
 	c.messagesMu.Lock()
 	defer c.messagesMu.Unlock()
+	// Re-check under the write lock: another goroutine may have emptied
+	// flashExpiry between the read-unlock and the write-lock above.
 	if len(c.flashExpiry) == 0 {
 		return
 	}

--- a/mount.go
+++ b/mount.go
@@ -747,6 +747,8 @@ eventLoop:
 			var newState interface{}
 			var actionErr error
 			if msg.Action == actionNavigate {
+				// msg.Data flows through actionCtx as query params: ctx.GetString/GetInt
+				// reads from actionCtx.data, so no explicit param-injection step is needed.
 				actionCtx = actionCtx.WithAction("")
 				newState, actionErr = callMount(h.config.Controller, connSt.state, actionCtx)
 			} else {

--- a/mount.go
+++ b/mount.go
@@ -1224,6 +1224,14 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	// Clear previous errors
 	connSt.clearErrors()
 
+	// __navigate__ is a WebSocket-only reserved action. Reject early so HTTP
+	// clients get a clear "wrong transport" error instead of a confusing
+	// ErrMethodNotFound response.
+	if msg.Action == actionNavigate {
+		http.Error(w, "action __navigate__ is only supported over WebSocket", http.StatusBadRequest)
+		return
+	}
+
 	// Merge query params with form data (form data takes precedence)
 	mergedData := send.MergeData(queryData, msg.Data)
 

--- a/mount.go
+++ b/mount.go
@@ -245,6 +245,7 @@ func (c *connState) clearFlashKey(key string) {
 	c.messagesMu.Lock()
 	defer c.messagesMu.Unlock()
 	delete(c.messages, lvtcontext.FlashPrefix+key)
+	// delete on a nil map is a safe no-op in Go, so no nil guard needed here.
 	delete(c.flashExpiry, key)
 }
 
@@ -825,10 +826,13 @@ eventLoop:
 			}
 
 			// Prune flash messages whose expiry has elapsed; non-expiry flash
-			// persists until ClearFlash is called. Only reached on the success
-			// path — on error, expired entries remain until the next successful
-			// render (non-expiry flash is unaffected by error paths).
-			connSt.pruneExpiredFlash()
+			// persists until ClearFlash is called. Guarded by actionErr == nil
+			// so error renders (validation errors, method-not-found, etc.) do
+			// NOT prune expiry flash — expired entries survive until the next
+			// successful render (non-expiry flash is unaffected by error paths).
+			if actionErr == nil {
+				connSt.pruneExpiredFlash()
+			}
 
 		case req := <-connection.DispatchChan:
 			h.handleDispatchedAction(connSt, connection, req, userID)

--- a/mount.go
+++ b/mount.go
@@ -681,8 +681,32 @@ eventLoop:
 			actionCtx = actionCtx.WithFlashSetter(connSt)
 			actionCtx = actionCtx.WithSession(newLocalSession(h, groupID))
 
-			// Dispatch action using Controller+State pattern
-			newState, actionErr := DispatchWithState(h.config.Controller, connSt.state, actionCtx)
+			// Dispatch action using Controller+State pattern.
+			//
+			// Reserved action actionNavigate ("__navigate__") re-runs
+			// Mount on the existing connection with fresh query data
+			// passed in msg.Data. This is the in-band equivalent of
+			// Phoenix LiveView's live_patch / handle_params: query-param
+			// changes on the SAME handler do NOT reconnect the WebSocket
+			// — the server just re-projects state from the new data via
+			// the controller's Mount method. Controllers that read
+			// `ctx.GetString("...")` in Mount transparently pick up the
+			// new params without needing to know the navigate came over
+			// an open socket.
+			//
+			// We reuse actionCtx (with the action name cleared via
+			// WithAction("")) so flash/broadcast plumbing routes through
+			// one context for both dispatch paths. The empty action name
+			// matches the convention used by the initial connect-time
+			// Mount at mount.go:503 so controllers can uniformly write
+			// `if ctx.Action() == "" { /* GET or nav */ }`.
+			var newState interface{}
+			var actionErr error
+			if msg.Action == actionNavigate {
+				newState, actionErr = callMount(h.config.Controller, connSt.state, actionCtx.WithAction(""))
+			} else {
+				newState, actionErr = DispatchWithState(h.config.Controller, connSt.state, actionCtx)
+			}
 			if actionErr != nil {
 				// Handle errors
 				switch e := actionErr.(type) {

--- a/mount.go
+++ b/mount.go
@@ -1327,6 +1327,8 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
+		// HTTP: connSt is per-request (GC'd after response); pruneExpiredFlash is
+		// a no-op here unless an expiry-based message has already lapsed this request.
 		connSt.pruneExpiredFlash()
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther) // 303 See Other
 		return
@@ -1360,8 +1362,8 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Prune flash messages whose expiry has elapsed; non-expiry flash
-	// persists until ClearFlash is called.
+	// HTTP: connSt is per-request (GC'd after response); pruneExpiredFlash is
+	// a no-op here unless an expiry-based message has already lapsed this request.
 	connSt.pruneExpiredFlash()
 }
 
@@ -1930,7 +1932,8 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 			continue
 		}
 
-		// Clear flash messages after successful send
+		// Prune flash messages whose expiry has elapsed; non-expiry flash
+		// persists until ClearFlash is called.
 		state.pruneExpiredFlash()
 	}
 
@@ -2441,7 +2444,8 @@ func (h *liveHandler) handleUploadComplete(ctx context.Context, conn WSConn, raw
 		return nil // Don't fail the upload, just skip the update
 	}
 
-	// Clear flash messages after successful send
+	// Prune flash messages whose expiry has elapsed; non-expiry flash
+	// persists until ClearFlash is called.
 	state.pruneExpiredFlash()
 
 	// Dispatch Sync to peer connections for upload completion visibility

--- a/mount.go
+++ b/mount.go
@@ -174,10 +174,11 @@ type wsReadMessage struct {
 }
 
 type connState struct {
-	state      interface{}       // Typed state (cloned per session)
-	messages   map[string]string // Unified map: field errors + flash (prefixed with "_flash:")
-	messagesMu sync.RWMutex      // Mutex for thread-safe message access
-	groupID    string            // Session/group ID for this connection
+	state       interface{}          // Typed state (cloned per session)
+	messages    map[string]string    // Unified map: field errors + flash (prefixed with "_flash:")
+	flashExpiry map[string]time.Time // Optional per-key expiry for flash (key WITHOUT prefix)
+	messagesMu  sync.RWMutex         // Mutex for thread-safe message access
+	groupID     string               // Session/group ID for this connection
 }
 
 func (c *connState) setError(field, message string) {
@@ -212,7 +213,7 @@ func (c *connState) getMessages() map[string]string {
 	return result
 }
 
-func (c *connState) setFlash(key, message string) {
+func (c *connState) setFlash(key, message string, expiry time.Duration) {
 	// Validate key: reject keys with ":" or starting with "_"
 	if strings.Contains(key, ":") || strings.HasPrefix(key, "_") {
 		slog.Warn("Invalid flash key ignored",
@@ -225,19 +226,48 @@ func (c *connState) setFlash(key, message string) {
 	c.messagesMu.Lock()
 	defer c.messagesMu.Unlock()
 	c.messages[lvtcontext.FlashPrefix+key] = message
+	if expiry > 0 {
+		if c.flashExpiry == nil {
+			c.flashExpiry = make(map[string]time.Time)
+		}
+		c.flashExpiry[key] = time.Now().Add(expiry)
+	} else {
+		// No expiry — persist until ClearFlash. Remove any prior expiry.
+		delete(c.flashExpiry, key)
+	}
 }
 
-func (c *connState) clearFlash() {
+// clearFlashKey removes a single flash message by key. Called by
+// Context.ClearFlash — the explicit clearing path for flash messages
+// that persist until acknowledged.
+func (c *connState) clearFlashKey(key string) {
 	c.messagesMu.Lock()
 	defer c.messagesMu.Unlock()
-	// Only clear flash messages (preserve errors)
-	newMessages := make(map[string]string)
-	for k, v := range c.messages {
-		if !strings.HasPrefix(k, lvtcontext.FlashPrefix) {
-			newMessages[k] = v
+	delete(c.messages, lvtcontext.FlashPrefix+key)
+	delete(c.flashExpiry, key)
+}
+
+// pruneExpiredFlash removes only flash messages whose expiry has
+// passed. Flash messages without an expiry (expiry == zero time) are
+// NOT removed — they persist until explicitly cleared via ClearFlash.
+//
+// This replaces the old clearFlash() which removed ALL flash messages
+// after each render. The new model matches Phoenix LiveView: flash
+// is a separate namespace that survives renders and background updates
+// until the developer (or an expiry timer) explicitly clears it.
+func (c *connState) pruneExpiredFlash() {
+	c.messagesMu.Lock()
+	defer c.messagesMu.Unlock()
+	if len(c.flashExpiry) == 0 {
+		return
+	}
+	now := time.Now()
+	for key, exp := range c.flashExpiry {
+		if now.After(exp) {
+			delete(c.messages, lvtcontext.FlashPrefix+key)
+			delete(c.flashExpiry, key)
 		}
 	}
-	c.messages = newMessages
 }
 
 // getFlashValues returns all flash messages as url.Values for cookie encoding.
@@ -773,7 +803,7 @@ eventLoop:
 			}
 
 			// Clear flash messages after successful render (flash shows once per action)
-			connSt.clearFlash()
+			connSt.pruneExpiredFlash()
 
 		case req := <-connection.DispatchChan:
 			h.handleDispatchedAction(connSt, connection, req, userID)
@@ -976,7 +1006,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		if flashValues, err := url.ParseQuery(flashCookie.Value); err == nil {
 			for key, values := range flashValues {
 				if len(values) > 0 {
-					connSt.setFlash(key, values[0])
+					connSt.setFlash(key, values[0], 0)
 				}
 			}
 		}
@@ -1247,7 +1277,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		// flash state in connSt is stale — clear it to prevent leakage into
 		// subsequent responses for this session/group.
 		if actionCtx.redirected != nil && *actionCtx.redirected {
-			connSt.clearFlash()
+			connSt.pruneExpiredFlash()
 			return
 		}
 
@@ -1291,7 +1321,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
-		connSt.clearFlash()
+		connSt.pruneExpiredFlash()
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther) // 303 See Other
 		return
 	}
@@ -1325,7 +1355,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Clear flash messages after successful render (flash shows once per action)
-	connSt.clearFlash()
+	connSt.pruneExpiredFlash()
 }
 
 // newUploadRegistry creates a new upload registry instance.
@@ -1521,7 +1551,7 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 			slog.Any("error", err))
 	}
 
-	connSt.clearFlash()
+	connSt.pruneExpiredFlash()
 }
 
 // httpTemplateSweepLoop periodically removes cached HTTP templates to prevent
@@ -1894,7 +1924,7 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 		}
 
 		// Clear flash messages after successful send
-		state.clearFlash()
+		state.pruneExpiredFlash()
 	}
 
 	// Persist once per distinct groupID (avoids N writes for multi-tab users
@@ -2405,7 +2435,7 @@ func (h *liveHandler) handleUploadComplete(ctx context.Context, conn WSConn, raw
 	}
 
 	// Clear flash messages after successful send
-	state.clearFlash()
+	state.pruneExpiredFlash()
 
 	// Dispatch Sync to peer connections for upload completion visibility
 	h.dispatchBroadcastToGroup(state.groupID, connection, syncMethodName, nil)

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -224,9 +224,13 @@ func TestNavigateActionMountErrorLeavesStateUnchanged(t *testing.T) {
 	if success, _ := meta["success"].(bool); success {
 		t.Errorf("error navigate: meta.success = true, want false")
 	}
-	// No tree update expected on failure — state is unchanged.
-	if _, hasTree := respErr["tree"]; hasTree {
-		t.Logf("note: tree present in error response (may be empty update): %#v", respErr["tree"])
+	// The error path may emit an empty tree {} (a no-op diff). What must
+	// NOT appear is a non-empty tree with slot changes — that would mean
+	// the failed navigate emitted a diff that mutates client state.
+	if tree, hasTree := respErr["tree"]; hasTree {
+		if treeMap, ok := tree.(map[string]any); ok && len(treeMap) > 0 {
+			t.Errorf("error navigate: response contains non-empty tree (failed navigate must not mutate client state): %#v", tree)
+		}
 	}
 
 	// Third navigate succeeds — Selected becomes "gamma". MountCount must

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -1,0 +1,178 @@
+package livetemplate
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// navigateTestState is the per-connection state for the navigate action
+// test. It records how many times Mount ran, which simulates a controller
+// that needs to re-run Mount-time side effects on each navigation.
+type navigateTestState struct {
+	Selected   string
+	MountCount int
+}
+
+// navigateTestController reads a "s" query param in Mount and uses it to
+// set state.Selected, then renders the current value. The test can assert
+// against MountCount to verify the navigate action re-ran Mount without
+// double-counting.
+type navigateTestController struct{}
+
+func (c *navigateTestController) Mount(state navigateTestState, ctx *Context) (navigateTestState, error) {
+	state.Selected = ctx.GetString("s")
+	state.MountCount++
+	return state, nil
+}
+
+// Noop is a regular action that does nothing — used by tests to verify
+// non-navigate actions still hit DispatchWithState and don't accidentally
+// route through Mount.
+func (c *navigateTestController) Noop(state navigateTestState, _ *Context) (navigateTestState, error) {
+	return state, nil
+}
+
+func setupNavigateTestServer(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+
+	// All connections share a single session group so we can reason
+	// about a single WebSocket's state transitions across messages.
+	auth := &fixedGroupAuth{groupID: "navigate-test-group"}
+
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div class="sel">{{.Selected}}</div><div class="count">{{.MountCount}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	ctrl := &navigateTestController{}
+	state := AsState(&navigateTestState{})
+	handler := tmpl.Handle(ctrl, state)
+
+	server := httptest.NewServer(handler)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/?s=alpha"
+	return server, wsURL
+}
+
+// TestNavigateActionReMountsWithNewQueryData is the load-bearing test
+// for the in-band navigate message. It wires a controller whose Mount
+// reads the "s" query param, opens a WebSocket connect with ?s=alpha,
+// confirms state.Selected == "alpha", then sends a {action:"__navigate__",
+// data:{s:"beta"}} message and confirms state.Selected flips to "beta"
+// on the SAME WebSocket connection — without any reconnect.
+//
+// Uses raw substring assertions on the tree response bytes rather than
+// trying to walk the static/dynamic tree shape — livetemplate's tree
+// format is an implementation detail that may change, and what matters
+// for this test is that the new query param's value reaches the render
+// output.
+func TestNavigateActionReMountsWithNewQueryData(t *testing.T) {
+	server, wsURL := setupNavigateTestServer(t)
+	defer server.Close()
+
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Fire the navigate action with new query data. The response is
+	// the tree update for the re-mounted state.
+	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "beta"})
+	bytesAfter := readWSBytes(t, ws, 2*time.Second)
+	if !strings.Contains(string(bytesAfter), "beta") {
+		t.Errorf("after navigate, response missing 'beta':\n%s", bytesAfter)
+	}
+	// MountCount=2: one from initial connect, one from the navigate.
+	if !strings.Contains(string(bytesAfter), `"2"`) {
+		t.Errorf("after navigate, response missing mount count '2':\n%s", bytesAfter)
+	}
+
+	// One more navigate to a third value confirms we can re-nav
+	// multiple times on the same connection.
+	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "gamma"})
+	bytesAfter2 := readWSBytes(t, ws, 2*time.Second)
+	if !strings.Contains(string(bytesAfter2), "gamma") {
+		t.Errorf("after second navigate, response missing 'gamma':\n%s", bytesAfter2)
+	}
+	if !strings.Contains(string(bytesAfter2), `"3"`) {
+		t.Errorf("after second navigate, response missing mount count '3':\n%s", bytesAfter2)
+	}
+}
+
+// TestNavigateActionNotRoutedThroughDispatchWithState verifies that the
+// navigate action is intercepted BEFORE the regular DispatchWithState
+// path runs. The controller doesn't define a method named __navigate__
+// or Navigate, yet the action succeeds because the event loop routes it
+// to Mount directly. This is the contract that makes the navigate
+// message work on any controller without a method-name collision.
+func TestNavigateActionNotRoutedThroughDispatchWithState(t *testing.T) {
+	server, wsURL := setupNavigateTestServer(t)
+	defer server.Close()
+
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// The controller has no method named Navigate or __navigate__.
+	// Sending the navigate action should succeed (route through Mount)
+	// rather than producing an ErrMethodNotFound error in state.
+	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "abc"})
+	resp := readWSUpdate(t, ws, 2*time.Second)
+
+	meta, ok := resp["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("response has no meta: %#v", resp)
+	}
+	if success, _ := meta["success"].(bool); !success {
+		t.Errorf("navigate response success = false, want true; meta = %#v", meta)
+	}
+	if errs, hasErrs := meta["errors"].(map[string]interface{}); hasErrs && len(errs) > 0 {
+		t.Errorf("navigate response has errors: %#v", errs)
+	}
+}
+
+// sendWSAction sends an action message over the WebSocket, matching the
+// wire format the client uses.
+func sendWSAction(t *testing.T, ws *websocket.Conn, action string, data map[string]interface{}) {
+	t.Helper()
+	msg := map[string]interface{}{
+		"action": action,
+	}
+	if data != nil {
+		msg["data"] = data
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal action: %v", err)
+	}
+	if err := ws.WriteMessage(websocket.TextMessage, b); err != nil {
+		t.Fatalf("ws write: %v", err)
+	}
+}
+
+// readWSBytes reads one WebSocket frame and returns the raw bytes.
+// Useful for assertions that don't care about the internal tree shape.
+func readWSBytes(t *testing.T, ws *websocket.Conn, timeout time.Duration) []byte {
+	t.Helper()
+	if err := ws.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	_, data, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("ws read: %v", err)
+	}
+	return data
+}

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -2,6 +2,7 @@ package livetemplate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"strings"
@@ -164,6 +165,75 @@ func TestNavigateActionEmptyDataResetsQueryParams(t *testing.T) {
 	resp := readWSUpdate(t, ws, 2*time.Second)
 	// Slot 0 = Selected — must be empty string, not the original "alpha".
 	assertTreeSlot(t, "empty-data navigate", resp, "0", "")
+}
+
+// navigateErrorController returns an error from Mount when the "s" param
+// equals "error" — used by TestNavigateActionMountErrorLeavesStateUnchanged.
+type navigateErrorController struct{}
+
+func (c *navigateErrorController) Mount(state navigateTestState, ctx *Context) (navigateTestState, error) {
+	if ctx.GetString("s") == "error" {
+		return state, errors.New("mount rejected invalid param")
+	}
+	state.Selected = ctx.GetString("s")
+	state.MountCount++
+	return state, nil
+}
+
+// TestNavigateActionMountErrorLeavesStateUnchanged verifies that when
+// callMount returns an error on the navigate path, connSt.state is NOT
+// updated — the connection stays at its previous state — and the response
+// carries success=false. This guards the invariant that failed navigates
+// do not partially mutate state.
+func TestNavigateActionMountErrorLeavesStateUnchanged(t *testing.T) {
+	auth := &fixedGroupAuth{groupID: "navigate-err-group"}
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div class="sel">{{.Selected}}</div><div class="count">{{.MountCount}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	handler := tmpl.Handle(&navigateErrorController{}, AsState(&navigateTestState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/?s=alpha"
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// First navigate succeeds — Selected becomes "beta".
+	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "beta"})
+	resp1 := readWSUpdate(t, ws, 2*time.Second)
+	assertTreeSlot(t, "first navigate", resp1, "0", "beta")
+
+	// Second navigate fails — Mount returns an error for s="error".
+	// The response must carry success=false and connSt.state must stay "beta".
+	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "error"})
+	respErr := readWSUpdate(t, ws, 2*time.Second)
+	meta, ok := respErr["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("error navigate response has no meta: %#v", respErr)
+	}
+	if success, _ := meta["success"].(bool); success {
+		t.Errorf("error navigate: meta.success = true, want false")
+	}
+	// No tree update expected on failure — state is unchanged.
+	if _, hasTree := respErr["tree"]; hasTree {
+		t.Logf("note: tree present in error response (may be empty update): %#v", respErr["tree"])
+	}
+
+	// Third navigate succeeds — Selected becomes "gamma". MountCount must
+	// NOT reflect a count from the failed navigate (error path doesn't commit).
+	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "gamma"})
+	resp3 := readWSUpdate(t, ws, 2*time.Second)
+	assertTreeSlot(t, "third navigate after error", resp3, "0", "gamma")
 }
 
 // sendWSAction sends an action message over the WebSocket, matching the

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -2,6 +2,7 @@ package livetemplate
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -69,11 +70,10 @@ func setupNavigateTestServer(t *testing.T) (*httptest.Server, string) {
 // data:{s:"beta"}} message and confirms state.Selected flips to "beta"
 // on the SAME WebSocket connection — without any reconnect.
 //
-// Uses raw substring assertions on the tree response bytes rather than
-// trying to walk the static/dynamic tree shape — livetemplate's tree
-// format is an implementation detail that may change, and what matters
-// for this test is that the new query param's value reaches the render
-// output.
+// Navigate responses are tree UPDATES: the client already has the statics
+// cached from the initial render, so subsequent responses contain only the
+// changed dynamic slot values. assertTreeSlot parses the JSON tree and
+// checks specific slots by position (slot "0" = Selected, slot "1" = MountCount).
 func TestNavigateActionReMountsWithNewQueryData(t *testing.T) {
 	server, wsURL := setupNavigateTestServer(t)
 	defer server.Close()
@@ -87,30 +87,23 @@ func TestNavigateActionReMountsWithNewQueryData(t *testing.T) {
 
 	// Fire the navigate action with new query data. The response is
 	// the tree update for the re-mounted state.
+	//
+	// Navigate responses are tree UPDATES: statics are already cached
+	// client-side, so the wire format contains only changed dynamic slot
+	// values (no HTML, no fingerprints). Parse the JSON tree to assert
+	// specific slot values rather than using fragile substring matching.
 	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "beta"})
-	bytesAfter := readWSBytes(t, ws, 2*time.Second)
-	if !strings.Contains(string(bytesAfter), "beta") {
-		t.Errorf("after navigate, response missing 'beta':\n%s", bytesAfter)
-	}
-	// MountCount=2: one from initial connect, one from the navigate.
-	// Navigate responses are tree UPDATES (statics already cached client-side),
-	// so the raw bytes contain only dynamic slot values like `"1":"2"` —
-	// no statics, no fingerprints. `"2"` here is the rendered count value
-	// and is unambiguous in this response shape.
-	if !strings.Contains(string(bytesAfter), `"2"`) {
-		t.Errorf("after navigate, response missing mount count '2':\n%s", bytesAfter)
-	}
+	resp1 := readWSUpdate(t, ws, 2*time.Second)
+	assertTreeSlot(t, "after first navigate", resp1, "0", "beta")
+	// Slot 1 = MountCount: 2 after initial connect + one navigate.
+	assertTreeSlot(t, "after first navigate", resp1, "1", "2")
 
 	// One more navigate to a third value confirms we can re-nav
 	// multiple times on the same connection.
 	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "gamma"})
-	bytesAfter2 := readWSBytes(t, ws, 2*time.Second)
-	if !strings.Contains(string(bytesAfter2), "gamma") {
-		t.Errorf("after second navigate, response missing 'gamma':\n%s", bytesAfter2)
-	}
-	if !strings.Contains(string(bytesAfter2), `"3"`) {
-		t.Errorf("after second navigate, response missing mount count '3':\n%s", bytesAfter2)
-	}
+	resp2 := readWSUpdate(t, ws, 2*time.Second)
+	assertTreeSlot(t, "after second navigate", resp2, "0", "gamma")
+	assertTreeSlot(t, "after second navigate", resp2, "1", "3")
 }
 
 // TestNavigateActionNotRoutedThroughDispatchWithState verifies that the
@@ -179,4 +172,20 @@ func readWSBytes(t *testing.T, ws *websocket.Conn, timeout time.Duration) []byte
 		t.Fatalf("ws read: %v", err)
 	}
 	return data
+}
+
+// assertTreeSlot checks that the parsed WS update response has the given
+// value at tree slot key. Navigate responses are tree UPDATES containing
+// only changed dynamic slot values, so this is the correct way to verify
+// specific field values without fragile substring matching.
+func assertTreeSlot(t *testing.T, context string, resp map[string]any, slotKey, wantValue string) {
+	t.Helper()
+	tree, ok := resp["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: response has no tree: %#v", context, resp)
+	}
+	got := fmt.Sprintf("%v", tree[slotKey])
+	if got != wantValue {
+		t.Errorf("%s: tree[%q] = %q, want %q", context, slotKey, got, wantValue)
+	}
 }

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -160,20 +160,6 @@ func sendWSAction(t *testing.T, ws *websocket.Conn, action string, data map[stri
 	}
 }
 
-// readWSBytes reads one WebSocket frame and returns the raw bytes.
-// Useful for assertions that don't care about the internal tree shape.
-func readWSBytes(t *testing.T, ws *websocket.Conn, timeout time.Duration) []byte {
-	t.Helper()
-	if err := ws.SetReadDeadline(time.Now().Add(timeout)); err != nil {
-		t.Fatalf("SetReadDeadline: %v", err)
-	}
-	_, data, err := ws.ReadMessage()
-	if err != nil {
-		t.Fatalf("ws read: %v", err)
-	}
-	return data
-}
-
 // assertTreeSlot checks that the parsed WS update response has the given
 // value at tree slot key. Navigate responses are tree UPDATES containing
 // only changed dynamic slot values, so this is the correct way to verify

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -139,6 +139,47 @@ func TestNavigateActionNotRoutedThroughDispatchWithState(t *testing.T) {
 	}
 }
 
+// TestNonNavigateActionRoutedThroughDispatchWithState verifies that the Noop
+// action (a regular controller method, not __navigate__) routes through
+// DispatchWithState and NOT through Mount. After the initial connect, Mount
+// has run once (MountCount=1). Calling Noop must not increment MountCount —
+// if it did, it would mean DispatchWithState is incorrectly routing Noop
+// through Mount's path.
+func TestNonNavigateActionRoutedThroughDispatchWithState(t *testing.T) {
+	server, wsURL := setupNavigateTestServer(t)
+	defer server.Close()
+
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Send a regular (non-navigate) action. Noop returns state unchanged,
+	// so the diff will contain no tree slot changes — but the meta must show
+	// success=true (Noop dispatched correctly via DispatchWithState).
+	sendWSAction(t, ws, "Noop", nil)
+	resp := readWSUpdate(t, ws, 2*time.Second)
+	meta, ok := resp["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Noop response has no meta: %#v", resp)
+	}
+	if success, _ := meta["success"].(bool); !success {
+		t.Errorf("Noop: meta.success = false, want true; meta = %#v", meta)
+	}
+	// MountCount slot must NOT appear in the diff — state didn't change,
+	// so no tree update is emitted for the MountCount slot.
+	// This proves Noop went through DispatchWithState, not callMount.
+	if tree, hasTree := resp["tree"]; hasTree {
+		if treeMap, ok := tree.(map[string]any); ok {
+			if _, hasMountCount := treeMap["1"]; hasMountCount {
+				t.Errorf("Noop: MountCount slot present in diff — Mount was called unexpectedly; tree = %#v", tree)
+			}
+		}
+	}
+}
+
 // TestNavigateActionEmptyDataResetsQueryParams documents and pins the
 // "no data = all-empty params" behavior. Sending __navigate__ with no
 // data field (or an empty map) gives Mount ctx.GetString/GetInt zero

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -93,6 +93,10 @@ func TestNavigateActionReMountsWithNewQueryData(t *testing.T) {
 		t.Errorf("after navigate, response missing 'beta':\n%s", bytesAfter)
 	}
 	// MountCount=2: one from initial connect, one from the navigate.
+	// Navigate responses are tree UPDATES (statics already cached client-side),
+	// so the raw bytes contain only dynamic slot values like `"1":"2"` —
+	// no statics, no fingerprints. `"2"` here is the rendered count value
+	// and is unambiguous in this response shape.
 	if !strings.Contains(string(bytesAfter), `"2"`) {
 		t.Errorf("after navigate, response missing mount count '2':\n%s", bytesAfter)
 	}

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -104,6 +104,7 @@ func TestNavigateActionReMountsWithNewQueryData(t *testing.T) {
 	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "gamma"})
 	resp2 := readWSUpdate(t, ws, 2*time.Second)
 	assertTreeSlot(t, "after second navigate", resp2, "0", "gamma")
+	// Slot 1 = MountCount: 3 after initial connect + two navigates.
 	assertTreeSlot(t, "after second navigate", resp2, "1", "3")
 }
 

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -141,6 +141,31 @@ func TestNavigateActionNotRoutedThroughDispatchWithState(t *testing.T) {
 	}
 }
 
+// TestNavigateActionEmptyDataResetsQueryParams documents and pins the
+// "no data = all-empty params" behavior. Sending __navigate__ with no
+// data field (or an empty map) gives Mount ctx.GetString/GetInt zero
+// values for all keys — the original connection query string is NOT
+// preserved. This test guards against a future regression where someone
+// tries to "merge" the original params into a nil-data navigate.
+func TestNavigateActionEmptyDataResetsQueryParams(t *testing.T) {
+	server, wsURL := setupNavigateTestServer(t)
+	defer server.Close()
+
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Connect with ?s=alpha — initial Selected is "alpha".
+	// Send navigate with NO data — Mount should see s="" (not "alpha").
+	sendWSAction(t, ws, actionNavigate, nil)
+	resp := readWSUpdate(t, ws, 2*time.Second)
+	// Slot 0 = Selected — must be empty string, not the original "alpha".
+	assertTreeSlot(t, "empty-data navigate", resp, "0", "")
+}
+
 // sendWSAction sends an action message over the WebSocket, matching the
 // wire format the client uses.
 func sendWSAction(t *testing.T, ws *websocket.Conn, action string, data map[string]interface{}) {

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -42,9 +42,9 @@ func (c *navigateTestController) Noop(state navigateTestState, _ *Context) (navi
 func setupNavigateTestServer(t *testing.T) (*httptest.Server, string) {
 	t.Helper()
 
-	// All connections share a single session group so we can reason
-	// about a single WebSocket's state transitions across messages.
-	auth := &fixedGroupAuth{groupID: "navigate-test-group"}
+	// Each test gets a unique group ID derived from its name, preventing
+	// state bleed if tests ever run in parallel against a shared session store.
+	auth := &fixedGroupAuth{groupID: t.Name()}
 
 	tmpl, err := New("test", WithAuthenticator(auth))
 	if err != nil {

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -1,15 +1,11 @@
 package livetemplate
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/gorilla/websocket"
 )
 
 // navigateTestState is the per-connection state for the navigate action
@@ -241,37 +237,55 @@ func TestNavigateActionMountErrorLeavesStateUnchanged(t *testing.T) {
 	assertTreeSlot(t, "third navigate after error", resp3, "0", "gamma")
 }
 
-// sendWSAction sends an action message over the WebSocket, matching the
-// wire format the client uses.
-func sendWSAction(t *testing.T, ws *websocket.Conn, action string, data map[string]interface{}) {
-	t.Helper()
-	msg := map[string]interface{}{
-		"action": action,
-	}
-	if data != nil {
-		msg["data"] = data
-	}
-	b, err := json.Marshal(msg)
+// noMountController has no Mount method. Used by
+// TestNavigateActionNoMountMethodIsNoOpRerender to pin the "no Mount → no-op
+// re-render" invariant documented in the actionNavigate constant.
+type noMountController struct{}
+
+func (c *noMountController) Ping(state navigateTestState, _ *Context) (navigateTestState, error) {
+	return state, nil
+}
+
+// TestNavigateActionNoMountMethodIsNoOpRerender pins the invariant: when the
+// controller defines no Mount method, __navigate__ produces a success=true
+// response without changing state. This verifies that callMount's no-method
+// path (lifecycle.go) works correctly end-to-end for the navigate action.
+func TestNavigateActionNoMountMethodIsNoOpRerender(t *testing.T) {
+	tmpl, err := New("test")
 	if err != nil {
-		t.Fatalf("marshal action: %v", err)
+		t.Fatalf("New: %v", err)
 	}
-	if err := ws.WriteMessage(websocket.TextMessage, b); err != nil {
-		t.Fatalf("ws write: %v", err)
+	tmpl, err = tmpl.Parse(`<div>{{.Selected}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	handler := tmpl.Handle(&noMountController{}, AsState(&navigateTestState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Navigate on a controller with no Mount method: must succeed (success=true)
+	// and must NOT produce an ErrMethodNotFound error.
+	sendWSAction(t, ws, actionNavigate, map[string]interface{}{"s": "anything"})
+	resp := readWSUpdate(t, ws, 2*time.Second)
+
+	meta, ok := resp["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("response has no meta: %#v", resp)
+	}
+	if success, _ := meta["success"].(bool); !success {
+		t.Errorf("no-Mount navigate: meta.success = false, want true; meta = %#v", meta)
+	}
+	if errs, hasErrs := meta["errors"].(map[string]interface{}); hasErrs && len(errs) > 0 {
+		t.Errorf("no-Mount navigate: unexpected errors: %#v", errs)
 	}
 }
 
-// assertTreeSlot checks that the parsed WS update response has the given
-// value at tree slot key. Navigate responses are tree UPDATES containing
-// only changed dynamic slot values, so this is the correct way to verify
-// specific field values without fragile substring matching.
-func assertTreeSlot(t *testing.T, context string, resp map[string]any, slotKey, wantValue string) {
-	t.Helper()
-	tree, ok := resp["tree"].(map[string]any)
-	if !ok {
-		t.Fatalf("%s: response has no tree: %#v", context, resp)
-	}
-	got := fmt.Sprintf("%v", tree[slotKey])
-	if got != wantValue {
-		t.Errorf("%s: tree[%q] = %q, want %q", context, slotKey, got, wantValue)
-	}
-}

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -183,7 +183,7 @@ func (c *navigateErrorController) Mount(state navigateTestState, ctx *Context) (
 // carries success=false. This guards the invariant that failed navigates
 // do not partially mutate state.
 func TestNavigateActionMountErrorLeavesStateUnchanged(t *testing.T) {
-	auth := &fixedGroupAuth{groupID: "navigate-err-group"}
+	auth := &fixedGroupAuth{groupID: t.Name()}
 	tmpl, err := New("test", WithAuthenticator(auth))
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/navigate_test.go
+++ b/navigate_test.go
@@ -279,13 +279,8 @@ func TestNavigateActionMountErrorLeavesStateUnchanged(t *testing.T) {
 }
 
 // noMountController has no Mount method. Used by
-// TestNavigateActionNoMountMethodIsNoOpRerender to pin the "no Mount → no-op
-// re-render" invariant documented in the actionNavigate constant.
+// TestNavigateActionNoMountMethodIsNoOpRerender.
 type noMountController struct{}
-
-func (c *noMountController) Ping(state navigateTestState, _ *Context) (navigateTestState, error) {
-	return state, nil
-}
 
 // TestNavigateActionNoMountMethodIsNoOpRerender pins the invariant: when the
 // controller defines no Mount method, __navigate__ produces a success=true

--- a/ws_test_helpers_test.go
+++ b/ws_test_helpers_test.go
@@ -1,0 +1,44 @@
+package livetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// sendWSAction sends an action message over the WebSocket, matching the
+// wire format the client uses.
+func sendWSAction(t *testing.T, ws *websocket.Conn, action string, data map[string]interface{}) {
+	t.Helper()
+	msg := map[string]interface{}{
+		"action": action,
+	}
+	if data != nil {
+		msg["data"] = data
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal action: %v", err)
+	}
+	if err := ws.WriteMessage(websocket.TextMessage, b); err != nil {
+		t.Fatalf("ws write: %v", err)
+	}
+}
+
+// assertTreeSlot checks that the parsed WS update response has the given
+// value at tree slot key. Navigate responses are tree UPDATES containing
+// only changed dynamic slot values, so this is the correct way to verify
+// specific field values without fragile substring matching.
+func assertTreeSlot(t *testing.T, context string, resp map[string]any, slotKey, wantValue string) {
+	t.Helper()
+	tree, ok := resp["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: response has no tree: %#v", context, resp)
+	}
+	got := fmt.Sprintf("%v", tree[slotKey])
+	if got != wantValue {
+		t.Errorf("%s: tree[%q] = %q, want %q", context, slotKey, got, wantValue)
+	}
+}


### PR DESCRIPTION
## Summary

- **\`__navigate__\` action**: reserved action name that re-runs Mount on the existing WebSocket with fresh query data. Enables same-handler SPA navigation without reconnecting — the in-band equivalent of Phoenix LiveView's \`live_patch\` / \`handle_params\`.
- **Flash lifecycle refactor**: flash messages persist until explicitly cleared via \`ClearFlash(key)\` or until optional \`FlashExpiry(duration)\` elapses. Replaces the auto-clear-after-render behavior that caused flash messages set by user actions to be clobbered by the next background Refresh tick.

## Breaking Changes

**Flash lifecycle (WebSocket connections only):** In v0.8.x, \`ctx.SetFlash(key, msg)\` was inherently one-shot — flash was auto-cleared after the next render. In v0.9, flash persists on WebSocket connections until \`ctx.ClearFlash(key)\` is explicitly called or \`FlashExpiry(duration)\` elapses. Existing handlers that set flash and rely on auto-clear will accumulate flash indefinitely unless updated. Migration steps are documented in the \`SetFlash\` godoc. HTTP connections (PRG forms) remain one-shot as before.

**\`ctx.Action() == ""\` guard fires on navigate:** The \`__navigate__\` action uses \`actionCtx.WithAction("")\` so that Mount's \`if ctx.Action() == "" { ... }\` guard fires on navigate — this is intentional (navigate is conceptually a re-mount). Existing controllers using this guard for analytics or side-effects (e.g., \`trackPageView()\`) will fire on every navigate, which may be unexpected. Move initial-connect-only side-effects to \`OnConnect\`.

**\`__navigate__\` with no/empty data replaces (not merges) query params:** Sending \`__navigate__\` with a nil or empty data field passes an empty map to Mount — the original WebSocket connection's query string is NOT preserved. All \`ctx.GetString\` / \`ctx.GetInt\` calls return zero values. There is no implicit merge; callers must explicitly include all params they want Mount to see.

## Test plan

- [x] \`navigate_test.go\`: 5 tests — Mount re-runs with new data, routing bypass, non-navigate routes through DispatchWithState, empty-data resets params, error-path state unchanged, no-Mount is no-op
- [x] \`flash_lifecycle_test.go\`: 8 tests — persist, explicit clear, expiry (unit), selective prune, expiry-overwrite, WS action integration, navigate path integration, FlashExpiry public-API integration
- [x] Full test suite (70s including Redis integration) — green
- [x] Flash lifecycle tested end-to-end via devbox-dash chromedp: \`TestFlashSurvivesScanRefresh\` passes
- [ ] Deferred to #343: dispatched-action flash path (\`handleDispatchedAction\`) and pubsub broadcast flash path (\`handleServerActionMessage\`) — both call \`pruneExpiredFlash()\` correctly but lack dedicated flash regression tests; covered indirectly by the existing broadcast/pubsub test suites

## Follow-up

- livetemplate/livetemplate#343: update examples, docs, and migration guide for the new flash lifecycle and navigate behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)