### PR TITLE
docs: automatic client-side state preservation

### DIFF
--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -755,7 +755,7 @@ When a `<dialog>` is opened via `showModal()`, the browser adds it to the top la
 
 ### Datalist Dropdown
 
-Native `<datalist>` dropdowns are fragile — touching the element dismisses the popup, and unlike checkbox state, dropdown-open has no DOM representation that can be copied. The client skips the morphdom update for any `<datalist>` whose connected `<input>` (via the `list` attribute) is currently focused.
+Native `<datalist>` dropdowns are fragile — ANY DOM mutation on the page (not just to the datalist itself) dismisses the popup, and unlike checkbox state, dropdown-open has no DOM representation. The client defers the entire morphdom pass while `document.activeElement` is an `<input>` connected to a `<datalist>` via the `list` attribute.
 
 ```html
 <input type="text" list="suggestions" name="query">
@@ -765,7 +765,7 @@ Native `<datalist>` dropdowns are fragile — touching the element dismisses the
 </datalist>
 ```
 
-When the user blurs the input, the next server update will apply any pending changes to the `<datalist>` options.
+When the user blurs the input, the next server push applies all pending changes (not just to the datalist, but to the entire page).
 
 ### Focused Input Elements
 
@@ -784,7 +784,7 @@ All automatic preservation behaviors can be overridden by adding `data-lvt-force
 |---|---|---|
 | Checkbox/radio `checked` | Property copied to virtual DOM | `data-lvt-force-update` on the input |
 | Dialog `open` | morphdom update skipped while dialog is open | `data-lvt-force-update` on the dialog |
-| Datalist options | morphdom update skipped while input focused | `data-lvt-force-update` on the datalist |
+| Datalist dropdown | Entire morphdom pass deferred while input focused | `data-lvt-force-update` on any element |
 | Focused input value | morphdom update skipped | `data-lvt-force-update` on the input |
 
 ---
@@ -939,7 +939,9 @@ Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`,
 
 | Attribute | Description | Example |
 |-----------|-------------|---------|
-| `data-lvt-force-update` | Override automatic state preservation; server value wins | `<input type="checkbox" data-lvt-force-update>` |
+| `lvt-ignore` | Skip this element and its entire subtree during morphdom diff. Checked on the live DOM (`fromEl`), usable from both templates and client JS. Equivalent to Phoenix LiveView's `phx-update="ignore"` | `<div lvt-ignore class="map-widget">` |
+| `lvt-ignore-attrs` | Skip attribute diffing but still diff children. Preserves client-set attributes (e.g. `open` on `<details>`) while keeping child content server-managed | `<details lvt-ignore-attrs>` |
+| `data-lvt-force-update` | Override all preservation (automatic and `lvt-ignore`); server value wins. Self-clears after one render | `<input type="checkbox" data-lvt-force-update>` |
 
 ### Identity Attributes
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -734,7 +734,7 @@ The client automatically preserves certain client-side state across server-pushe
 User-toggled `checked` state on `<input type="checkbox">` and `<input type="radio">` survives DOM updates. The client copies the live DOM's `.checked` property onto the incoming virtual element before morphdom compares them, so morphdom sees no diff and leaves the element alone.
 
 ```html
-<!-- User checks this box; a server refresh won't uncheck it -->
+<!-- User checks this box; a server-pushed update won't uncheck it -->
 <label><input type="checkbox" name="select" value="item-1"> Item 1</label>
 ```
 
@@ -789,10 +789,10 @@ All automatic preservation behaviors can be overridden by adding `data-lvt-force
 ```
 
 | Preserved State | Mechanism | Override |
-|---|---|---|
+|-----------|-------------|---------|
 | Checkbox/radio `checked` | Property copied to virtual DOM | `data-lvt-force-update` on the input |
 | Dialog `open` | morphdom update skipped while dialog is open | `data-lvt-force-update` on the dialog |
-| Datalist dropdown | Entire morphdom pass deferred while input focused | `data-lvt-force-update` on the connected `<input>` (overrides deferral for the entire pass) |
+| Datalist dropdown | Entire morphdom pass deferred while datalist input focused | `data-lvt-force-update` on the connected `<input>` (overrides deferral for the entire pass) |
 | Focused input elements | morphdom update skipped | `data-lvt-force-update` on the input |
 
 ### Manual Preservation with `lvt-ignore`
