### PR TITLE
fix: prune expired flash before render (not after sendUpdate)

### DIFF
--- a/context.go
+++ b/context.go
@@ -308,8 +308,9 @@ type flashConfig struct {
 }
 
 // FlashExpiry sets an auto-expiry duration for the flash message. After
-// the duration elapses, the message is pruned on the next action or server
-// push that triggers a render — there is no background timer. Use this for
+// the duration elapses, the message is pruned on the next render that walks
+// flash state — there is no background timer. The render that the user
+// triggers post-expiry is rendered without the expired flash. Use this for
 // transient feedback ("Settings saved") that doesn't need explicit
 // acknowledgement. Messages without an expiry persist until explicitly
 // cleared via ClearFlash.
@@ -320,10 +321,6 @@ type flashConfig struct {
 // Note: FlashExpiry has no observable effect on HTTP connections — HTTP
 // flash is inherently one-shot (per-request connSt is GC'd after the
 // handler returns) regardless of the expiry duration set here.
-//
-// Note: The expiry timer is only checked before successful renders. If
-// a connection receives only error responses after the expiry elapses,
-// the expired flash remains visible until the next successful render.
 //
 // Example:
 //

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -27,11 +27,8 @@ func flashPresent(cs *connState, key string) bool {
 }
 
 // TestExpiredFlashAbsentFromGetMessagesSnapshot verifies that getMessages
-// prunes expired flash before returning a snapshot — i.e. an expired flash
-// is NOT visible to template renderers. Regression guard: prior behavior
-// pruned only after sendUpdate, so the render that ran after expiry still
-// included the expired entry. Users observed flash that "stayed one extra
-// interaction past its 5-second deadline."
+// prunes expired flash before returning a snapshot, so renderers never see
+// an entry whose deadline has passed.
 func TestExpiredFlashAbsentFromGetMessagesSnapshot(t *testing.T) {
 	cs := newFlashState()
 	cs.setFlash("success", "Saved!", time.Hour)
@@ -198,10 +195,8 @@ func (c *flashIntegController) Increment(state flashIntegState, ctx *Context) (f
 	return state, nil
 }
 
-// transientFlashExpiry is the deadline used by SetTransientFlash. Long enough
-// that step 1's own render (which now runs pruneExpiredFlash before the
-// snapshot — see getMessages) reliably observes the flash as still-live, and
-// short enough that subsequent test steps can sleep past it cheaply.
+// Long enough for step 1's render to observe the flash as live; short enough
+// for subsequent steps to sleep past it cheaply.
 const transientFlashExpiry = 100 * time.Millisecond
 
 func (c *flashIntegController) SetTransientFlash(state flashIntegState, ctx *Context) (flashIntegState, error) {

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -26,6 +26,28 @@ func flashPresent(cs *connState, key string) bool {
 	return ok
 }
 
+// TestExpiredFlashAbsentFromGetMessagesSnapshot verifies that getMessages
+// prunes expired flash before returning a snapshot — i.e. an expired flash
+// is NOT visible to template renderers. Regression guard: prior behavior
+// pruned only after sendUpdate, so the render that ran after expiry still
+// included the expired entry. Users observed flash that "stayed one extra
+// interaction past its 5-second deadline."
+func TestExpiredFlashAbsentFromGetMessagesSnapshot(t *testing.T) {
+	cs := newFlashState()
+	cs.setFlash("success", "Saved!", time.Hour)
+	if !flashPresent(cs, "success") {
+		t.Fatal("flash not set")
+	}
+	// Backdate the deadline to simulate expiry having elapsed since SetFlash.
+	cs.flashExpiry["success"] = time.Now().Add(-1 * time.Second)
+
+	// getMessages must NOT include the expired entry — it prunes before
+	// snapshotting so the next render walks a clean slate.
+	if flashPresent(cs, "success") {
+		t.Error("expired flash present in getMessages snapshot, want it pruned")
+	}
+}
+
 // TestFlashPersistsAcrossRenders verifies that non-expiry flash survives
 // repeated pruneExpiredFlash calls. This guards against the regression where
 // background Refresh ticks cleared flash by calling the old clearFlash()

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -198,8 +198,14 @@ func (c *flashIntegController) Increment(state flashIntegState, ctx *Context) (f
 	return state, nil
 }
 
+// transientFlashExpiry is the deadline used by SetTransientFlash. Long enough
+// that step 1's own render (which now runs pruneExpiredFlash before the
+// snapshot — see getMessages) reliably observes the flash as still-live, and
+// short enough that subsequent test steps can sleep past it cheaply.
+const transientFlashExpiry = 100 * time.Millisecond
+
 func (c *flashIntegController) SetTransientFlash(state flashIntegState, ctx *Context) (flashIntegState, error) {
-	ctx.SetFlash("status", "transient", FlashExpiry(time.Millisecond))
+	ctx.SetFlash("status", "transient", FlashExpiry(transientFlashExpiry))
 	return state, nil
 }
 
@@ -212,24 +218,26 @@ func (c *flashIntegController) ClearFlashAction(state flashIntegState, ctx *Cont
 	return state, nil
 }
 
-// TestFlashExpiryNotPrunedOnErrorRender verifies the "success-path-only"
-// pruning invariant: when an action returns an error, pruneExpiredFlash is
-// NOT called, so expired flash survives the error render and persists until
-// the next SUCCESSFUL render.
+// TestFlashExpiryPrunedBeforeErrorRender verifies that an expired flash is
+// removed before the error render's tree is built — the deadline fires whether
+// or not the next action succeeds.
+//
+// Earlier behaviour preserved expired flash across error paths (pruneExpiredFlash
+// was guarded by actionErr == nil), so an expired flash survived the error
+// render and disappeared only on the next successful one. The current
+// invariant — pruning at the getMessages boundary — runs uniformly for every
+// render and matches user intent: an explicit timeout fires when it elapses.
 //
 // Test flow:
-//  1. "SetTransientFlash" sets flash "status"="transient" with 1ms expiry.
-//     The first render includes slot 0 = "transient".
-//  2. Sleep 10ms to guarantee the 1ms expiry has elapsed.
-//  3. "FailAction" returns an error → error render (meta.success=false).
-//     pruneExpiredFlash is NOT called, so flash stays in connSt.messages.
-//  4. "Increment" succeeds → render. Flash is still "transient" (unchanged
-//     from the error render in step 3), so slot 0 is ABSENT from the diff.
-//     If flash were pruned in step 3, slot 0 would appear as "" (changed).
-//
-// This test catches a regression where pruneExpiredFlash is called
-// unconditionally after every render instead of only on success renders.
-func TestFlashExpiryNotPrunedOnErrorRender(t *testing.T) {
+//  1. "SetTransientFlash" sets flash with FlashExpiry(transientFlashExpiry).
+//     The first render's tree slot 0 = "transient" (deadline still in the future).
+//  2. Sleep past the deadline.
+//  3. "FailAction" returns an error. The error render's getMessages prunes the
+//     expired flash; slot 0 in the error tree must show as "" (a change from
+//     "transient" → "", positively asserting the prune fired).
+//  4. "Increment" succeeds. Flash was already evicted in step 3, so slot 0 in
+//     the success tree is ABSENT (no change to emit).
+func TestFlashExpiryPrunedBeforeErrorRender(t *testing.T) {
 	tmpl, err := New("test")
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -253,7 +261,7 @@ func TestFlashExpiryNotPrunedOnErrorRender(t *testing.T) {
 		}
 	}()
 
-	// Step 1: Set transient flash with 1ms expiry.
+	// Step 1: Set transient flash; first render carries slot 0 = "transient".
 	sendWSAction(t, ws, "SetTransientFlash", nil)
 	resp1 := readWSUpdate(t, ws, 2*time.Second)
 	tree1, ok := resp1["tree"].(map[string]any)
@@ -264,24 +272,35 @@ func TestFlashExpiryNotPrunedOnErrorRender(t *testing.T) {
 		t.Fatalf("SetTransientFlash: flash slot = %q, want %q", v, "transient")
 	}
 
-	// Step 2: Wait for the 1ms expiry to definitely elapse.
-	time.Sleep(10 * time.Millisecond)
+	// Step 2: Wait past the deadline.
+	time.Sleep(transientFlashExpiry + 50*time.Millisecond)
 
-	// Step 3: Trigger an error render. pruneExpiredFlash must NOT fire here.
+	// Step 3: Error render. getMessages prunes before snapshotting, so the
+	// error tree must show slot 0 as "" — positive evidence that the prune
+	// fired on the error path. Without the new invariant, slot 0 would be
+	// absent (unchanged "transient").
 	sendWSAction(t, ws, "FailAction", nil)
 	respErr := readWSUpdate(t, ws, 2*time.Second)
-	meta, ok := respErr["meta"].(map[string]interface{})
+	meta, ok := respErr["meta"].(map[string]any)
 	if !ok {
 		t.Fatalf("FailAction response has no meta: %#v", respErr)
 	}
 	if success, _ := meta["success"].(bool); success {
 		t.Fatalf("FailAction: meta.success = true, want false")
 	}
+	tree3, ok := respErr["tree"].(map[string]any)
+	if !ok {
+		t.Fatalf("FailAction response has no tree: %#v", respErr)
+	}
+	flashVal3, present3 := tree3["0"]
+	if !present3 {
+		t.Errorf("error render did not emit slot 0 — expected slot 0 = %q (transient → \"\" after expiry pruned in error render's getMessages)", "")
+	} else if v := fmt.Sprintf("%v", flashVal3); v != "" {
+		t.Errorf("error render slot 0 = %q, want %q (flash should be pruned to empty)", v, "")
+	}
 
-	// Step 4: Succeed action. Flash survives because step 3 did not prune it.
-	// Slot 0 must be ABSENT (flash unchanged: "transient" in both step 3 and step 4
-	// renders). If pruneExpiredFlash had fired in step 3, flash would be "" here —
-	// a change from "transient" — and slot 0 would appear in the diff.
+	// Step 4: Success render. Flash was already evicted in step 3, so slot 0
+	// is unchanged ("" → "") — no diff entry.
 	sendWSAction(t, ws, "Increment", nil)
 	resp4 := readWSUpdate(t, ws, 2*time.Second)
 	tree4, ok := resp4["tree"].(map[string]any)
@@ -289,7 +308,7 @@ func TestFlashExpiryNotPrunedOnErrorRender(t *testing.T) {
 		t.Fatalf("Increment response has no tree: %#v", resp4)
 	}
 	if flashVal, present := tree4["0"]; present {
-		t.Errorf("flash slot appeared in diff after error render: got %q — pruneExpiredFlash was incorrectly called on the error render (flash should survive until the next successful render)", flashVal)
+		t.Errorf("success render emitted slot 0 = %q, want absent (flash was already evicted in step 3)", flashVal)
 	}
 }
 
@@ -453,13 +472,18 @@ func TestFlashSurvivesNavigateAction(t *testing.T) {
 // ctx.SetFlash(key, msg, FlashExpiry(d)) through the event loop to the diff
 // engine. Unit tests in this file call connState.setFlash() directly; this
 // test verifies that FlashExpiry flows correctly through the public API and
-// that pruneExpiredFlash removes the flash entry before the next render.
+// that pruneExpiredFlash removes the flash entry before the snapshot used for
+// the next render.
 //
 // Test flow:
-//  1. "SetTransientFlash" action sets flash "status"="transient" with 1ms expiry.
-//     The first render includes slot 0 = "transient".
-//  2. After the 1ms expiry elapses, "Increment" changes state (Counter 0→1).
-//     pruneExpiredFlash removes the lapsed flash; slot 0 is absent from the diff.
+//  1. "SetTransientFlash" action sets flash "status"="transient" via the
+//     public ctx.SetFlash(..., FlashExpiry(d)) API. The first render includes
+//     slot 0 = "transient".
+//  2. After the deadline elapses, "Increment" changes state (Counter 0→1).
+//     getMessages prunes the lapsed flash before snapshotting, so slot 0
+//     changes from "transient" → "" in the second diff. The test asserts the
+//     change is positively emitted (slot 0 = ""), proving the public API
+//     wired the expiry through to the prune path.
 func TestFlashExpiryThroughPublicAPI(t *testing.T) {
 	tmpl, err := New("test")
 	if err != nil {
@@ -495,21 +519,23 @@ func TestFlashExpiryThroughPublicAPI(t *testing.T) {
 		t.Fatalf("SetTransientFlash: flash slot = %q, want %q", v, "transient")
 	}
 
-	// Step 2: Increment — Counter changes (0→1), expiry has elapsed.
-	// Sleep 10ms to guarantee the 1ms expiry has elapsed even on a loaded CI
-	// machine under -race; the WS round-trip alone is usually sufficient, but
-	// 10x margin makes the test reliable without a meaningful slowdown.
-	time.Sleep(10 * time.Millisecond)
-	// pruneExpiredFlash removes the lapsed flash before the render,
-	// so slot 0 must be absent from the diff.
+	// Step 2: Sleep past the deadline, then Increment. Counter changes 0→1,
+	// AND the expired flash is pruned in getMessages before the second
+	// render's snapshot is taken. The diff must include slot 0 = "" — the
+	// transition from "transient" to empty proves the prune fired through
+	// the public API.
+	time.Sleep(transientFlashExpiry + 50*time.Millisecond)
 	sendWSAction(t, ws, "Increment", nil)
 	resp2 := readWSUpdate(t, ws, 2*time.Second)
 	tree2, ok := resp2["tree"].(map[string]any)
 	if !ok {
 		t.Fatalf("Increment response has no tree: %#v", resp2)
 	}
-	if flashVal, present := tree2["0"]; present {
-		t.Errorf("flash slot present after 1ms expiry: got %q — FlashExpiry not enforced through public ctx.SetFlash API", flashVal)
+	flashVal, present := tree2["0"]
+	if !present {
+		t.Errorf("flash slot absent in second render — expected slot 0 = %q (transient → empty after FlashExpiry fired through public ctx.SetFlash API)", "")
+	} else if v := fmt.Sprintf("%v", flashVal); v != "" {
+		t.Errorf("flash slot = %q in second render, want %q (FlashExpiry should have pruned it to empty)", v, "")
 	}
 }
 

--- a/mount.go
+++ b/mount.go
@@ -202,12 +202,11 @@ func (c *connState) clearErrors() {
 }
 
 func (c *connState) getMessages() map[string]string {
-	// Prune expired flash before snapshotting so callers (template renderers)
-	// don't see entries whose deadline has passed. Previously prune ran *after*
-	// each successful sendUpdate, which meant an expired flash got one final
-	// render before being evicted — visible to users as "the success message
-	// stayed one extra interaction past its 5-second expiry." Pruning at the
-	// snapshot boundary aligns getMessages with the FlashExpiry doc contract.
+	// Prune at the snapshot boundary so renderers never see an expired entry.
+	// The expiry then fires in the render that follows the deadline rather than
+	// one render later (the previous post-sendUpdate prune leaked one extra
+	// frame, visible to users as "the success message stayed one extra
+	// interaction past its 5-second deadline").
 	c.pruneExpiredFlash()
 
 	c.messagesMu.RLock()

--- a/mount.go
+++ b/mount.go
@@ -202,6 +202,14 @@ func (c *connState) clearErrors() {
 }
 
 func (c *connState) getMessages() map[string]string {
+	// Prune expired flash before snapshotting so callers (template renderers)
+	// don't see entries whose deadline has passed. Previously prune ran *after*
+	// each successful sendUpdate, which meant an expired flash got one final
+	// render before being evicted — visible to users as "the success message
+	// stayed one extra interaction past its 5-second expiry." Pruning at the
+	// snapshot boundary aligns getMessages with the FlashExpiry doc contract.
+	c.pruneExpiredFlash()
+
 	c.messagesMu.RLock()
 	defer c.messagesMu.RUnlock()
 
@@ -801,15 +809,6 @@ eventLoop:
 					slog.String("component", "live_handler"),
 					slog.Any("error", err))
 				break eventLoop
-			}
-
-			// Prune flash messages whose expiry has elapsed; non-expiry flash
-			// persists until ClearFlash is called. Guarded by actionErr == nil
-			// so error renders (validation errors, method-not-found, etc.) do
-			// NOT prune expiry flash — expired entries survive until the next
-			// successful render (non-expiry flash is unaffected by error paths).
-			if actionErr == nil {
-				connSt.pruneExpiredFlash()
 			}
 
 		case req := <-connection.DispatchChan:
@@ -1559,9 +1558,6 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 			slog.String("action", req.Action),
 			slog.Any("error", err))
 	}
-
-	// Only reached on dispatch success (err != nil returns early above).
-	connSt.pruneExpiredFlash()
 }
 
 // httpTemplateSweepLoop periodically removes cached HTTP templates to prevent
@@ -1932,9 +1928,6 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 			errCount++
 			continue
 		}
-
-		// Only reached after sendUpdate succeeds (continue on error above).
-		state.pruneExpiredFlash()
 	}
 
 	// Persist once per distinct groupID (avoids N writes for multi-tab users
@@ -2443,10 +2436,6 @@ func (h *liveHandler) handleUploadComplete(ctx context.Context, conn WSConn, raw
 			slog.Any("error", err))
 		return nil // Don't fail the upload, just skip the update
 	}
