### PR TITLE
ci: pin sqlc to v1.28.0

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install sqlc
       run: |
-        go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+        go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.28.0
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Set up Node.js
@@ -158,7 +158,7 @@ jobs:
 
     - name: Install sqlc
       run: |
-        go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+        go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.28.0
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Add replace directives to examples


### PR DESCRIPTION
## Summary

- Pin `sqlc` install in cross-repo CI to `v1.28.0` instead of `@latest`
- sqlc `v1.31.0` added `replace` directives to its `go.mod`, which breaks `go install ...@latest`
- Affects both `test-lvt` and `test-examples` jobs

## Test plan

- [ ] Cross-repo CI passes (sqlc installs successfully)
- [ ] LVT, Examples, and Tinkerdown tests run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)