### PR TITLE
feat: streaming range Phase 1 — foundational types (no-op)

### DIFF
--- a/docs/proposals/streaming-range-impl-audit.md
+++ b/docs/proposals/streaming-range-impl-audit.md
@@ -266,7 +266,7 @@ The two shared presence-only helpers (`isComplexInsertionPatternCtx`, `areAllIte
 
 ### Phase 2 unblocked
 
-Phase 2 deliverable per proposal §11: `GenerateRangeStreamOperations(streamState *RangeStreamState, newItems []interface{}, statics interface{}, metadata map[string]interface{}, stripStatics bool) []interface{}` plus the `rangeContext.oldKeySet` field and the helper-by-helper adaptations cataloged in §10's `helpers_range.go` row + Gate 6. None of these depend on additional Phase 1 work; the foundational types are now in place.
+Phase 2 deliverable per proposal §11: `GenerateRangeStreamOperations(streamState *RangeStreamState, newItems []interface{}, statics interface{}, metadata map[string]interface{}, stripStatics bool) []interface{}` plus the `rangeContext.oldKeySet` field and the helper-by-helper adaptations cataloged across §10's full implementation table — including `range_ops.go`, `tree_compare.go`, `helpers_range.go`, `prepare.go` (the wire-format path silently drops `StreamState` today; needs `StreamState` preservation), `helpers_compare.go` (`rangeItemsEqual` compares only `Items`; two stream-mode trees differing in `StreamState.Hashes` would compare equal), `helpers_value.go` (`HasRangeItems` returns false for stream-mode trees), `keys/loader.go` (`LoadExistingKeyMappings` reads only `Items`), and the fuzz-invariant sites — plus Gate 6. None of these depend on additional Phase 1 work; the foundational types are now in place.
 
 ---
 

--- a/docs/proposals/streaming-range-impl-audit.md
+++ b/docs/proposals/streaming-range-impl-audit.md
@@ -268,6 +268,8 @@ The two shared presence-only helpers (`isComplexInsertionPatternCtx`, `areAllIte
 
 Phase 2 deliverable per proposal §11: `GenerateRangeStreamOperations(streamState *RangeStreamState, newItems []interface{}, statics interface{}, metadata map[string]interface{}, stripStatics bool) []interface{}` plus the `rangeContext.oldKeySet` field and the helper-by-helper adaptations cataloged across §10's full implementation table — including `range_ops.go`, `tree_compare.go`, `helpers_range.go`, `prepare.go` (the wire-format path silently drops `StreamState` today; needs `StreamState` preservation), `helpers_compare.go` (`rangeItemsEqual` compares only `Items`; two stream-mode trees differing in `StreamState.Hashes` would compare equal), `helpers_value.go` (`HasRangeItems` returns false for stream-mode trees), `keys/loader.go` (`LoadExistingKeyMappings` reads only `Items`), and the fuzz-invariant sites — plus Gate 6. None of these depend on additional Phase 1 work; the foundational types are now in place.
 
+**Phase 2 invariant note: `IsStreamMode()` transitional case.** The helper currently returns `false` (legacy mode wins) when `Items != nil && StreamState != nil` — a state Phase 2's StreamState producer must never create. Phase 2 should consider promoting this branch from a silent fallback to a `panic`/`log.Warn` so producer-side invariant violations surface during development rather than silently falling back to legacy emission.
+
 ---
 
 ## Audit sign-off

--- a/docs/proposals/streaming-range-impl-audit.md
+++ b/docs/proposals/streaming-range-impl-audit.md
@@ -241,13 +241,13 @@ The two shared presence-only helpers (`isComplexInsertionPatternCtx`, `areAllIte
 | File | Change |
 |---|---|
 | `internal/build/types.go` | Add `RangeStreamState` type + `RangeData.StreamState` field; preserve nil `Items` in `Clone`; add stream-mode deep-copy block in `Clone`; add omit-`"d"` guard in `MarshalJSON` and `ToMap`. |
-| `internal/build/types_test.go` | 9 new tests: `TestTreeNode_Clone_PreservesNilItems`, `TestRangeStreamState_DeepClone`, `TestTreeNode_MarshalJSON_OmitsD_StreamMode` + `_EmitsD_LegacyMode` + `_PreservesStatics_StreamMode` (regression guard against tying "s" emission to "d") + `_EmitsNullD_LegacyEmptyMode` (boundary: Items==nil && StreamState==nil preserves prior null shape), `TestTreeNode_ToMap_OmitsD_StreamMode` + `_EmitsD_LegacyMode` + `_EmitsEmptyD_LegacyEmptyMode` (ToMap parallel, preserves pre-existing "d": [] shape for the same boundary). |
+| `internal/build/types_test.go` | 10 new tests: `TestRangeData_IsStreamMode` (table-driven across legacy/legacy-empty/stream/transitional cases for the new `IsStreamMode()` helper), `TestTreeNode_Clone_PreservesNilItems`, `TestRangeStreamState_DeepClone`, `TestTreeNode_MarshalJSON_OmitsD_StreamMode` + `_EmitsD_LegacyMode` + `_PreservesStatics_StreamMode` (regression guard against tying "s" emission to "d") + `_EmitsNullD_LegacyEmptyMode` (boundary: Items==nil && StreamState==nil preserves prior null shape), `TestTreeNode_ToMap_OmitsD_StreamMode` + `_EmitsD_LegacyMode` + `_EmitsEmptyD_LegacyEmptyMode` (ToMap parallel, preserves pre-existing "d": [] shape for the same boundary). |
 | `internal/keys/hash.go` | Add `ItemHashUint64(dynamics []interface{}) uint64` after `GenerateItemHashFromSlice`. Godoc covers nil-skip + nil-vs-`""` divergence. |
 | `internal/keys/hash_test.go` | 5 new tests: `TestItemHashUint64_Deterministic`, `_NilVsEmptyString`, `_PositionMatters`, `_NilEntriesSkipped`, `_CollisionStress_NoDupesIn10k` (10k synthetic dynamics, all hashes unique). |
 
 ### Test results
 
-- **14 new tests** (9 in `types_test.go` + 5 in `hash_test.go`) — all pass.
+- **15 new tests** (10 in `types_test.go` + 5 in `hash_test.go`) — all pass.
 - **Full test suite** (`GOWORK=off go test ./...`) — green; zero regressions across the 17 internal/* packages, the root `livetemplate` package, or `pubsub`.
 - **Build sanity** — `go build` clean; pre-existing `interface{} → any` linter hints are unchanged from the base commit.
 

--- a/docs/proposals/streaming-range-impl-audit.md
+++ b/docs/proposals/streaming-range-impl-audit.md
@@ -230,6 +230,46 @@ The two shared presence-only helpers (`isComplexInsertionPatternCtx`, `areAllIte
 
 ---
 
+## Phase 1 audit checkpoint
+
+**Date:** 2026-04-29  
+**Branch:** `phase1/streaming-range-types` (worktree `.worktrees/streaming-range-phase1/`)  
+**Base commit:** `f075d7b5` (PR #361 audit-doc merge into `main`)
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `internal/build/types.go` | Add `RangeStreamState` type + `RangeData.StreamState` field; preserve nil `Items` in `Clone`; add stream-mode deep-copy block in `Clone`; add omit-`"d"` guard in `MarshalJSON` and `ToMap`. |
+| `internal/build/types_test.go` | 7 new tests: `TestTreeNode_Clone_PreservesNilItems`, `TestRangeStreamState_DeepClone`, `TestTreeNode_MarshalJSON_OmitsD_StreamMode` + `_EmitsD_LegacyMode` + `_PreservesStatics_StreamMode` (regression guard against tying "s" emission to "d"), `TestTreeNode_ToMap_OmitsD_StreamMode` + `_EmitsD_LegacyMode`. |
+| `internal/keys/hash.go` | Add `ItemHashUint64(dynamics []interface{}) uint64` after `GenerateItemHashFromSlice`. Godoc covers nil-skip + nil-vs-`""` divergence. |
+| `internal/keys/hash_test.go` | 5 new tests: `TestItemHashUint64_Deterministic`, `_NilVsEmptyString`, `_PositionMatters`, `_NilEntriesSkipped`, `_CollisionStress_NoDupesIn10k` (10k synthetic dynamics, all hashes unique). |
+
+### Test results
+
+- **12 new tests** (7 in `types_test.go` + 5 in `hash_test.go`) — all pass.
+- **Full test suite** (`GOWORK=off go test ./...`) — green; zero regressions across the 17 internal/* packages, the root `livetemplate` package, or `pubsub`.
+- **Build sanity** — `go build` clean; pre-existing `interface{} → any` linter hints are unchanged from the base commit.
+
+### Per Phase 1 audit checkpoint requirement
+
+> Per proposal §11 Phase 1 audit checkpoint: "existing test suite green (no regression); new tests assert shape-only invariants. Reviewer confirms `RangeData.Items` is still the source of truth on every render path — no caller has been switched yet."
+
+`grep -rn "StreamState" internal/ --include='*.go'` returns matches in exactly four locations, all expected:
+
+1. **Type definition** — `internal/build/types.go` (the `RangeData.StreamState` field + `RangeStreamState` struct itself).
+2. **`Clone` deep-copy block** — `internal/build/types.go` (handles the field IF present; never reached on production trees today).
+3. **`MarshalJSON` / `ToMap` omit-`"d"` guards** — `internal/build/types.go` (the guard only fires when `Items==nil && StreamState!=nil`, a configuration no production caller produces today).
+4. **Test files** + **godoc cross-reference** in `internal/keys/hash.go` (documentation only, no executable read).
+
+**Confirmed: zero production callers construct or read `StreamState`.** All existing render paths continue to populate `RangeData.Items` and read from it; the new field is dormant until Phase 2 wires `GenerateRangeStreamOperations` to populate it.
+
+### Phase 2 unblocked
+
+Phase 2 deliverable per proposal §11: `GenerateRangeStreamOperations(streamState *RangeStreamState, newItems []interface{}, statics interface{}, metadata map[string]interface{}, stripStatics bool) []interface{}` plus the `rangeContext.oldKeySet` field and the helper-by-helper adaptations cataloged in §10's `helpers_range.go` row + Gate 6. None of these depend on additional Phase 1 work; the foundational types are now in place.
+
+---
+
 ## Audit sign-off
 
 All six §15 gates close as recorded. Phase 1 (foundational types) is unblocked under the proposal's audit-checkpoint sequencing. The two open questions retain explicit owners (OQ1 closed by decision; OQ2 owned by Phase 5 measurement).

--- a/docs/proposals/streaming-range-impl-audit.md
+++ b/docs/proposals/streaming-range-impl-audit.md
@@ -241,13 +241,13 @@ The two shared presence-only helpers (`isComplexInsertionPatternCtx`, `areAllIte
 | File | Change |
 |---|---|
 | `internal/build/types.go` | Add `RangeStreamState` type + `RangeData.StreamState` field; preserve nil `Items` in `Clone`; add stream-mode deep-copy block in `Clone`; add omit-`"d"` guard in `MarshalJSON` and `ToMap`. |
-| `internal/build/types_test.go` | 7 new tests: `TestTreeNode_Clone_PreservesNilItems`, `TestRangeStreamState_DeepClone`, `TestTreeNode_MarshalJSON_OmitsD_StreamMode` + `_EmitsD_LegacyMode` + `_PreservesStatics_StreamMode` (regression guard against tying "s" emission to "d"), `TestTreeNode_ToMap_OmitsD_StreamMode` + `_EmitsD_LegacyMode`. |
+| `internal/build/types_test.go` | 9 new tests: `TestTreeNode_Clone_PreservesNilItems`, `TestRangeStreamState_DeepClone`, `TestTreeNode_MarshalJSON_OmitsD_StreamMode` + `_EmitsD_LegacyMode` + `_PreservesStatics_StreamMode` (regression guard against tying "s" emission to "d") + `_EmitsNullD_LegacyEmptyMode` (boundary: Items==nil && StreamState==nil preserves prior null shape), `TestTreeNode_ToMap_OmitsD_StreamMode` + `_EmitsD_LegacyMode` + `_EmitsEmptyD_LegacyEmptyMode` (ToMap parallel, preserves pre-existing "d": [] shape for the same boundary). |
 | `internal/keys/hash.go` | Add `ItemHashUint64(dynamics []interface{}) uint64` after `GenerateItemHashFromSlice`. Godoc covers nil-skip + nil-vs-`""` divergence. |
 | `internal/keys/hash_test.go` | 5 new tests: `TestItemHashUint64_Deterministic`, `_NilVsEmptyString`, `_PositionMatters`, `_NilEntriesSkipped`, `_CollisionStress_NoDupesIn10k` (10k synthetic dynamics, all hashes unique). |
 
 ### Test results
 
-- **12 new tests** (7 in `types_test.go` + 5 in `hash_test.go`) — all pass.
+- **14 new tests** (9 in `types_test.go` + 5 in `hash_test.go`) — all pass.
 - **Full test suite** (`GOWORK=off go test ./...`) — green; zero regressions across the 17 internal/* packages, the root `livetemplate` package, or `pubsub`.
 - **Build sanity** — `go build` clean; pre-existing `interface{} → any` linter hints are unchanged from the base commit.
 

--- a/internal/build/types.go
+++ b/internal/build/types.go
@@ -104,6 +104,31 @@ type RangeData struct {
 	// For heterogeneous ranges (items with different statics), the fingerprint-based
 	// diff will detect structure changes and trigger a full tree send.
 	Statics []string
+
+	// StreamState, when non-nil, indicates this RangeData is in stream mode:
+	// Items is nil (the retained tree no longer holds per-item dynamics) and
+	// stream-mode diffing uses StreamState.Hashes to detect content changes.
+	// nil StreamState means legacy mode (Items is the source of truth).
+	StreamState *RangeStreamState
+}
+
+// RangeStreamState caches the per-range data needed by stream-mode diffing
+// in place of retaining full per-item TreeNodes. Populated by the diff path
+// on the first stream-mode render of a range; cleared/repopulated on each
+// subsequent stream-mode render of the same range.
+type RangeStreamState struct {
+	// Keys holds the item keys in render order; parallel to Hashes.
+	Keys []string
+
+	// Hashes holds the per-item content hash (FNV-1a 64-bit of the item's
+	// JSON-serialised dynamics); parallel to Keys.
+	Hashes []uint64
+
+	// Fingerprint is the structure-fingerprint snapshot taken at the first
+	// stream-mode render of this range. Compared against the new render's
+	// item-template fingerprint each diff to detect a homogeneity transition;
+	// mismatch triggers het-range fallback.
+	Fingerprint string
 }
 
 // TreeMetadata contains metadata about the tree node.
@@ -476,7 +501,10 @@ func (tn *TreeNode) MarshalJSON() ([]byte, error) {
 
 	// Add range data if present
 	if tn.Range != nil {
-		result["d"] = tn.Range.Items
+		// Omit "d" in stream mode (Items==nil && StreamState!=nil); see RangeStreamState.
+		if tn.Range.Items != nil || tn.Range.StreamState == nil {
+			result["d"] = tn.Range.Items
+		}
 		// Include statics for range items
 		if len(tn.Range.Statics) > 0 {
 			result["s"] = tn.Range.Statics
@@ -610,12 +638,15 @@ func (tn *TreeNode) ToMap() map[string]interface{} {
 
 	// Add range data
 	if tn.Range != nil {
-		// Recursively convert any nested TreeNodes in range items
-		convertedItems := make([]interface{}, len(tn.Range.Items))
-		for i, item := range tn.Range.Items {
-			convertedItems[i] = convertValueToMap(item)
+		// Omit "d" in stream mode (Items==nil && StreamState!=nil); see RangeStreamState.
+		if tn.Range.Items != nil || tn.Range.StreamState == nil {
+			// Recursively convert any nested TreeNodes in range items
+			convertedItems := make([]interface{}, len(tn.Range.Items))
+			for i, item := range tn.Range.Items {
+				convertedItems[i] = convertValueToMap(item)
+			}
+			result["d"] = convertedItems
 		}
-		result["d"] = convertedItems
 	}
 
 	// Add metadata
@@ -673,13 +704,29 @@ func (tn *TreeNode) Clone() *TreeNode {
 
 	// Clone range data
 	if tn.Range != nil {
-		clone.Range = &RangeData{
-			Items: make([]interface{}, len(tn.Range.Items)),
+		clone.Range = &RangeData{}
+		// Preserve nil-ness of Items: stream-mode trees have Items == nil and
+		// must not be promoted to an empty slice during clone.
+		if tn.Range.Items != nil {
+			clone.Range.Items = make([]interface{}, len(tn.Range.Items))
+			copy(clone.Range.Items, tn.Range.Items)
 		}
-		copy(clone.Range.Items, tn.Range.Items)
 		if len(tn.Range.Statics) > 0 {
 			clone.Range.Statics = make([]string, len(tn.Range.Statics))
 			copy(clone.Range.Statics, tn.Range.Statics)
+		}
+		if tn.Range.StreamState != nil {
+			clone.Range.StreamState = &RangeStreamState{
+				Fingerprint: tn.Range.StreamState.Fingerprint,
+			}
+			if len(tn.Range.StreamState.Keys) > 0 {
+				clone.Range.StreamState.Keys = make([]string, len(tn.Range.StreamState.Keys))
+				copy(clone.Range.StreamState.Keys, tn.Range.StreamState.Keys)
+			}
+			if len(tn.Range.StreamState.Hashes) > 0 {
+				clone.Range.StreamState.Hashes = make([]uint64, len(tn.Range.StreamState.Hashes))
+				copy(clone.Range.StreamState.Hashes, tn.Range.StreamState.Hashes)
+			}
 		}
 	}
 

--- a/internal/build/types.go
+++ b/internal/build/types.go
@@ -112,10 +112,10 @@ type RangeData struct {
 	StreamState *RangeStreamState
 }
 
-// RangeStreamState caches the per-range data needed by stream-mode diffing
-// in place of retaining full per-item TreeNodes. Populated by the diff path
-// on the first stream-mode render of a range; cleared/repopulated on each
-// subsequent stream-mode render of the same range.
+// RangeStreamState holds the per-range snapshot used by stream-mode range
+// diffing in place of full per-item TreeNodes: the item keys in render order,
+// the per-item content hashes parallel to those keys, and a homogeneity
+// fingerprint to detect het-range fallback.
 type RangeStreamState struct {
 	// Keys holds the item keys in render order; parallel to Hashes.
 	Keys []string

--- a/internal/build/types.go
+++ b/internal/build/types.go
@@ -112,6 +112,15 @@ type RangeData struct {
 	StreamState *RangeStreamState
 }
 
+// IsStreamMode reports whether this RangeData is in stream mode: Items has
+// been dropped from the retained tree and StreamState carries the per-range
+// snapshot. Centralises the condition checked by MarshalJSON/ToMap (and by
+// every Phase 2+ call site that needs to branch on stream-mode shape) so the
+// three-place check can never silently diverge.
+func (rd *RangeData) IsStreamMode() bool {
+	return rd != nil && rd.Items == nil && rd.StreamState != nil
+}
+
 // RangeStreamState holds the per-range snapshot used by stream-mode range
 // diffing in place of full per-item TreeNodes: the item keys in render order,
 // the per-item content hashes parallel to those keys, and a homogeneity
@@ -497,8 +506,8 @@ func (tn *TreeNode) MarshalJSON() ([]byte, error) {
 
 	// Add range data if present
 	if tn.Range != nil {
-		// Omit "d" in stream mode (Items==nil && StreamState!=nil); see RangeStreamState.
-		if tn.Range.Items != nil || tn.Range.StreamState == nil {
+		// Omit "d" in stream mode; see RangeStreamState.
+		if !tn.Range.IsStreamMode() {
 			result["d"] = tn.Range.Items
 		}
 		// Include statics for range items
@@ -634,8 +643,8 @@ func (tn *TreeNode) ToMap() map[string]interface{} {
 
 	// Add range data
 	if tn.Range != nil {
-		// Omit "d" in stream mode (Items==nil && StreamState!=nil); see RangeStreamState.
-		if tn.Range.Items != nil || tn.Range.StreamState == nil {
+		// Omit "d" in stream mode; see RangeStreamState.
+		if !tn.Range.IsStreamMode() {
 			// Recursively convert any nested TreeNodes in range items
 			convertedItems := make([]interface{}, len(tn.Range.Items))
 			for i, item := range tn.Range.Items {

--- a/internal/build/types.go
+++ b/internal/build/types.go
@@ -120,14 +120,10 @@ type RangeStreamState struct {
 	// Keys holds the item keys in render order; parallel to Hashes.
 	Keys []string
 
-	// Hashes holds the per-item content hash (FNV-1a 64-bit of the item's
-	// JSON-serialised dynamics); parallel to Keys.
+	// Hashes is the per-item FNV-1a 64-bit content hash; parallel to Keys.
 	Hashes []uint64
 
-	// Fingerprint is the structure-fingerprint snapshot taken at the first
-	// stream-mode render of this range. Compared against the new render's
-	// item-template fingerprint each diff to detect a homogeneity transition;
-	// mismatch triggers het-range fallback.
+	// Fingerprint is the homogeneity-check snapshot; mismatch on a later render triggers het-range fallback.
 	Fingerprint string
 }
 
@@ -719,11 +715,13 @@ func (tn *TreeNode) Clone() *TreeNode {
 			clone.Range.StreamState = &RangeStreamState{
 				Fingerprint: tn.Range.StreamState.Fingerprint,
 			}
-			if len(tn.Range.StreamState.Keys) > 0 {
+			// Use != nil (not len > 0) for consistency with Items above —
+			// preserves empty-but-non-nil slices through clone.
+			if tn.Range.StreamState.Keys != nil {
 				clone.Range.StreamState.Keys = make([]string, len(tn.Range.StreamState.Keys))
 				copy(clone.Range.StreamState.Keys, tn.Range.StreamState.Keys)
 			}
-			if len(tn.Range.StreamState.Hashes) > 0 {
+			if tn.Range.StreamState.Hashes != nil {
 				clone.Range.StreamState.Hashes = make([]uint64, len(tn.Range.StreamState.Hashes))
 				copy(clone.Range.StreamState.Hashes, tn.Range.StreamState.Hashes)
 			}

--- a/internal/build/types_test.go
+++ b/internal/build/types_test.go
@@ -508,3 +508,183 @@ func TestContext_WithPath(t *testing.T) {
 		t.Error("Original context should be unchanged")
 	}
 }
+
+// TestTreeNode_Clone_PreservesNilItems verifies that cloning a TreeNode with
+// Range.Items==nil leaves the clone's Items==nil rather than promoting it to
+// an empty slice — stream-mode detection downstream relies on the nil-ness.
+func TestTreeNode_Clone_PreservesNilItems(t *testing.T) {
+	original := &TreeNode{
+		Range: &RangeData{
+			Items:   nil,
+			Statics: []string{"<li>", "</li>"},
+		},
+	}
+
+	clone := original.Clone()
+
+	if clone.Range == nil {
+		t.Fatal("Clone Range should not be nil")
+	}
+	if clone.Range.Items != nil {
+		t.Errorf("Clone Range.Items should be nil, got %v", clone.Range.Items)
+	}
+	if !reflect.DeepEqual(clone.Range.Statics, original.Range.Statics) {
+		t.Errorf("Clone Range.Statics = %v, want %v", clone.Range.Statics, original.Range.Statics)
+	}
+}
+
+// TestRangeStreamState_DeepClone tests deep cloning of RangeStreamState.
+func TestRangeStreamState_DeepClone(t *testing.T) {
+	original := &TreeNode{
+		Range: &RangeData{
+			StreamState: &RangeStreamState{
+				Keys:        []string{"k1", "k2"},
+				Hashes:      []uint64{0xdeadbeef, 0xcafebabe},
+				Fingerprint: "fp123",
+			},
+		},
+	}
+
+	clone := original.Clone()
+
+	if clone.Range == nil || clone.Range.StreamState == nil {
+		t.Fatal("Clone Range.StreamState should not be nil")
+	}
+	if !reflect.DeepEqual(clone.Range.StreamState.Keys, original.Range.StreamState.Keys) {
+		t.Errorf("Clone Keys = %v, want %v", clone.Range.StreamState.Keys, original.Range.StreamState.Keys)
+	}
+	if !reflect.DeepEqual(clone.Range.StreamState.Hashes, original.Range.StreamState.Hashes) {
+		t.Errorf("Clone Hashes = %v, want %v", clone.Range.StreamState.Hashes, original.Range.StreamState.Hashes)
+	}
+	if clone.Range.StreamState.Fingerprint != original.Range.StreamState.Fingerprint {
+		t.Errorf("Clone Fingerprint = %v, want %v", clone.Range.StreamState.Fingerprint, original.Range.StreamState.Fingerprint)
+	}
+
+	// Mutate clone, confirm original unchanged
+	clone.Range.StreamState.Keys[0] = "mutated"
+	if original.Range.StreamState.Keys[0] == "mutated" {
+		t.Error("Mutating clone Keys should not affect original")
+	}
+	clone.Range.StreamState.Hashes[0] = 0xff
+	if original.Range.StreamState.Hashes[0] == 0xff {
+		t.Error("Mutating clone Hashes should not affect original")
+	}
+}
+
+// TestTreeNode_MarshalJSON_OmitsD_StreamMode verifies stream-mode trees omit "d".
+// (Items==nil && StreamState!=nil emits {} not {"d": null}.)
+func TestTreeNode_MarshalJSON_OmitsD_StreamMode(t *testing.T) {
+	node := &TreeNode{
+		Range: &RangeData{
+			Items: nil,
+			StreamState: &RangeStreamState{
+				Keys:        []string{"k1"},
+				Hashes:      []uint64{0x1},
+				Fingerprint: "fp",
+			},
+		},
+	}
+
+	data, err := json.Marshal(node)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if _, hasD := result["d"]; hasD {
+		t.Errorf("Stream-mode tree should NOT have 'd' key, got %v", result)
+	}
+}
+
+// TestTreeNode_MarshalJSON_EmitsD_LegacyMode is the regression guard: legacy
+// trees (non-nil Items) still emit "d" exactly as today.
+func TestTreeNode_MarshalJSON_EmitsD_LegacyMode(t *testing.T) {
+	node := &TreeNode{
+		Range: &RangeData{
+			Items: []interface{}{"item1"},
+		},
+	}
+
+	data, err := json.Marshal(node)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if _, hasD := result["d"]; !hasD {
+		t.Errorf("Legacy-mode tree should have 'd' key, got %v", result)
+	}
+}
+
+// TestTreeNode_ToMap_OmitsD_StreamMode mirrors MarshalJSON_OmitsD_StreamMode for ToMap.
+func TestTreeNode_ToMap_OmitsD_StreamMode(t *testing.T) {
+	node := &TreeNode{
+		Range: &RangeData{
+			Items: nil,
+			StreamState: &RangeStreamState{
+				Keys: []string{"k1"},
+			},
+		},
+	}
+
+	m := node.ToMap()
+
+	if _, hasD := m["d"]; hasD {
+		t.Errorf("Stream-mode tree's ToMap() should NOT have 'd' key, got %v", m)
+	}
+}
+
+// TestTreeNode_ToMap_EmitsD_LegacyMode mirrors MarshalJSON_EmitsD_LegacyMode for ToMap.
+func TestTreeNode_ToMap_EmitsD_LegacyMode(t *testing.T) {
+	node := &TreeNode{
+		Range: &RangeData{
+			Items: []interface{}{"item1"},
+		},
+	}
+
+	m := node.ToMap()
+
+	if _, hasD := m["d"]; !hasD {
+		t.Errorf("Legacy-mode tree's ToMap() should have 'd' key, got %v", m)
+	}
+}
+
+// TestTreeNode_MarshalJSON_PreservesStatics_StreamMode guards against tying
+// "s" emission to "d" emission: stream-mode trees omit "d" but must still
+// emit "s" so the client can render items from cached statics.
+func TestTreeNode_MarshalJSON_PreservesStatics_StreamMode(t *testing.T) {
+	node := &TreeNode{
+		Range: &RangeData{
+			Items:   nil,
+			Statics: []string{"<li>", "</li>"},
+			StreamState: &RangeStreamState{
+				Keys: []string{"k1"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(node)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if _, hasD := result["d"]; hasD {
+		t.Errorf("Stream-mode tree should NOT have 'd' key, got %v", result)
+	}
+	if _, hasS := result["s"]; !hasS {
+		t.Errorf("Stream-mode tree SHOULD have 's' key for cached client statics, got %v", result)
+	}
+}

--- a/internal/build/types_test.go
+++ b/internal/build/types_test.go
@@ -711,6 +711,29 @@ func TestTreeNode_MarshalJSON_EmitsNullD_LegacyEmptyMode(t *testing.T) {
 	}
 }
 
+// IsStreamMode covers the 2x2 grid of (Items present/nil) x (StreamState
+// present/nil); only Items==nil && StreamState!=nil counts as stream mode.
+func TestRangeData_IsStreamMode(t *testing.T) {
+	tests := []struct {
+		name string
+		rd   *RangeData
+		want bool
+	}{
+		{"nil receiver", nil, false},
+		{"legacy non-empty", &RangeData{Items: []interface{}{"x"}}, false},
+		{"legacy empty", &RangeData{Items: nil}, false},
+		{"stream mode", &RangeData{Items: nil, StreamState: &RangeStreamState{Keys: []string{"k"}}}, true},
+		{"transitional both set (illegal but defensive)", &RangeData{Items: []interface{}{"x"}, StreamState: &RangeStreamState{}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rd.IsStreamMode(); got != tt.want {
+				t.Errorf("IsStreamMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // ToMap parallel of EmitsNullD_LegacyEmptyMode. ToMap pre-Phase-1 emits
 // "d": [] (not "d": null) because of the convertedItems := make(...) deep-
 // convert path — that pre-existing shape is preserved by the omit guard.

--- a/internal/build/types_test.go
+++ b/internal/build/types_test.go
@@ -509,9 +509,8 @@ func TestContext_WithPath(t *testing.T) {
 	}
 }
 
-// TestTreeNode_Clone_PreservesNilItems verifies that cloning a TreeNode with
-// Range.Items==nil leaves the clone's Items==nil rather than promoting it to
-// an empty slice — stream-mode detection downstream relies on the nil-ness.
+// Items==nil must stay nil through clone — stream-mode detection downstream
+// relies on the nil-ness.
 func TestTreeNode_Clone_PreservesNilItems(t *testing.T) {
 	original := &TreeNode{
 		Range: &RangeData{
@@ -533,7 +532,6 @@ func TestTreeNode_Clone_PreservesNilItems(t *testing.T) {
 	}
 }
 
-// TestRangeStreamState_DeepClone tests deep cloning of RangeStreamState.
 func TestRangeStreamState_DeepClone(t *testing.T) {
 	original := &TreeNode{
 		Range: &RangeData{
@@ -571,8 +569,7 @@ func TestRangeStreamState_DeepClone(t *testing.T) {
 	}
 }
 
-// TestTreeNode_MarshalJSON_OmitsD_StreamMode verifies stream-mode trees omit "d".
-// (Items==nil && StreamState!=nil emits {} not {"d": null}.)
+// Items==nil && StreamState!=nil emits {} not {"d": null}.
 func TestTreeNode_MarshalJSON_OmitsD_StreamMode(t *testing.T) {
 	node := &TreeNode{
 		Range: &RangeData{
@@ -600,8 +597,6 @@ func TestTreeNode_MarshalJSON_OmitsD_StreamMode(t *testing.T) {
 	}
 }
 
-// TestTreeNode_MarshalJSON_EmitsD_LegacyMode is the regression guard: legacy
-// trees (non-nil Items) still emit "d" exactly as today.
 func TestTreeNode_MarshalJSON_EmitsD_LegacyMode(t *testing.T) {
 	node := &TreeNode{
 		Range: &RangeData{
@@ -686,5 +681,55 @@ func TestTreeNode_MarshalJSON_PreservesStatics_StreamMode(t *testing.T) {
 	}
 	if _, hasS := result["s"]; !hasS {
 		t.Errorf("Stream-mode tree SHOULD have 's' key for cached client statics, got %v", result)
+	}
+}
+
+// Boundary case: Items==nil && StreamState==nil (legacy-empty) — the omit
+// guard must NOT fire here; pre-Phase-1 wire output emitted "d": null and
+// that behaviour is preserved.
+func TestTreeNode_MarshalJSON_EmitsNullD_LegacyEmptyMode(t *testing.T) {
+	node := &TreeNode{
+		Range: &RangeData{Items: nil},
+	}
+
+	data, err := json.Marshal(node)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	v, hasD := result["d"]
+	if !hasD {
+		t.Errorf("Legacy-empty tree should still have 'd' key (preserves prior behaviour), got %v", result)
+	}
+	if v != nil {
+		t.Errorf("Legacy-empty 'd' should be null, got %v (%T)", v, v)
+	}
+}
+
+// ToMap parallel of EmitsNullD_LegacyEmptyMode. ToMap pre-Phase-1 emits
+// "d": [] (not "d": null) because of the convertedItems := make(...) deep-
+// convert path — that pre-existing shape is preserved by the omit guard.
+func TestTreeNode_ToMap_EmitsEmptyD_LegacyEmptyMode(t *testing.T) {
+	node := &TreeNode{
+		Range: &RangeData{Items: nil},
+	}
+
+	m := node.ToMap()
+
+	v, hasD := m["d"]
+	if !hasD {
+		t.Errorf("Legacy-empty ToMap should still have 'd' key, got %v", m)
+	}
+	items, ok := v.([]interface{})
+	if !ok {
+		t.Fatalf("Legacy-empty ToMap 'd' should be []interface{}, got %T (%v)", v, v)
+	}
+	if len(items) != 0 {
+		t.Errorf("Legacy-empty ToMap 'd' should be empty slice, got len=%d", len(items))
 	}
 }

--- a/internal/keys/hash.go
+++ b/internal/keys/hash.go
@@ -58,6 +58,10 @@ func GenerateItemHashFromSlice(dynamics []interface{}) string {
 // `0:""`), while the nil entry is skipped entirely. A transition from
 // "field set to empty" to "field omitted entirely" is correctly detected
 // as a content change.
+//
+// empty/nil input: an empty or nil dynamics slice produces FNV-1a's
+// offset-basis constant (0xcbf29ce484222325) — a stable, non-zero,
+// distinguishable hash for the "empty range item" case.
 func ItemHashUint64(dynamics []interface{}) uint64 {
 	content := strings.Join(buildHashParts(dynamics), "|")
 	hasher := fnv.New64a()

--- a/internal/keys/hash.go
+++ b/internal/keys/hash.go
@@ -41,14 +41,7 @@ func GenerateItemHash(dynamics map[string]interface{}) string {
 // This avoids the overhead of converting []interface{} to map[string]interface{}
 // when the dynamics are already in slice form. Nil entries are skipped.
 func GenerateItemHashFromSlice(dynamics []interface{}) string {
-	var parts []string
-	for i, val := range dynamics {
-		if val == nil {
-			continue
-		}
-		parts = append(parts, formatHashPart(strconv.Itoa(i), val))
-	}
-	return hashParts(parts)
+	return hashParts(buildHashParts(dynamics))
 }
 
 // ItemHashUint64 hashes the given dynamics slice with FNV-1a 64-bit and returns
@@ -66,14 +59,7 @@ func GenerateItemHashFromSlice(dynamics []interface{}) string {
 // "field set to empty" to "field omitted entirely" is correctly detected
 // as a content change.
 func ItemHashUint64(dynamics []interface{}) uint64 {
-	var parts []string
-	for i, val := range dynamics {
-		if val == nil {
-			continue
-		}
-		parts = append(parts, formatHashPart(strconv.Itoa(i), val))
-	}
-	content := strings.Join(parts, "|")
+	content := strings.Join(buildHashParts(dynamics), "|")
 	hasher := fnv.New64a()
 	hasher.Write([]byte(content))
 	return hasher.Sum64()
@@ -97,4 +83,18 @@ func hashParts(parts []string) string {
 		return hash[:HashPrefixLength]
 	}
 	return hash
+}
+
+// buildHashParts formats the dynamics slice into ordered hash parts (skipping
+// nil entries). Shared by GenerateItemHashFromSlice and ItemHashUint64 so the
+// two hash functions can never silently diverge in their input encoding.
+func buildHashParts(dynamics []interface{}) []string {
+	var parts []string
+	for i, val := range dynamics {
+		if val == nil {
+			continue
+		}
+		parts = append(parts, formatHashPart(strconv.Itoa(i), val))
+	}
+	return parts
 }

--- a/internal/keys/hash.go
+++ b/internal/keys/hash.go
@@ -51,6 +51,38 @@ func GenerateItemHashFromSlice(dynamics []interface{}) string {
 	return hashParts(parts)
 }
 
+// ItemHashUint64 hashes the given dynamics slice with FNV-1a 64-bit and returns
+// the raw uint64. Used by Phase 2 stream-mode range diffing to populate
+// RangeStreamState.Hashes — the per-item content hash that lets the diff path
+// detect changes without retaining full per-item TreeNodes.
+//
+// Mirrors GenerateItemHashFromSlice's value-formatting (same formatHashPart
+// helper, same skip-nil rule), but returns the raw uint64 instead of the
+// 12-char hex prefix.
+//
+// nil-skip: nil entries are skipped — only non-nil entries' positions are
+// encoded into the hash. A trailing-nil and a missing-trailing-position
+// produce the same hash (consistent with the existing hashing rule).
+//
+// nil-vs-"" divergence: [nil, "x"] hashes to a different value than
+// ["", "x"] because the empty-string entry IS included (formatted as
+// `0:""`), while the nil entry is skipped entirely. A transition from
+// "field set to empty" to "field omitted entirely" is correctly detected
+// as a content change.
+func ItemHashUint64(dynamics []interface{}) uint64 {
+	var parts []string
+	for i, val := range dynamics {
+		if val == nil {
+			continue
+		}
+		parts = append(parts, formatHashPart(strconv.Itoa(i), val))
+	}
+	content := strings.Join(parts, "|")
+	hasher := fnv.New64a()
+	hasher.Write([]byte(content))
+	return hasher.Sum64()
+}
+
 func formatHashPart(key string, val interface{}) string {
 	valJSON, err := json.Marshal(val)
 	if err != nil {

--- a/internal/keys/hash.go
+++ b/internal/keys/hash.go
@@ -52,13 +52,9 @@ func GenerateItemHashFromSlice(dynamics []interface{}) string {
 }
 
 // ItemHashUint64 hashes the given dynamics slice with FNV-1a 64-bit and returns
-// the raw uint64. Used by Phase 2 stream-mode range diffing to populate
-// RangeStreamState.Hashes — the per-item content hash that lets the diff path
-// detect changes without retaining full per-item TreeNodes.
-//
-// Mirrors GenerateItemHashFromSlice's value-formatting (same formatHashPart
-// helper, same skip-nil rule), but returns the raw uint64 instead of the
-// 12-char hex prefix.
+// the raw uint64. Mirrors GenerateItemHashFromSlice's value-formatting (same
+// formatHashPart helper, same skip-nil rule), but returns the raw uint64
+// instead of the 12-char hex prefix.
 //
 // nil-skip: nil entries are skipped — only non-nil entries' positions are
 // encoded into the hash. A trailing-nil and a missing-trailing-position

--- a/internal/keys/hash_test.go
+++ b/internal/keys/hash_test.go
@@ -1,6 +1,7 @@
 package keys
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -152,5 +153,59 @@ func TestGenerateItemHashFromSlice_Nil(t *testing.T) {
 	hash := GenerateItemHashFromSlice(nil)
 	if hash == "" {
 		t.Error("Nil slice should return a non-empty hash")
+	}
+}
+
+func TestItemHashUint64_Deterministic(t *testing.T) {
+	dynamics := []interface{}{"title", "content"}
+	h1 := ItemHashUint64(dynamics)
+	h2 := ItemHashUint64(dynamics)
+	if h1 != h2 {
+		t.Errorf("Hash should be deterministic, got: %d and %d", h1, h2)
+	}
+}
+
+func TestItemHashUint64_NilVsEmptyString(t *testing.T) {
+	// Per godoc: nil entries are SKIPPED; "" entries are INCLUDED. So
+	// [nil, "x"] and ["", "x"] must produce DIFFERENT hashes — proves the
+	// nil-vs-"" divergence promise (a transition from "field set to empty"
+	// to "field omitted entirely" is detected as a content change).
+	withNil := []interface{}{nil, "x"}
+	withEmpty := []interface{}{"", "x"}
+	if ItemHashUint64(withNil) == ItemHashUint64(withEmpty) {
+		t.Error("[nil, \"x\"] and [\"\", \"x\"] should produce DIFFERENT hashes")
+	}
+}
+
+func TestItemHashUint64_PositionMatters(t *testing.T) {
+	h1 := ItemHashUint64([]interface{}{"a", "b"})
+	h2 := ItemHashUint64([]interface{}{"b", "a"})
+	if h1 == h2 {
+		t.Error("Different positional orderings should produce different hashes")
+	}
+}
+
+func TestItemHashUint64_NilEntriesSkipped(t *testing.T) {
+	// nil is skipped but position is preserved by formatHashPart's index key.
+	// [nil, "x"] formats as `1:"x"`; [nil, nil, "x"] formats as `2:"x"`.
+	// Different position keys → different hashes.
+	h1 := ItemHashUint64([]interface{}{nil, "x"})
+	h2 := ItemHashUint64([]interface{}{nil, nil, "x"})
+	if h1 == h2 {
+		t.Error("Position of non-nil entry should affect hash even when prior entries are all nil")
+	}
+}
+
+func TestItemHashUint64_CollisionStress_NoDupesIn10k(t *testing.T) {
+	// Mirrors TestFingerprintStress_NoDuplicatesIn10kStructures pattern:
+	// 10k synthetic dynamics with one varying field, all hashes must be unique.
+	const count = 10000
+	seen := make(map[uint64]int, count)
+	for i := 0; i < count; i++ {
+		h := ItemHashUint64([]interface{}{"item-" + strconv.Itoa(i), "x"})
+		if prev, exists := seen[h]; exists {
+			t.Fatalf("collision: input %d and input %d both hash to %d", prev, i, h)
+		}
+		seen[h] = i
 	}
 }


### PR DESCRIPTION
## Summary

Phase 1 of the streaming range rendering refactor (proposal #360, audit #361). Adds foundational types — `RangeStreamState{Keys, Hashes, Fingerprint}` + `StreamState` field on `RangeData` + `keys.ItemHashUint64` — with **no production code path constructing or reading them yet**. Observable behavior is unchanged.

Per proposal §11 Phase 1 deliverable: "RangeStreamState type exists and is testable in isolation. No production code path constructs or reads it; all existing tests pass unchanged."

## Changes

- **`internal/build/types.go`** — Add `RangeStreamState` type + `RangeData.StreamState` field; extend `TreeNode.Clone()` (deep-copy StreamState slices + preserve nil-ness of `Range.Items`); add omit-`"d"` guards in `MarshalJSON` and `ToMap` (only fire when `Items==nil && StreamState!=nil`).
- **`internal/keys/hash.go`** — Add `ItemHashUint64(dynamics []interface{}) uint64`. Mirrors `GenerateItemHashFromSlice`'s value-formatting (skip-nil) but returns raw FNV-1a 64-bit uint64 instead of 12-char hex prefix. Godoc covers nil-skip + nil-vs-`""` divergence.
- **`internal/build/types_test.go`** — 7 new tests covering Clone nil-preservation, RangeStreamState deep-clone, MarshalJSON/ToMap omit-d in stream mode, MarshalJSON/ToMap emits-d in legacy mode (regression guard), and MarshalJSON preserves Statics in stream mode (regression guard against tying "s" emission to "d").
- **`internal/keys/hash_test.go`** — 5 new tests covering ItemHashUint64 determinism, nil-vs-"" divergence, position sensitivity, nil-entries skip semantics, and 10k-collision stress.
- **`docs/proposals/streaming-range-impl-audit.md`** — Phase 1 audit checkpoint section appended (zero production callers verified by grep, full suite green, Phase 2 unblocked).

## Test plan

- [x] `GOWORK=off go test ./...` — full suite green, +12 new tests pass
- [x] `GOWORK=off go test -race ./...` — race detector clean (root 438s, session 32s, pubsub 19s, all internals < 2s)
- [x] `grep -rn "StreamState" internal/ --include='*.go'` — zero production callers; only type def + Clone/MarshalJSON/ToMap defensive handlers + tests + 1 godoc cross-ref
- [x] Phase 1 audit checkpoint appended to `streaming-range-impl-audit.md` per proposal §15 audit-history thread requirement
- [ ] Reviewer confirms `RangeData.Items` is still source of truth on every render path (per audit checkpoint)
- [ ] Reviewer confirms no production caller ever constructs `RangeStreamState{}` or reads `RangeData.StreamState` (the gate that lets this PR ship as a true no-op)

## Phase 2 unblocks on merge

`GenerateRangeStreamOperations(streamState *RangeStreamState, newItems []interface{}, statics interface{}, metadata map[string]interface{}, stripStatics bool) []interface{}` plus `rangeContext.oldKeySet` field + helper-by-helper adaptations cataloged in §10 + Gate 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)