-
-	// Prune flash messages whose expiry has elapsed; non-expiry flash
-	// persists until ClearFlash is called.
-	state.pruneExpiredFlash()
 
 	// Dispatch Sync to peer connections for upload completion visibility
 	h.dispatchBroadcastToGroup(state.groupID, connection, syncMethodName, nil)

--- a/mount.go
+++ b/mount.go
@@ -202,11 +202,7 @@ func (c *connState) clearErrors() {
 }
 
 func (c *connState) getMessages() map[string]string {
-	// Prune at the snapshot boundary so renderers never see an expired entry.
-	// The expiry then fires in the render that follows the deadline rather than
-	// one render later (the previous post-sendUpdate prune leaked one extra
-	// frame, visible to users as "the success message stayed one extra
-	// interaction past its 5-second deadline").
+	// Prune before snapshot so renderers never observe expired entries.
 	c.pruneExpiredFlash()
 
 	c.messagesMu.RLock()


### PR DESCRIPTION
## Summary

- `FlashExpiry(d)` documented the message is pruned "on the next render that triggers" — but `pruneExpiredFlash` actually ran *after* each successful `sendUpdate`, so an expired flash got one extra render before being evicted from `connState`. Users observed flash that "stayed one extra interaction past the 5-second deadline."
- Move the prune into `getMessages` — the single funnel all template renderers go through — so the action's own render reflects the expiry. Remove the four post-`sendUpdate` calls (WS, broadcast, pubsub group, upload completion).
- Side effect: error renders now also prune. The old code guarded the WS prune with `actionErr == nil`. New behavior: an explicit timeout fires whether or not the next action succeeds — matches user intent for a deadline.

Surfaced while implementing the `Flash Messages / Toasts` pattern in livetemplate/examples Session 5: a 5s auto-expire demo couldn't deliver on its pitch — the next click after expiry still rendered the success flash one final time.

## Test plan

- [x] `TestExpiredFlashAbsentFromGetMessagesSnapshot` (new regression test) — verifies `getMessages()` prunes before snapshotting
- [x] Existing flash tests (`TestFlashPersistsAcrossRenders`, `TestFlashExpiryPrunesAfterDeadline`, `TestFlashSurvivesSubsequentWSAction`, `TestFlashSurvivesNavigateAction`, `TestFlashExpiryThroughPublicAPI`, `TestClearFlashThroughPublicAPI`, etc.) — all pass
- [x] Library full suite: `go test ./...` — green
- [x] Library race: `go test -race -run TestFlash .` — green
- [ ] After release: bump `go.mod` in `livetemplate/examples` Session 5 PR and re-verify the demo's "Save → wait 5s → success disappears on first interaction" works as advertised

🤖 Generated with [Claude Code](https://claude.com/claude-code)