### PR TITLE
docs: scroll effect targeting, lvt-scroll-away, and chat recipe

### DIFF
--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -726,9 +726,9 @@ Triggers a `load_more` action when the element scrolls into view, enabling infin
 
 | Attribute | Description |
 |-----------|-------------|
-| `lvt-scroll-sentinel` | Marks the element as an infinite-scroll trigger. When it enters the viewport, the client sends a hardcoded `load_more` action to the server (maps to a `LoadMore()` handler) |
+| `lvt-scroll-sentinel` | Marks the element as an infinite-scroll trigger. When it enters the viewport, the client sends a `load_more` action to the server |
 
-The server handler (e.g., `LoadMore()`) increments a page counter and returns more items. Conditionally render the sentinel with `{{if .HasMore}}` so it disappears when all items are loaded. The observer automatically cascades — if the sentinel is still visible after new items load, it fires again.
+The action name `load_more` is hardcoded and not configurable. It maps to a `LoadMore()` handler on the server via livetemplate's standard snake_case-to-PascalCase action routing. The handler increments a page counter and returns more items. Conditionally render the sentinel with `{{if .HasMore}}` so it disappears when all items are loaded. The observer automatically cascades — if the sentinel is still visible after new items load, it fires again.
 
 The `data-key="sentinel"` ensures stable identity across re-renders so morphdom patches correctly when surrounding content changes.
 
@@ -1015,9 +1015,15 @@ Complete reference of all `lvt-*` and `data-*` template attributes.
 | `lvt-fx:scroll` | Scroll behavior | `lvt-fx:scroll="bottom"` |
 | `lvt-fx:highlight` | Highlight effect | `lvt-fx:highlight="flash"` |
 | `lvt-fx:animate` | Entrance animation | `lvt-fx:animate="fade"` |
-| `lvt-scroll-away` | Show/hide based on scroll position | `lvt-scroll-away="bottom"` |
 
 Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`, `--lvt-scroll-threshold`, `--lvt-highlight-color`, `--lvt-highlight-duration`, `--lvt-animate-duration`. DOM event triggers resolve `data-lvt-target` to apply effects to a different element.
+
+### Standalone Directive Attributes
+
+| Attribute | Description | Example |
+|-----------|-------------|---------|
+| `lvt-scroll-sentinel` | Infinite-scroll trigger (IntersectionObserver sends hardcoded `load_more` action) | `<div lvt-scroll-sentinel>` |
+| `lvt-scroll-away` | Show/hide based on scroll position | `lvt-scroll-away="bottom"` |
 
 ### Upload Attributes
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -614,7 +614,7 @@ Control scroll behavior after DOM updates.
 </div>
 
 <!-- Sticky scroll (only if user is near bottom) -->
-<div lvt-fx:scroll="bottom-sticky" style="--lvt-scroll-threshold: 100px">
+<div lvt-fx:scroll="bottom-sticky" style="--lvt-scroll-threshold: 100">
     {{range .Logs}}
         <div>{{.}}</div>
     {{end}}
@@ -631,9 +631,9 @@ Control scroll behavior after DOM updates.
 |-----------|-------------|
 | `lvt-fx:scroll` | Scroll mode: `bottom`, `bottom-sticky`, `top`, `preserve` |
 | `--lvt-scroll-behavior` | CSS custom property: `auto` (default), `smooth` |
-| `--lvt-scroll-threshold` | CSS custom property: pixel threshold for sticky scroll (default: 100px) |
+| `--lvt-scroll-threshold` | CSS custom property: pixel threshold for sticky scroll (default: `100`). Parsed as an integer; `px` suffix is accepted but optional |
 
-**`bottom-sticky` first-run behavior:** On the first encounter (fresh element), `bottom-sticky` scrolls to bottom unconditionally with `behavior: "instant"`. Subsequent updates only scroll if the user is within the threshold. Use `data-key` on the scrollable element to reset this when content changes (e.g., switching chat sessions).
+**`bottom-sticky` first-run behavior:** On the first encounter (fresh element), `bottom-sticky` scrolls to bottom unconditionally using `scrollTo()` with `behavior: "instant"` (a [valid Web API value](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo) that jumps without animation). Subsequent updates only scroll if the user is within the threshold. Use `data-key` on the scrollable element to reset this when content changes (e.g., switching chat sessions).
 
 ### Highlight Directives
 
@@ -698,7 +698,9 @@ Apply entrance animations to elements.
 <div lvt-fx:animate:on:click="fade">Click to animate</div>
 ```
 
