### PR TITLE
docs: update scroll-sentinel to lvt-scroll-sentinel attribute

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install sqlc
       run: |
-        go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+        go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.28.0
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Set up Node.js
@@ -158,7 +158,7 @@ jobs:
 
     - name: Install sqlc
       run: |
-        go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+        go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.28.0
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Add replace directives to examples

--- a/docs/proposals/patterns.md
+++ b/docs/proposals/patterns.md
@@ -728,7 +728,7 @@ func (c *Controller) LoadMore(state ClickToLoadState, ctx *livetemplate.Context)
 
 **htmx:** Uses `hx-get` with `hx-trigger="revealed"` and `hx-swap="afterend"` on the last row to auto-load on scroll.
 
-**LiveTemplate (Tier 1):** The client has built-in IntersectionObserver support. A `<div id="scroll-sentinel">` at the end of the list triggers the `load_more` action automatically when it becomes visible. The framework routes `load_more` (snake_case) to the `LoadMore()` method.
+**LiveTemplate (Tier 1):** The client has built-in IntersectionObserver support. A `<div lvt-scroll-sentinel>` at the end of the list triggers the `load_more` action automatically when it becomes visible. The framework routes `load_more` (snake_case) to the `LoadMore()` method.
 
 **Also implemented in:** —
 
@@ -767,15 +767,15 @@ func (c *Controller) LoadMore(state InfiniteScrollState, ctx *livetemplate.Conte
         </tbody>
     </table>
     {{if .HasMore}}
-    <div id="scroll-sentinel"><small>Loading more...</small></div>
+    <div lvt-scroll-sentinel><small>Loading more...</small></div>
     {{end}}
 </article>
 {{end}}
 ```
 
-**Key features:** `scroll-sentinel` auto-triggers `load_more` (source: `client/dom/observer-manager.ts`), IntersectionObserver built into client
+**Key features:** `lvt-scroll-sentinel` attribute auto-triggers `load_more`; IntersectionObserver support is built into the client
 
-> **Limitation:** The client detects the sentinel by `id="scroll-sentinel"`, so only one infinite scroll list can exist per page. This is fine for the patterns app (one pattern per page).
+> **Limitation:** The client detects the sentinel by `[lvt-scroll-sentinel]` attribute (`querySelector` selects the first match), so only one infinite scroll list can exist per wrapper. This is fine for the patterns app (one list per page).
 
 ---
 
@@ -2198,7 +2198,7 @@ State is pure data (`AssertPureState` still passes) and gets repopulated on ever
 
 **Infinite Scroll dataset sizing:** With `listPageSize = 10`, use **25+ items** in the dataset. 25 produces 3 pages (10 + 10 + 5), which is enough to demonstrate auto-advance through multiple pages. Anything less than ~25 and the infinite-scroll effect isn't visible.
 
-**Sentinel must render only when `.HasMore`:** Always-rendering `<div id="scroll-sentinel">` causes an **infinite empty-load loop** after the last page — the sentinel stays visible, the observer fires, the server returns an empty page, rinse/repeat. Wrap it in `{{if .HasMore}}...{{end}}`.
+**Sentinel must render only when `.HasMore`:** Always-rendering `<div lvt-scroll-sentinel>` causes an **infinite empty-load loop** after the last page — the sentinel stays visible, the observer fires, the server returns an empty page, rinse/repeat. Wrap it in `{{if .HasMore}}...{{end}}`.
 
 **Headless Chrome test limitations (and their fixes):**
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -969,6 +969,12 @@ Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`,
 |-----------|-------------|---------|
 | `data-key` | Stable element identity for the diff engine and morphdom matching. In `{{range}}` templates, controls which items are updated in-place vs. removed/inserted. On singleton elements, helps morphdom match nodes across updates. Hardcoded keys are valid for singletons; use template expressions (`{{.ID}}`) in lists | `<dialog data-key="settings-dialog">` |
 
+### Infinite Scroll
+
+| Attribute | Description | Example |
+|-----------|-------------|---------|
+| `lvt-scroll-sentinel` | Marks an element as the infinite scroll sentinel. The client's `IntersectionObserver` watches this element; when it enters the viewport (default 200px rootMargin; see observer module in `livetemplate/client`), the client dispatches `load_more` automatically. Only the first matching element per wrapper is observed. Wrap in `{{if .HasMore}}...{{end}}` to prevent infinite empty-load loops | `<div lvt-scroll-sentinel>Loading more...</div>` |
+
 ### Valid Key Values
 
 **For `lvt-key` attribute** (not `data-key`):

--- a/testdata/golden/resource_template.tmpl.golden
+++ b/testdata/golden/resource_template.tmpl.golden
@@ -198,7 +198,7 @@
         Loading more...
       </div>
     {{end}}
-    <div id="scroll-sentinel" style="height: 1px;"></div>
+    <div lvt-scroll-sentinel style="height: 1px;"></div>
   {{end}}
 {{end}}
 


### PR DESCRIPTION
## Summary

- Rename `id="scroll-sentinel"` → `lvt-scroll-sentinel` attribute across docs and golden file
- Align with `lvt-*` attribute naming convention
- Update limitation note scope from "per page" to "per wrapper"
- Phrase rootMargin as "default" value with cross-repo source reference

Reopened after accidental merge of #352 while cross-repo tests were still failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)