@@ -959,7 +959,7 @@ Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`,
 |-----------|-------------|---------|
 | `lvt-ignore` | Skip this element and its entire subtree during morphdom diff. Checked on the live DOM (`fromEl`), usable from both templates and client JS. Equivalent to Phoenix LiveView's `phx-update="ignore"` | `<div lvt-ignore class="map-widget">` |
 | `lvt-ignore-attrs` | Skip attribute diffing but still diff children. Preserves client-set attributes (e.g. `open` on `<details>`) while keeping child content server-managed | `<details lvt-ignore-attrs>` |
-| `data-lvt-force-update` | Override all preservation (automatic and `lvt-ignore`); server value wins. Client strips it after processing; server re-sends it each render | `<input type="checkbox" data-lvt-force-update>` |
+| `data-lvt-force-update` | Override all preservation (automatic, `lvt-ignore`, and `lvt-ignore-attrs`); server value wins. Client strips it after processing; server re-sends it each render | `<input type="checkbox" data-lvt-force-update>` |
 
 ### Identity Attributes
 
@@ -969,7 +969,7 @@ Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`,
 
 ### Valid Key Values
 
-For `lvt-key` attribute:
+**For `lvt-key` attribute** (not `data-key`):
 
 - Letter keys: `"a"`, `"b"`, `"c"`, etc.
 - Special keys: `"Enter"`, `"Escape"`, `"Space"`, `"Tab"`, `"Backspace"`, `"Delete"`

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -15,6 +15,7 @@ Complete reference for LiveTemplate form handling and `lvt-*` HTML attributes.
 - [Rate Limiting](#rate-limiting)
 - [Directives](#directives)
 - [Modals](#modals)
+- [Automatic Client-Side State Preservation](#automatic-client-side-state-preservation)
 - [File Uploads](#file-uploads)
 - [Form Behavior](#form-behavior)
 - [Attribute Reference](#attribute-reference)
@@ -741,7 +742,7 @@ User-toggled `checked` state on `<input type="checkbox">` and `<input type="radi
 
 ### Dialog Open State
 
-When a `<dialog>` is opened via `showModal()`, the browser adds it to the top layer — a special rendering context above all other content. The `open` attribute alone doesn't preserve this state; morphdom's attribute sync and child reconciliation can disrupt the top-layer positioning even when `open` is retained. The client prevents this by skipping the entire dialog element and its subtree while `open` is present. The server continues sending updates while the dialog is open, but the client discards them. After the dialog closes, the next server update applies normally, reconciling the client DOM with current server state.
+When a `<dialog>` is opened via `showModal()`, the browser adds it to the top layer — a special rendering context above all other content. The `open` attribute alone doesn't preserve this state; morphdom's attribute sync and child reconciliation can disrupt the top-layer positioning even when `open` is retained. The client prevents this by skipping the entire dialog element and its subtree while `open` is present. The server continues sending updates while the dialog is open, but the client skips the dialog subtree during morphdom (the rest of the page still updates normally). After the dialog closes, the next server update reconciles the dialog's DOM with the current server state.
 
 Adding `data-lvt-force-update` to the `<dialog>` overrides this skip: the client applies morphdom to the dialog's content while it remains open, allowing the server to update dialog contents in real time (e.g., live validation feedback inside a modal form).
 
@@ -773,6 +774,11 @@ When the user blurs the input, the deferred morphdom pass runs, applying all pen
 
 Any form element that currently has focus is skipped during morphdom updates, preserving in-progress user input.
 
+```html
+<!-- User typing here won't be interrupted by server updates -->
+<input type="text" name="search" value="{{.Query}}">
+```
+
 ### Overriding with `data-lvt-force-update`
 
 All automatic preservation behaviors can be overridden by adding `data-lvt-force-update` to the element in the server template. When present, the server's value wins over the client-side state. The client strips the attribute from the live DOM after applying the update; because it lives in the server template, the server re-sends it on every render, so it continuously forces the server value.
@@ -797,7 +803,7 @@ For cases where automatic preservation doesn't cover your needs, two attributes 
 
 - **`lvt-ignore-attrs`** — Skips attribute diffing but still diffs children. Use this when client-set attributes (e.g., `open` on `<details>`) need to survive server updates while child content remains server-managed.
 
-Both can be overridden by `data-lvt-force-update` when the server needs to take control.
+Both can be overridden by `data-lvt-force-update` when the server needs to take control — adding it to an `lvt-ignore` element re-enables morphdom for that subtree for the current update.
 
 ---
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -741,7 +741,7 @@ User-toggled `checked` state on `<input type="checkbox">` and `<input type="radi
 
 ### Dialog Open State
 
-When a `<dialog>` is opened via `showModal()` or `.show()`, the `open` attribute is set by client-side JavaScript. Since the server template never includes `open`, morphdom would normally strip it on every update, closing the dialog. The client prevents this by copying the `open` attribute from the live DOM to the incoming virtual element.
+When a `<dialog>` is opened via `showModal()`, the browser adds it to the top layer — a special rendering context above all other content. The `open` attribute alone doesn't preserve this state; morphdom's attribute sync and child reconciliation can disrupt the top-layer positioning even when `open` is retained. The client prevents this by skipping the entire dialog element and its subtree while `open` is present. Any pending server changes apply on the next update after the dialog is closed.
 
 ```html
 <!-- Dialog stays open across server refreshes -->
@@ -783,7 +783,7 @@ All automatic preservation behaviors can be overridden by adding `data-lvt-force
 | Preserved State | Mechanism | Override |
 |---|---|---|
 | Checkbox/radio `checked` | Property copied to virtual DOM | `data-lvt-force-update` on the input |
-| Dialog `open` | Attribute copied to virtual DOM | `data-lvt-force-update` on the dialog |
+| Dialog `open` | morphdom update skipped while dialog is open | `data-lvt-force-update` on the dialog |
 | Datalist options | morphdom update skipped while input focused | `data-lvt-force-update` on the datalist |
 | Focused input value | morphdom update skipped | `data-lvt-force-update` on the input |
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -724,6 +724,71 @@ For modals whose visibility is controlled by server state (e.g., confirmation di
 
 ---
 
+## Automatic Client-Side State Preservation
+
+The client automatically preserves certain client-side state across server-pushed DOM updates. These behaviors require no attributes — they are built into the morphdom diffing pass.
+
+### Checkbox and Radio Buttons
+
+User-toggled `checked` state on `<input type="checkbox">` and `<input type="radio">` survives DOM updates. The client copies the live DOM's `.checked` property onto the incoming virtual element before morphdom compares them, so morphdom sees no diff and leaves the element alone.
+
+```html
+<!-- User checks this box; a server refresh won't uncheck it -->
+<input type="checkbox" name="select" value="item-1">
+```
+
+**Radio group caveat:** Browser mutual exclusion fires synchronously during the morphdom pass. If you need to force-reset a radio group from the server, add `data-lvt-force-update` to *all* radios in the group, not just the one being checked.
+
+### Dialog Open State
+
+When a `<dialog>` is opened via `showModal()` or `.show()`, the `open` attribute is set by client-side JavaScript. Since the server template never includes `open`, morphdom would normally strip it on every update, closing the dialog. The client prevents this by copying the `open` attribute from the live DOM to the incoming virtual element.
+
+```html
+<!-- Dialog stays open across server refreshes -->
+<dialog id="settings">
+  <form method="post" name="SaveSettings">
+    <input name="theme">
+    <button type="submit">Save</button>
+  </form>
+</dialog>
+```
+
+### Datalist Dropdown
+
+Native `<datalist>` dropdowns are fragile — touching the element dismisses the popup, and unlike checkbox state, dropdown-open has no DOM representation that can be copied. The client skips the morphdom update for any `<datalist>` whose connected `<input>` (via the `list` attribute) is currently focused.
+
+```html
+<input type="text" list="suggestions" name="query">
+<datalist id="suggestions">
+  <option value="alpha">
+  <option value="beta">
+</datalist>
+```
+
+When the user blurs the input, the next server update will apply any pending changes to the `<datalist>` options.
+
+### Focused Input Elements
+
+Any form element that currently has focus is skipped during morphdom updates, preserving in-progress user input. This is handled by the focus manager and predates the above behaviors.
+
+### Overriding with `data-lvt-force-update`
+
+All automatic preservation behaviors can be overridden by adding `data-lvt-force-update` to the element in the server template. When present, the server's value wins over the client-side state. The attribute is removed after processing so it doesn't persist across updates.
+
+```html
+<!-- Server always controls this checkbox -->
+<input type="checkbox" name="locked" data-lvt-force-update {{if .Locked}}checked{{end}}>
+```
+
+| Preserved State | Mechanism | Override |
+|---|---|---|
+| Checkbox/radio `checked` | Property copied to virtual DOM | `data-lvt-force-update` on the input |
+| Dialog `open` | Attribute copied to virtual DOM | `data-lvt-force-update` on the dialog |
+| Datalist options | morphdom update skipped while input focused | `data-lvt-force-update` on the datalist |
+| Focused input value | morphdom update skipped | `data-lvt-force-update` on the input |
+
+---
+
 ## File Uploads
 
 Handle file uploads with progress tracking.
@@ -869,6 +934,18 @@ Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`,
 | Attribute | Description | Example |
 |-----------|-------------|---------|
 | `lvt-upload` | File upload identifier | `lvt-upload="avatar"` |
+
+### Preservation Attributes
+
+| Attribute | Description | Example |
+|-----------|-------------|---------|
+| `data-lvt-force-update` | Override automatic state preservation; server value wins | `<input type="checkbox" data-lvt-force-update>` |
+
+### Identity Attributes
+
+| Attribute | Description | Example |
+|-----------|-------------|---------|
+| `data-key` | Stable identity for morphdom element matching; ensures elements are updated in-place rather than removed and re-added when siblings change | `<dialog data-key="settings-dialog">` |
 
 ### Valid Key Values
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -734,19 +734,21 @@ User-toggled `checked` state on `<input type="checkbox">` and `<input type="radi
 
 ```html
 <!-- User checks this box; a server refresh won't uncheck it -->
-<input type="checkbox" name="select" value="item-1">
+<label><input type="checkbox" name="select" value="item-1"> Item 1</label>
 ```
 
 **Radio group caveat:** Browser mutual exclusion fires synchronously during the morphdom pass. If you need to force-reset a radio group from the server, add `data-lvt-force-update` to *all* radios in the group, not just the one being checked.
 
 ### Dialog Open State
 
-When a `<dialog>` is opened via `showModal()`, the browser adds it to the top layer — a special rendering context above all other content. The `open` attribute alone doesn't preserve this state; morphdom's attribute sync and child reconciliation can disrupt the top-layer positioning even when `open` is retained. The client prevents this by skipping the entire dialog element and its subtree while `open` is present. Any pending server changes apply on the next update after the dialog is closed.
+When a `<dialog>` is opened via `showModal()`, the browser adds it to the top layer — a special rendering context above all other content. The `open` attribute alone doesn't preserve this state; morphdom's attribute sync and child reconciliation can disrupt the top-layer positioning even when `open` is retained. The client prevents this by skipping the entire dialog element and its subtree while `open` is present. The server continues sending updates while the dialog is open, but the client discards them. After the dialog closes, the next server update applies normally, reconciling the client DOM with current server state.
+
+Adding `data-lvt-force-update` to the `<dialog>` overrides this skip: the client applies morphdom to the dialog's content while it remains open, allowing the server to update dialog contents in real time (e.g., live validation feedback inside a modal form).
 
 ```html
 <!-- Dialog stays open across server refreshes -->
 <dialog id="settings">
-  <form method="post" name="SaveSettings">
+  <form method="POST" name="SaveSettings">
     <input name="theme">
     <button type="submit">Save</button>
   </form>
@@ -765,15 +767,15 @@ Native `<datalist>` dropdowns are fragile — ANY DOM mutation on the page (not 
 </datalist>
 ```
 
-When the user blurs the input, the next server push applies all pending changes (not just to the datalist, but to the entire page).
+When the user blurs the input, the deferred morphdom pass runs, applying all pending changes (not just to the datalist, but to the entire page). Adding `data-lvt-force-update` to the connected `<input>` overrides this deferral, allowing the morphdom pass to proceed immediately even while the datalist dropdown is open.
 
 ### Focused Input Elements
 
-Any form element that currently has focus is skipped during morphdom updates, preserving in-progress user input. This is handled by the focus manager and predates the above behaviors.
+Any form element that currently has focus is skipped during morphdom updates, preserving in-progress user input.
 
 ### Overriding with `data-lvt-force-update`
 
-All automatic preservation behaviors can be overridden by adding `data-lvt-force-update` to the element in the server template. When present, the server's value wins over the client-side state. The attribute is removed after processing so it doesn't persist across updates.
+All automatic preservation behaviors can be overridden by adding `data-lvt-force-update` to the element in the server template. When present, the server's value wins over the client-side state. The client strips the attribute from the live DOM after applying the update; because it lives in the server template, the server re-sends it on every render, so it continuously forces the server value.
 
 ```html
 <!-- Server always controls this checkbox -->
@@ -784,8 +786,18 @@ All automatic preservation behaviors can be overridden by adding `data-lvt-force
 |---|---|---|
 | Checkbox/radio `checked` | Property copied to virtual DOM | `data-lvt-force-update` on the input |
 | Dialog `open` | morphdom update skipped while dialog is open | `data-lvt-force-update` on the dialog |
-| Datalist dropdown | Entire morphdom pass deferred while input focused | `data-lvt-force-update` on any element |
-| Focused input value | morphdom update skipped | `data-lvt-force-update` on the input |
+| Datalist dropdown | Entire morphdom pass deferred while input focused | `data-lvt-force-update` on the connected `<input>` (overrides deferral for the entire pass) |
+| Focused input elements | morphdom update skipped | `data-lvt-force-update` on the input |
+
+### Manual Preservation with `lvt-ignore`
+
+For cases where automatic preservation doesn't cover your needs, two attributes provide explicit control:
+
+- **`lvt-ignore`** — Skips the element and its entire subtree during morphdom diff. Use this for third-party widgets (maps, rich-text editors) whose DOM is managed by external JavaScript. Checked on the live DOM element, so it can be set from templates or client JS. Equivalent to Phoenix LiveView's `phx-update="ignore"`.
+
+- **`lvt-ignore-attrs`** — Skips attribute diffing but still diffs children. Use this when client-set attributes (e.g., `open` on `<details>`) need to survive server updates while child content remains server-managed.
+
+Both can be overridden by `data-lvt-force-update` when the server needs to take control.
 
 ---
 
@@ -856,7 +868,7 @@ Use standard `onsubmit` for confirmation dialogs:
 
 ## Attribute Reference
 
-Complete reference of all `lvt-*` attributes.
+Complete reference of all `lvt-*` and `data-*` template attributes.
 
 ### Event Attributes (`lvt-on:`)
 
@@ -941,13 +953,13 @@ Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`,
 |-----------|-------------|---------|
 | `lvt-ignore` | Skip this element and its entire subtree during morphdom diff. Checked on the live DOM (`fromEl`), usable from both templates and client JS. Equivalent to Phoenix LiveView's `phx-update="ignore"` | `<div lvt-ignore class="map-widget">` |
 | `lvt-ignore-attrs` | Skip attribute diffing but still diff children. Preserves client-set attributes (e.g. `open` on `<details>`) while keeping child content server-managed | `<details lvt-ignore-attrs>` |
-| `data-lvt-force-update` | Override all preservation (automatic and `lvt-ignore`); server value wins. Self-clears after one render | `<input type="checkbox" data-lvt-force-update>` |
+| `data-lvt-force-update` | Override all preservation (automatic and `lvt-ignore`); server value wins. Client strips it after processing; server re-sends it each render | `<input type="checkbox" data-lvt-force-update>` |
 
 ### Identity Attributes
 
 | Attribute | Description | Example |
 |-----------|-------------|---------|
-| `data-key` | Stable identity for morphdom element matching; ensures elements are updated in-place rather than removed and re-added when siblings change | `<dialog data-key="settings-dialog">` |
+| `data-key` | Stable element identity for the diff engine and morphdom matching. In `{{range}}` templates, controls which items are updated in-place vs. removed/inserted. On singleton elements, helps morphdom match nodes across updates. Hardcoded keys are valid for singletons; use template expressions (`{{.ID}}`) in lists | `<dialog data-key="settings-dialog">` |
 
 ### Valid Key Values
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -772,12 +772,14 @@ When the user blurs the input, the deferred morphdom pass runs, applying all pen
 
 ### Focused Input Elements
 
-Any form element that currently has focus is skipped during morphdom updates, preserving in-progress user input.
+Any form element that currently has focus is skipped during morphdom updates, preserving in-progress user input. Once the element loses focus, the next server update reconciles its value with the current server state.
 
 ```html
 <!-- User typing here won't be interrupted by server updates -->
 <input type="text" name="search" value="{{.Query}}">
 ```
+
+To override this for a specific input — e.g., when a server-controlled value must always win — add `data-lvt-force-update` to the element.
 
 ### Overriding with `data-lvt-force-update`
 


### PR DESCRIPTION
## Summary

- Adds a new "Automatic Client-Side State Preservation" section to `docs/references/client-attributes.md`
- Documents the four automatic preservation behaviors: checkbox/radio checked, dialog open, datalist dropdown, and focused input
- Documents the `data-lvt-force-update` override mechanism and `data-key` identity attribute
- Placed between "Modals" and "File Uploads" sections, where users looking for dialog behavior will find it

These features ship in the client release following v0.8.29 (PR https://github.com/livetemplate/client/pull/85).

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify code examples are accurate against client source
- [ ] Cross-reference with client PR #85 for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)