-**Target resolution:** DOM event triggers resolve `data-lvt-target` before applying the effect. This lets a button control a different element:
+#### Target Resolution
+
+DOM event triggers resolve `data-lvt-target` before applying the effect. This lets a button control a different element:
 
 ```html
 <button lvt-fx:scroll:on:click="bottom"
@@ -706,7 +708,29 @@ Apply entrance animations to elements.
         aria-label="Scroll to bottom">↓</button>
 ```
 
-The button scrolls `#chat-log` to the bottom on click. Without `data-lvt-target`, the effect applies to the trigger element itself. Supports `#id` and `closest:selector` resolution (same as reactive attributes).
+The button scrolls `#chat-log` to the bottom on click. Without `data-lvt-target`, the effect applies to the trigger element itself. `data-lvt-target` supports `#id` and `closest:selector` resolution.
+
+`data-lvt-target` is also used by [`lvt-scroll-away`](#scroll-away-visibility) to identify which scrollable container to observe.
+
+### Scroll Sentinel (Infinite Scroll)
+
+Triggers a `load_more` action when the element scrolls into view, enabling infinite scroll without custom JavaScript. Uses an IntersectionObserver internally.
+
+```html
+{{if .HasMore}}
+<div lvt-scroll-sentinel data-key="sentinel">
+  <small aria-busy="true">Loading older messages…</small>
+</div>
+{{end}}
+```
+
+| Attribute | Description |
+|-----------|-------------|
+| `lvt-scroll-sentinel` | Marks the element as an infinite-scroll trigger. When it enters the viewport, the client sends a `load_more` action to the server |
+
+The server handler (e.g., `LoadMore()`) increments a page counter and returns more items. Conditionally render the sentinel with `{{if .HasMore}}` so it disappears when all items are loaded. The observer automatically cascades — if the sentinel is still visible after new items load, it fires again.
+
+The `data-key="sentinel"` ensures stable identity across re-renders so morphdom patches correctly when surrounding content changes.
 
 ### Scroll-Away Visibility
 
@@ -723,10 +747,10 @@ Show or hide an element based on scroll position of a target container. When the
 | Attribute | Description |
 |-----------|-------------|
 | `lvt-scroll-away` | Edge to watch: `bottom` |
-| `data-lvt-target` | Scrollable container to observe (required) |
-| `--lvt-scroll-threshold` | CSS custom property: pixel distance from edge to toggle visibility (default: 200) |
+| `data-lvt-target` | Scrollable container to observe (required). See [Target Resolution](#target-resolution) |
+| `--lvt-scroll-threshold` | CSS custom property: pixel distance from edge to toggle visibility (default: `200`). Same property as `lvt-fx:scroll` but applied independently per element. Parsed as an integer; `px` suffix is accepted but optional |
 
-The element starts hidden. CSS controls the visual:
+The directive toggles a `visible` class on the element — your CSS controls the actual show/hide:
 
 ```css
 .scroll-bottom-btn { display: none; }

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -633,6 +633,8 @@ Control scroll behavior after DOM updates.
 | `--lvt-scroll-behavior` | CSS custom property: `auto` (default), `smooth` |
 | `--lvt-scroll-threshold` | CSS custom property: pixel threshold for sticky scroll (default: 100px) |
 
+**`bottom-sticky` first-run behavior:** On the first encounter (fresh element), `bottom-sticky` scrolls to bottom unconditionally with `behavior: "instant"`. Subsequent updates only scroll if the user is within the threshold. Use `data-key` on the scrollable element to reset this when content changes (e.g., switching chat sessions).
+
 ### Highlight Directives
 
 Temporarily highlight elements after updates.
@@ -694,6 +696,49 @@ Apply entrance animations to elements.
 <div lvt-fx:highlight:on:click="flash">Click to highlight</div>
 <div lvt-fx:highlight:on:mouseenter="flash">Hover to highlight</div>
 <div lvt-fx:animate:on:click="fade">Click to animate</div>
+```
+
+**Target resolution:** DOM event triggers resolve `data-lvt-target` before applying the effect. This lets a button control a different element:
+
+```html
+<button lvt-fx:scroll:on:click="bottom"
+        data-lvt-target="#chat-log"
+        aria-label="Scroll to bottom">↓</button>
+```
+
+The button scrolls `#chat-log` to the bottom on click. Without `data-lvt-target`, the effect applies to the trigger element itself. Supports `#id` and `closest:selector` resolution (same as reactive attributes).
+
+### Scroll-Away Visibility
+
+Show or hide an element based on scroll position of a target container. When the user scrolls away from the specified edge beyond a threshold, the element gains a `visible` class; when they return, it's removed.
+
+```html
+<button class="scroll-bottom-btn"
+        lvt-scroll-away="bottom"
+        data-lvt-target="#chat-log"
+        style="--lvt-scroll-threshold: 200"
+        aria-label="Scroll to bottom">↓</button>
+```
+
+| Attribute | Description |
+|-----------|-------------|
+| `lvt-scroll-away` | Edge to watch: `bottom` |
+| `data-lvt-target` | Scrollable container to observe (required) |
+| `--lvt-scroll-threshold` | CSS custom property: pixel distance from edge to toggle visibility (default: 200) |
+
+The element starts hidden. CSS controls the visual:
+
+```css
+.scroll-bottom-btn { display: none; }
+.scroll-bottom-btn.visible { display: flex; }
+```
+
+Pairs naturally with `lvt-fx:scroll:on:click="bottom"` on the same element:
+
+```html
+<button lvt-fx:scroll:on:click="bottom"
+        lvt-scroll-away="bottom"
+        data-lvt-target="#chat-log">↓</button>
 ```
 
 ---
@@ -946,8 +991,9 @@ Complete reference of all `lvt-*` and `data-*` template attributes.
 | `lvt-fx:scroll` | Scroll behavior | `lvt-fx:scroll="bottom"` |
 | `lvt-fx:highlight` | Highlight effect | `lvt-fx:highlight="flash"` |
 | `lvt-fx:animate` | Entrance animation | `lvt-fx:animate="fade"` |
+| `lvt-scroll-away` | Show/hide based on scroll position | `lvt-scroll-away="bottom"` |
 
-Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`, `--lvt-scroll-threshold`, `--lvt-highlight-color`, `--lvt-highlight-duration`, `--lvt-animate-duration`.
+Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`, `--lvt-scroll-threshold`, `--lvt-highlight-color`, `--lvt-highlight-duration`, `--lvt-animate-duration`. DOM event triggers resolve `data-lvt-target` to apply effects to a different element.
 
 ### Upload Attributes
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -635,6 +635,8 @@ Control scroll behavior after DOM updates.
 
 **`bottom-sticky` first-run behavior:** On the first encounter (fresh element), `bottom-sticky` scrolls to bottom unconditionally using `scrollTo()` with `behavior: "instant"` (a [valid Web API value](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo) that jumps without animation). Subsequent updates only scroll if the user is within the threshold. Use `data-key` on the scrollable element to reset this when content changes (e.g., switching chat sessions).
 
+> `data-lvt-target` resolution for scroll effects triggered by DOM events is described in [Target Resolution](#target-resolution).
+
 ### Highlight Directives
 
 Temporarily highlight elements after updates.

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -708,7 +708,7 @@ DOM event triggers resolve `data-lvt-target` before applying the effect. This le
         aria-label="Scroll to bottom">↓</button>
 ```
 
-The button scrolls `#chat-log` to the bottom on click. Without `data-lvt-target`, the effect applies to the trigger element itself. `data-lvt-target` supports `#id` and `closest:selector` resolution.
+The button scrolls `#chat-log` to the bottom on click. Without `data-lvt-target`, the effect applies to the trigger element itself. `data-lvt-target` supports `#id` resolution and `closest:selector` (walks up the DOM from the trigger element, equivalent to `element.closest(selector)`).
 
 `data-lvt-target` is also used by [`lvt-scroll-away`](#scroll-away-visibility) to identify which scrollable container to observe.
 
@@ -730,7 +730,7 @@ Triggers a `load_more` action when the element scrolls into view, enabling infin
 
 The action name `load_more` is hardcoded and not configurable. It maps to a `LoadMore()` handler on the server via livetemplate's standard snake_case-to-PascalCase action routing. The handler increments a page counter and returns more items. Conditionally render the sentinel with `{{if .HasMore}}` so it disappears when all items are loaded. The observer automatically cascades — if the sentinel is still visible after new items load, it fires again.
 
-The `data-key="sentinel"` ensures stable identity across re-renders so morphdom patches correctly when surrounding content changes.
+The `data-key="sentinel"` ensures stable identity across re-renders so morphdom patches correctly when surrounding content changes. One sentinel per page is the expected use case — the action name is not configurable.
 
 ### Scroll-Away Visibility
 
@@ -748,7 +748,7 @@ Show or hide an element based on scroll position of a target container. When the
 |-----------|-------------|
 | `lvt-scroll-away` | Edge to watch: `bottom` |
 | `data-lvt-target` | Scrollable container to observe (required). See [Target Resolution](#target-resolution) |
-| `--lvt-scroll-threshold` | CSS custom property: pixel distance from edge to toggle visibility (default: `200`, vs `100` for `lvt-fx:scroll`). Same property name, applied independently per element. Parsed as an integer; `px` suffix is accepted but optional |
+| `--lvt-scroll-threshold` | CSS custom property: pixel distance from edge to toggle visibility (default: `200`). The CSS property is read independently by each directive — `lvt-fx:scroll` defaults to `100` and `lvt-scroll-away` defaults to `200` when the property is absent. Parsed as an integer; `px` suffix is accepted but optional |
 
 The directive toggles a `visible` class on the element — your CSS controls the actual show/hide:
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -726,7 +726,7 @@ Triggers a `load_more` action when the element scrolls into view, enabling infin
 
 | Attribute | Description |
 |-----------|-------------|
-| `lvt-scroll-sentinel` | Marks the element as an infinite-scroll trigger. When it enters the viewport, the client sends a `load_more` action to the server |
+| `lvt-scroll-sentinel` | Marks the element as an infinite-scroll trigger. When it enters the viewport, the client sends a hardcoded `load_more` action to the server (maps to a `LoadMore()` handler) |
 
 The server handler (e.g., `LoadMore()`) increments a page counter and returns more items. Conditionally render the sentinel with `{{if .HasMore}}` so it disappears when all items are loaded. The observer automatically cascades — if the sentinel is still visible after new items load, it fires again.
 
@@ -748,7 +748,7 @@ Show or hide an element based on scroll position of a target container. When the
 |-----------|-------------|
 | `lvt-scroll-away` | Edge to watch: `bottom` |
 | `data-lvt-target` | Scrollable container to observe (required). See [Target Resolution](#target-resolution) |
-| `--lvt-scroll-threshold` | CSS custom property: pixel distance from edge to toggle visibility (default: `200`). Same property as `lvt-fx:scroll` but applied independently per element. Parsed as an integer; `px` suffix is accepted but optional |
+| `--lvt-scroll-threshold` | CSS custom property: pixel distance from edge to toggle visibility (default: `200`, vs `100` for `lvt-fx:scroll`). Same property name, applied independently per element. Parsed as an integer; `px` suffix is accepted but optional |
 
 The directive toggles a `visible` class on the element — your CSS controls the actual show/hide:
 

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -126,6 +126,7 @@ Compose multiple `lvt-*` attributes for a chat UI with upward infinite scroll, a
 <div class="chat-scroll-wrap">
   <div class="chat-log" id="chat-log" lvt-fx:scroll="bottom-sticky"
        style="--lvt-scroll-threshold: 80" data-key="chat-{{.SessionID}}">
+       <!-- threshold 80: scroll more eagerly than the default 100 -->
     {{if .HasMore}}
     <div lvt-scroll-sentinel data-key="sentinel">
       <small aria-busy="true">Loading older messages…</small>

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -124,9 +124,9 @@ Compose multiple `lvt-*` attributes for a chat UI with upward infinite scroll, a
 
 ```html
 <div class="chat-scroll-wrap">
+  <!-- threshold 80: scroll more eagerly than the default 100 -->
   <div class="chat-log" id="chat-log" lvt-fx:scroll="bottom-sticky"
        style="--lvt-scroll-threshold: 80" data-key="chat-{{.SessionID}}">
-       <!-- threshold 80: scroll more eagerly than the default 100 -->
     {{if .HasMore}}
     <div lvt-scroll-sentinel data-key="sentinel">
       <small aria-busy="true">Loading older messages…</small>

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -113,7 +113,7 @@ Some `lvt-*` attributes are standalone (not prefixed):
 
 | Attribute | Purpose | Example |
 |---|---|---|
-| `lvt-scroll-sentinel` | Infinite scroll trigger | `<div lvt-scroll-sentinel>Loading…</div>` |
+| `lvt-scroll-sentinel` | Infinite scroll trigger | `<div lvt-scroll-sentinel data-key="sentinel">Loading…</div>` |
 | `lvt-scroll-away` | Scroll-position visibility | `<button lvt-scroll-away="bottom" data-lvt-target="#log">↓</button>` |
 
 See the [Client Attributes Reference](client-attributes.md) for the complete listing.

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -157,4 +157,4 @@ How the attributes compose:
 | `lvt-scroll-away="bottom"` | Shows button only when scrolled away from bottom |
 | `data-key` on chat-log | Session switches replace the element, resetting the sticky scroll marker |
 
-Backend: `LoadMore()` increments a page counter; the handler slices messages from the tail of the full list. `lvt-scroll-sentinel` is conditionally rendered with `{{if .HasMore}}` to stop loading when all messages are shown.
+Backend: `LoadMore()` increments a page counter; the handler returns the most recent `page × N` messages from the full log (growing the visible window upward). `lvt-scroll-sentinel` is conditionally rendered with `{{if .HasMore}}` to stop loading when all messages are shown.

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -110,3 +110,43 @@ For behaviors that standard HTML cannot express — timing control, reactive DOM
 | `lvt-form:` | Form behavior | `lvt-form:preserve`, `lvt-form:disable-with="Saving..."` |
 
 See the [Client Attributes Reference](client-attributes.md) for the complete listing.
+
+### Recipe: Chat with Infinite Scroll
+
+Compose multiple `lvt-*` attributes for a chat UI with upward infinite scroll, auto-scroll on new messages, and a scroll-to-bottom button — all without custom JavaScript:
+
+```html
+<div class="chat-scroll-wrap">
+  <div class="chat-log" id="chat-log" lvt-fx:scroll="bottom-sticky"
+       style="--lvt-scroll-threshold: 80;" data-key="chat-{{.SessionID}}">
+    {{if .HasMore}}
+    <div lvt-scroll-sentinel data-key="sentinel">
+      <small aria-busy="true">Loading older messages…</small>
+    </div>
+    {{end}}
+    {{range .Messages}}
+    <div class="chat-row {{.Role}}" data-key="{{.Key}}">
+      <div class="chat-bubble">{{.Text}}</div>
+    </div>
+    {{end}}
+  </div>
+  <button type="button" class="scroll-bottom-btn"
+          lvt-fx:scroll:on:click="bottom"
+          lvt-scroll-away="bottom"
+          data-lvt-target="#chat-log"
+          aria-label="Scroll to bottom">↓</button>
+</div>
+```
+
+How the attributes compose:
+
+| Attribute | Role |
+|-----------|------|
+| `lvt-fx:scroll="bottom-sticky"` | Auto-scrolls on new messages if user is near bottom; scrolls to bottom on first load |
+| `lvt-scroll-sentinel` | IntersectionObserver triggers `LoadMore()` when sentinel enters viewport |
+| `data-key` on rows | Differential DOM updates — only new/changed rows are sent over the wire |
+| `lvt-fx:scroll:on:click="bottom"` | Scrolls target to bottom on button click |
+| `lvt-scroll-away="bottom"` | Shows button only when scrolled away from bottom |
+| `data-key` on chat-log | Session switches replace the element, resetting the sticky scroll marker |
+
+Backend: `LoadMore()` increments a page counter; the handler slices messages from the tail of the full list. `lvt-scroll-sentinel` is conditionally rendered with `{{if .HasMore}}` to stop loading when all messages are shown.

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -109,6 +109,13 @@ For behaviors that standard HTML cannot express — timing control, reactive DOM
 | `lvt-mod:` | Event modifiers | `lvt-mod:debounce="300"`, `lvt-mod:throttle="100"` |
 | `lvt-form:` | Form behavior | `lvt-form:preserve`, `lvt-form:disable-with="Saving..."` |
 
+Some `lvt-*` attributes are standalone (not prefixed):
+
+| Attribute | Purpose | Example |
+|---|---|---|
+| `lvt-scroll-sentinel` | Infinite scroll trigger | `<div lvt-scroll-sentinel>Loading…</div>` |
+| `lvt-scroll-away` | Scroll-position visibility | `<button lvt-scroll-away="bottom" data-lvt-target="#log">↓</button>` |
+
 See the [Client Attributes Reference](client-attributes.md) for the complete listing.
 
 ### Recipe: Chat with Infinite Scroll
@@ -118,7 +125,7 @@ Compose multiple `lvt-*` attributes for a chat UI with upward infinite scroll, a
 ```html
 <div class="chat-scroll-wrap">
   <div class="chat-log" id="chat-log" lvt-fx:scroll="bottom-sticky"
-       style="--lvt-scroll-threshold: 80;" data-key="chat-{{.SessionID}}">
+       style="--lvt-scroll-threshold: 80" data-key="chat-{{.SessionID}}">
     {{if .HasMore}}
     <div lvt-scroll-sentinel data-key="sentinel">
       <small aria-busy="true">Loading older messages…</small>


### PR DESCRIPTION
## Summary

- Document `data-lvt-target` resolution for `lvt-fx:scroll:on:{event}` — enables a button to scroll a different element
- Add new `lvt-scroll-away` section — scroll-position visibility toggle with `.visible` class
- Add "Chat with Infinite Scroll" recipe to progressive complexity reference showing how `bottom-sticky`, `lvt-scroll-sentinel`, `lvt-scroll-away`, and `lvt-fx:scroll:on:click` compose together

## Test plan

- [x] Docs render correctly in markdown preview
- [x] Recipe HTML matches working implementation in devbox-dash

🤖 Generated with [Claude Code](https://claude.com/claude-code)