### PR TITLE
feat: streaming range Phase 3 — caller integration (cutover)

### DIFF
--- a/docs/proposals/streaming-range-impl-audit.md
+++ b/docs/proposals/streaming-range-impl-audit.md
@@ -331,6 +331,101 @@ A future Phase 3+ helper added here MUST audit which `ctx` fields it reads — `
 
 ---
 
+## Phase 3 audit checkpoint
+
+**Date**: 2026-05-01
+**Branch**: `phase3/streaming-range-cutover` → PR pending
+**Base commit**: `c07977d9` (post-Phase-2 merge on `main`)
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `internal/diff/tree_compare.go` | `handleMatchedRanges` + `handleRangeMatch` stream-mode dispatch at top of function (BEFORE any read of `oldTree.Range.Items`); no-op fallback predicate at line 125-126 extended to recognise stream-mode-empty (`Items==nil` with non-nil StreamState) so a stream-mode no-op render doesn't fall into `*changes = *newTree` |
+| `internal/diff/range_ops.go` | Two adapter helpers: `handleStreamModeRange` (top-level) + `handleStreamModeRangeMatch` (nested) — extract new-side via new helper `extractStreamModeNewSide`, call `GenerateRangeStreamOperations`, write ops into changes (or full-tree replacement on het-fingerprint nil return) |
+| `internal/diff/transition.go` (NEW) | `TransitionToStreamMode(*build.TreeNode)` — top-level walker that runs the homogeneity check via `CalculateStaticsFingerprint` (Phase 2-driven), populates `RangeStreamState`, nils `Items`. Idempotent, nil-safe, top-level only per §5a |
+| `internal/diff/transition_test.go` (NEW) | 7 unit tests: homogeneous fires, heterogeneous defers, empty defers, single-item fires, idempotent re-entry, nested ranges NOT transitioned, nil tree safe |
+| `internal/diff/helpers_value.go` | `HasRangeItems` extended via existing `IsStreamMode()` predicate — answers the *logical* "does the range render anything" question for stream-mode trees |
+| `internal/keys/generator.go` | New `LoadExistingKeysFromSlice([]string)` — same numeric-max-tracking as `LoadExistingKeys` but reads keys directly from the slice (used by stream-mode loader path) |
+| `internal/keys/loader.go` | `LoadExistingKeyMappings` branches on `Range.StreamState != nil` → `LoadExistingKeysFromSlice(StreamState.Keys)` else legacy `LoadExistingKeys(Items)` |
+| `internal/fuzz/invariants/verifier.go` | `buildIDKeyMap` adapted for stream-mode trees — collapses ID and key to the same value (since the only retained identifier is `StreamState.Keys[i]`); `verifyTreeStructureRecursive` no-ops cleanly on stream-mode (Items is nil, no per-item recursion needed — homogeneity already verified at transition time) |
+| `internal/fuzz/invariants/helpers.go` | `convertValue` skips `result["d"]` assignment for stream-mode trees — matches the omitted-`"d"` wire shape Phase 1's MarshalJSON enforces (avoids producing `"d": []` shape that would diverge from production wire) |
+| `template.go` | Single transition site at TOP of `buildTree` (after key-generator init, BEFORE `LoadExistingKeyMappings`) — fires on the previous render's `lastTree`, which is the SAFE slot per §5a's "after the first stream-mode render" timing. Placement BEFORE `LoadExistingKeyMappings` exercises the `LoadExistingKeysFromSlice` path on every stream-mode render. The transition is NOT placed at the `lastTree =` assignment sites (lines 1358, 1388) because that would mutate the wire output on the first render |
+| `e2e_update_spec_test.go` | `TestUserJourney_TodoApp/add_multiple` validate function broadened to accept both forms: granular ops (`"i"`/`"a"`) when stream mode active OR full-tree replacement when het-fallback fires (TodoApp template's `{{if .Done}}` makes items heterogeneous once Done values mix — proposal §5d behavior) |
+| `streaming_range_phase3_test.go` (NEW) | 5 root-package integration tests: stream mode fires on second render (wire-shape proof); reconnect resync emits full tree; full-dynamics-map invariant (§5c); het-range fallback (§5d); memory regression at N ∈ {10, 100, 1k, 10k} |
+
+### Memory regression numbers (test plan item 2)
+
+Captured by `TestStreamMode_MemoryRegression` (`go test -v -run TestStreamMode_MemoryRegression ./`):
+
+| N | heap with Items | heap after transition | delta | bytes/item |
+|---|---|---|---|---|
+| 10 | 2,472,672 | 2,458,936 | 13,736 | 1,373.6 |
+| 100 | 2,497,800 | 2,460,688 | 37,112 | 371.1 |
+| 1,000 | 2,742,576 | 2,462,456 | 280,120 | 280.1 |
+| 10,000 | 5,208,400 | 2,469,816 | 2,738,584 | 273.9 |
+
+The per-item delta stabilises at ~273 bytes/item at large N (where allocator noise is amortised). Stream-mode `RangeStreamState` per item is one string key (~24 bytes header + bytes) + one uint64 hash (8 bytes) + amortised `Fingerprint` string (one per range, not per item) ≈ ~32 bytes/item. So legacy retains ~273 + 32 = ~305 bytes/item; stream mode retains ~32 bytes/item. **~9.5× reduction**, well above the proposal's ≥4× target.
+
+The N=10 row is dominated by allocator coarsening (heap pages allocate in 8KB chunks; small N rounds up). At N=1k+ the per-item number is the meaningful measurement.
+
+### Per Phase 3 audit checkpoint requirement
+
+> Per proposal §11 Phase 3 audit checkpoint: "memory regression test shows ≥4× per-item retained-byte reduction; `extractRangeData` regression gate green; reconnect test confirms first render after `lastTree` drop emits a full tree, not stream ops; existing E2E specs pass with regenerated `["u"]` goldens; `grep -rn "t\.mu\.\(Lock\|Unlock\)" template.go` confirms the call chain from `t.mu.Lock()` (Execute, ~line 1651) through `compareTreesAndGetChangesWithContext` to the `Items=nil` assignment never drops the lock — the phase-1→phase-2 transition is naturally protected, but the audit verifies it."
+
+- **Memory regression ≥4×**: confirmed (~9.5× at N=1k+, see table above).
+- **`extractRangeData` regression gate**: implicitly verified by the full suite green run plus `TestStreamMode_FiresOnSecondRender` — on the second render, the output contains stream-mode `["u","key",...]` ops with whole-dynamics-map payloads (§5c shape), proving the dispatch routed to `GenerateRangeStreamOperations` and NOT through `extractRangeData` → `handleEmptyToItemsTransition`. A direct call-count assertion was not added because the wire-shape proof is already authoritative.
+- **Reconnect resync**: confirmed via `TestStreamMode_ReconnectResyncEmitsFullTree` — drops `lastTree` + resets `hasInitialTree`, asserts the next render emits full statics and contains NO stream-mode update ops. PASS.
+- **Existing E2E specs pass with regenerated goldens**: full suite green; the only test that needed migration was `TestUserJourney_TodoApp/add_multiple` (because the TodoApp template has `{{if .Done}}` inside the range, making it heterogeneous once Done values mix). The migration accepted both stream-mode ops and het-fallback full-tree replacement — both satisfy the test's intent. **No goldens needed regeneration** — the spec tests in `e2e_update_spec_test.go` that assert specific wire payloads continue to use legacy templates that don't trigger stream mode (no homogeneous range with ≥1 item) or use templates that fall back via §5d.
+- **`t.mu` lock chain**: verified manually. `template.go:1651` acquires `t.mu.Lock()` (deferred unlock). The transition call at line 1660 (`diff.TransitionToStreamMode(t.lastTree)`) runs UNDER the lock. `LoadExistingKeyMappings` (line 1664) and the full diff path (`compareTreesAndGetChanges` at line 1382, `t.lastTree =` at lines 1358/1388) all run under the same lock. `grep -n "t\.mu\." template.go` shows no intermediate `Unlock()` calls between line 1651 and the function return. The transition is naturally protected.
+
+### Test count delta
+
+- 7 new unit tests in `internal/diff/transition_test.go` (TransitionToStreamMode_*)
+- 5 new integration tests in `streaming_range_phase3_test.go` (TestStreamMode_*)
+- 1 test migrated in `e2e_update_spec_test.go` (`TestUserJourney_TodoApp/add_multiple` validate fn broadened)
+- 0 deleted tests
+- 0 goldens regenerated
+
+**Total: 12 new tests + 1 migrated.**
+
+### Verification commands re-run
+
+```
+GOWORK=off go build ./...                                          # clean
+GOWORK=off go test -count=1 ./...                                  # green (98s)
+GOWORK=off go test -race -count=1 ./internal/diff/... ./internal/keys/... ./internal/build/... ./internal/fuzz/...   # race-clean
+GOWORK=off go test -race -count=1 ./                               # race-clean (root pkg, 457s)
+GOWORK=off gofmt -l internal/ template.go *.go                     # empty (Phase 3 files clean)
+```
+
+The root-package race run is the load-bearing verification for the `t.mu` chain — it covers the transition's mutation of `t.lastTree.Range.Items = nil` running under the same lock as the diff and the wire serialization. Internal-pkg race runs alone don't cover this. Confirmed clean.
+
+The pre-existing `e2e/docker/multi_instance_test.go` gofmt nit is NOT a Phase 3 regression (that file is untouched).
+
+### Phase 3 follow-ups
+
+- **`prepare.go` StreamState propagation + `helpers_compare.go::rangeItemsEqual` extension**: deferred. Both were planned per §10 but determined to be defensive code (the call paths today never see populated StreamState on a tree headed through these functions). Per project guidance "no code for scenarios that can't happen", they are NOT shipped here. Reinstate in Phase 4+ if a real call site materialises (e.g., a broadcast path that prepares a post-transition tree).
+- **Test plan item 10 (browser E2E in `lvt` repo)**: out of scope for this PR — Phase 3 ships without coordinated `lvt`-repo changes. The Go-side wire-format invariants (full-dynamics-map, stream-mode op codes) are tested in this repo via `TestStreamMode_FullDynamicsMapInvariant`. The browser-side rendering of those payloads is exercised by `lvt`'s existing range-ops E2E (which continues to pass because the op codes themselves are unchanged — only the `["u"]` payload contract is relaxed per §5c, and the existing client `mergeRangeItem` already accepts whole-item maps).
+- **Spec doc update** (`docs/specifications/tree-update-specification.md`): Phase 4 deliverable.
+- **Deletion of `CompareRangeItemsForChanges` and `compareRangeItemsWithKeyPos`**: Phase 4 deliverable.
+- **Stream-mode benchmarks** (`BenchmarkRangeDiff_Stream_*`): Phase 5 deliverable. Phase 3 confirmed `diff_bench_test.go` is unaffected by the cutover (benchmarks bypass the dispatch by calling `GenerateRangeDifferentialOperations` directly — they never trigger transition).
+- **`LargeTableController` example**: Phase 6 deliverable.
+- **`IsStreamMode()` panic upgrade**: Phase 1/2 audits flagged as a Phase 3 *option*; deferred to Phase 4+ where the producer can also enforce the invariant. Adding error paths in Phase 3 would be premature without the corresponding producer-side enforcement.
+
+### Phase 4 unblocked
+
+Phase 4 deliverable per proposal §11: delete `CompareRangeItemsForChanges` and `compareRangeItemsWithKeyPos` (and their tests), update `docs/specifications/tree-update-specification.md` per §5c (relax producer-side "only changed fields"; add consumer-side "treat ['u'] as full snapshot" contract), regenerate any remaining goldens, verify `fuzz_diff_test.go` stays green.
+
+The dispatch is wired and the cutover is observable end-to-end. The legacy `GenerateRangeDifferentialOperations` is now reached only by:
+- The first render of a stream-capable range (before transition).
+- The second render of a heterogeneous range (where transition deferred to legacy).
+- The Phase-2-style direct test invocations.
+
+Phase 4's cleanup audit can verify "no production caller of `compareRangeItemsWithKeyPos` other than `generateUpdateOps`" (the legacy diff helper), confirming the legacy path is reachable only through the explicit het-range fallback.
+
+---
+
 ## Audit sign-off
 
 All six §15 gates close as recorded. Phase 1 (foundational types) is unblocked under the proposal's audit-checkpoint sequencing. The two open questions retain explicit owners (OQ1 closed by decision; OQ2 owned by Phase 5 measurement).

--- a/docs/proposals/streaming-range-impl-audit.md
+++ b/docs/proposals/streaming-range-impl-audit.md
@@ -342,7 +342,7 @@ A future Phase 3+ helper added here MUST audit which `ctx` fields it reads — `
 | File | Change |
 |---|---|
 | `internal/diff/tree_compare.go` | `handleMatchedRanges` + `handleRangeMatch` stream-mode dispatch at top of function (BEFORE any read of `oldTree.Range.Items`); no-op fallback predicate at line 125-126 extended to recognise stream-mode-empty (`Items==nil` with non-nil StreamState) so a stream-mode no-op render doesn't fall into `*changes = *newTree` |
-| `internal/diff/range_ops.go` | Two adapter helpers: `handleStreamModeRange` (top-level) + `handleStreamModeRangeMatch` (nested) — extract new-side via new helper `extractStreamModeNewSide`, call `GenerateRangeStreamOperations`, write ops into changes (or full-tree replacement on het-fingerprint nil return) |
+| `internal/diff/range_ops.go` | Two adapter helpers: `handleStreamModeRange` (top-level) + `handleStreamModeRangeMatch` (nested) — extract new-side via new helper `extractNewSideRange`, call `GenerateRangeStreamOperations`, write ops into changes (or full-tree replacement on het-fingerprint nil return) |
 | `internal/diff/transition.go` (NEW) | `TransitionToStreamMode(*build.TreeNode)` — top-level walker that runs the homogeneity check via `CalculateStaticsFingerprint` (Phase 2-driven), populates `RangeStreamState`, nils `Items`. Idempotent, nil-safe, top-level only per §5a |
 | `internal/diff/transition_test.go` (NEW) | 7 unit tests: homogeneous fires, heterogeneous defers, empty defers, single-item fires, idempotent re-entry, nested ranges NOT transitioned, nil tree safe |
 | `internal/diff/helpers_value.go` | `HasRangeItems` extended via existing `IsStreamMode()` predicate — answers the *logical* "does the range render anything" question for stream-mode trees |

--- a/e2e_update_spec_test.go
+++ b/e2e_update_spec_test.go
@@ -639,22 +639,32 @@ func TestUserJourney_TodoApp(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, tree *build.TreeNode, isFirst bool) {
-				// Should have range operations for adding items (insert "i" or append "a")
-				foundRangeOps := false
+				// Should communicate the new todos to the client. Two acceptable forms:
+				//   1. Granular ops ("i" insert / "a" append): emitted when stream mode is
+				//      active AND the new items remain homogeneous with the streamState.
+				//   2. Full-tree replacement (Range with Items): the het-range fallback per
+				//      proposal §5d. The TodoApp template has {{if .Done}} inside the range,
+				//      which makes items structurally heterogeneous when Done values mix.
+				//      Once one item is Done=true and others are Done=false, the per-item
+				//      statics fingerprint differs and stream mode falls back. Both forms
+				//      satisfy the "new todos arrive on the wire" intent.
+				foundUpdate := false
 				for _, v := range tree.Dynamics {
 					if ops, ok := v.([]interface{}); ok {
 						for _, op := range ops {
 							if opArr, ok := op.([]interface{}); ok && len(opArr) > 0 {
-								// Accept both "i" (insert) and "a" (append) as valid granular operations
 								if opArr[0] == "i" || opArr[0] == "a" {
-									foundRangeOps = true
+									foundUpdate = true
 								}
 							}
 						}
 					}
+					if node, ok := v.(*build.TreeNode); ok && node.HasRange() && node.Range != nil && len(node.Range.Items) > 0 {
+						foundUpdate = true
+					}
 				}
-				if !foundRangeOps {
-					t.Error("Expected insert or append operations for new todos")
+				if !foundUpdate {
+					t.Error("Expected new todos to arrive via insert/append ops or full-tree replacement")
 				}
 			},
 		},

--- a/internal/diff/helpers_value.go
+++ b/internal/diff/helpers_value.go
@@ -91,10 +91,17 @@ func IsRangeConstruct(value interface{}) bool {
 	return false
 }
 
-// HasRangeItems checks if a range construct has any items in its data array.
+// HasRangeItems reports whether a range value has at least one item — the
+// logical question. Stream-mode trees count via StreamState.Keys length.
 func HasRangeItems(value interface{}) bool {
 	if node, ok := value.(*TreeNode); ok {
-		return node.HasRange() && len(node.Range.Items) > 0
+		if !node.HasRange() || node.Range == nil {
+			return false
+		}
+		if len(node.Range.Items) > 0 {
+			return true
+		}
+		return node.Range.IsStreamMode() && len(node.Range.StreamState.Keys) > 0
 	}
 	if valueMap, ok := value.(map[string]interface{}); ok {
 		if d, hasD := valueMap["d"]; hasD {

--- a/internal/diff/helpers_value.go
+++ b/internal/diff/helpers_value.go
@@ -95,7 +95,7 @@ func IsRangeConstruct(value interface{}) bool {
 // logical question. Stream-mode trees count via StreamState.Keys length.
 func HasRangeItems(value interface{}) bool {
 	if node, ok := value.(*TreeNode); ok {
-		if !node.HasRange() || node.Range == nil {
+		if !node.HasRange() {
 			return false
 		}
 		if len(node.Range.Items) > 0 {

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -290,6 +290,76 @@ func dynamicsToUpdatePayload(dynamics []interface{}, keyPos int) map[string]inte
 	return payload
 }
 
+// dispatchStreamMode runs the shared stream-mode diff. Returns (ops, true) on
+// success — empty ops mean no-change. Returns (nil, false) when extraction
+// fails or stream mode declines (het-range fingerprint mismatch); the caller
+// applies its own fallback.
+func dispatchStreamMode(streamState *RangeStreamState, newValue interface{}, clientHasRangeStatics bool) ([]interface{}, bool) {
+	newItems, statics, idKey := extractStreamModeNewSide(newValue)
+	if newItems == nil {
+		return nil, false
+	}
+	ops := GenerateRangeStreamOperations(streamState, newItems, statics, idKey, clientHasRangeStatics)
+	if ops == nil {
+		return nil, false
+	}
+	return ops, true
+}
+
+func handleStreamModeRange(oldTree, newTree *TreeNode, changes *TreeNode) bool {
+	clientHasRangeStatics := !ClientNeedsStatics(oldTree, newTree)
+	diffOps, ok := dispatchStreamMode(oldTree.Range.StreamState, newTree, clientHasRangeStatics)
+	if !ok {
+		*changes = *newTree
+		return true
+	}
+	if len(diffOps) > 0 {
+		changes.Range = &RangeData{Items: diffOps}
+		if !clientHasRangeStatics {
+			changes.Statics = newTree.Statics
+		}
+	}
+	return true
+}
+
+func handleStreamModeRangeMatch(k int, oldNode *TreeNode, newValue interface{}, changes *TreeNode) {
+	clientHasRangeStatics := !clientNeedsStaticsForValue(oldNode, newValue)
+	diffOps, ok := dispatchStreamMode(oldNode.Range.StreamState, newValue, clientHasRangeStatics)
+	if !ok {
+		handleEmptyRangeDiff(k, oldNode, newValue, changes)
+		return
+	}
+	if len(diffOps) > 0 {
+		changes.SetDynamic(k, diffOps)
+	}
+}
+
+// extractStreamModeNewSide returns the new-side range data for stream-mode
+// dispatch. Mirrors the new-side branch of extractRangeData. Returns nil
+// items if newValue is not a valid range.
+func extractStreamModeNewSide(newValue interface{}) (
+	newItems []interface{},
+	statics interface{},
+	metadata map[string]interface{},
+) {
+	newNode, ok := newValue.(*TreeNode)
+	if !ok || !newNode.HasRange() || newNode.Range == nil {
+		return nil, nil, nil
+	}
+	newItems = newNode.Range.Items
+	if newNode.Range.Statics != nil {
+		statics = newNode.Range.Statics
+	} else {
+		statics = newNode.Statics
+	}
+	if newNode.Metadata != nil {
+		metadata = map[string]interface{}{
+			"idKey": newNode.Metadata.IDKey,
+		}
+	}
+	return
+}
+
 // extractRangeData extracts items, statics, and metadata from old and new range values.
 func extractRangeData(oldValue, newValue interface{}) (
 	oldItems, newItems []interface{},

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -299,11 +299,11 @@ func dynamicsToUpdatePayload(dynamics []interface{}, keyPos int) map[string]inte
 
 // dispatchStreamMode runs the shared stream-mode diff. (nil, false) signals fallback; empty ops mean no-change.
 func dispatchStreamMode(streamState *RangeStreamState, newValue interface{}, clientHasRangeStatics bool) ([]interface{}, bool) {
-	newItems, statics, idKey := extractNewSideRange(newValue)
+	newItems, statics, metadata := extractNewSideRange(newValue)
 	if newItems == nil {
 		return nil, false
 	}
-	ops := GenerateRangeStreamOperations(streamState, newItems, statics, idKey, clientHasRangeStatics)
+	ops := GenerateRangeStreamOperations(streamState, newItems, statics, metadata, clientHasRangeStatics)
 	if ops == nil {
 		return nil, false
 	}

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -114,6 +114,13 @@ func GenerateRangeDifferentialOperations(oldValue, newValue interface{}, stripSt
 
 	ctx := newRangeContext(oldItems, newItems, statics, metadata)
 
+	// If items exist but none yield extractable keys (e.g., map items rather
+	// than *TreeNode), the diff engine cannot produce ops — signal fallback.
+	if (len(oldItems) > 0 && len(ctx.oldKeys) == 0) ||
+		(len(newItems) > 0 && len(ctx.newKeys) == 0) {
+		return nil
+	}
+
 	if isPureReorderingCtx(ctx) {
 		return []interface{}{[]interface{}{"o", ctx.newKeys}}
 	}
@@ -290,10 +297,7 @@ func dynamicsToUpdatePayload(dynamics []interface{}, keyPos int) map[string]inte
 	return payload
 }
 
-// dispatchStreamMode runs the shared stream-mode diff. Returns (ops, true) on
-// success — empty ops mean no-change. Returns (nil, false) when extraction
-// fails or stream mode declines (het-range fingerprint mismatch); the caller
-// applies its own fallback.
+// dispatchStreamMode runs the shared stream-mode diff. (nil, false) signals fallback; empty ops mean no-change.
 func dispatchStreamMode(streamState *RangeStreamState, newValue interface{}, clientHasRangeStatics bool) ([]interface{}, bool) {
 	newItems, statics, idKey := extractStreamModeNewSide(newValue)
 	if newItems == nil {
@@ -326,7 +330,9 @@ func handleStreamModeRangeMatch(k int, oldNode *TreeNode, newValue interface{}, 
 	clientHasRangeStatics := !clientNeedsStaticsForValue(oldNode, newValue)
 	diffOps, ok := dispatchStreamMode(oldNode.Range.StreamState, newValue, clientHasRangeStatics)
 	if !ok {
-		handleEmptyRangeDiff(k, oldNode, newValue, changes)
+		// Het-fallback or extraction failure — emit full new value at position k,
+		// mirroring the top-level path's *changes = *newTree fallback.
+		changes.SetDynamic(k, newValue)
 		return
 	}
 	if len(diffOps) > 0 {

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -299,7 +299,7 @@ func dynamicsToUpdatePayload(dynamics []interface{}, keyPos int) map[string]inte
 
 // dispatchStreamMode runs the shared stream-mode diff. (nil, false) signals fallback; empty ops mean no-change.
 func dispatchStreamMode(streamState *RangeStreamState, newValue interface{}, clientHasRangeStatics bool) ([]interface{}, bool) {
-	newItems, statics, idKey := extractStreamModeNewSide(newValue)
+	newItems, statics, idKey := extractNewSideRange(newValue)
 	if newItems == nil {
 		return nil, false
 	}
@@ -340,10 +340,10 @@ func handleStreamModeRangeMatch(k int, oldNode *TreeNode, newValue interface{}, 
 	}
 }
 
-// extractStreamModeNewSide returns the new-side range data for stream-mode
+// extractNewSideRange returns the new-side range data for stream-mode
 // dispatch. Mirrors the new-side branch of extractRangeData. Returns nil
 // items if newValue is not a valid range.
-func extractStreamModeNewSide(newValue interface{}) (
+func extractNewSideRange(newValue interface{}) (
 	newItems []interface{},
 	statics interface{},
 	metadata map[string]interface{},

--- a/internal/diff/transition.go
+++ b/internal/diff/transition.go
@@ -49,7 +49,10 @@ func TransitionToStreamMode(tree *build.TreeNode) {
 		keysList := make([]string, len(rd.Items))
 		hashes := make([]uint64, len(rd.Items))
 		for i, item := range rd.Items {
-			itemNode := item.(*build.TreeNode)
+			itemNode, ok := item.(*build.TreeNode)
+			if !ok {
+				continue
+			}
 			if keyStr, ok := getItemKeyWithPos(itemNode, keyPos); ok {
 				keysList[i] = keyStr
 			}

--- a/internal/diff/transition.go
+++ b/internal/diff/transition.go
@@ -1,0 +1,65 @@
+package diff
+
+import (
+	"github.com/livetemplate/livetemplate/internal/build"
+	"github.com/livetemplate/livetemplate/internal/keys"
+)
+
+// TransitionToStreamMode replaces Range.Items with a RangeStreamState snapshot
+// for top-level homogeneous ranges. Caller must hold the lock that protects tree.
+//
+// Uses CalculateStaticsFingerprint (not GetStructureFingerprint) for the
+// homogeneity check — the latter over-captures scalar position-presence,
+// falsely classifying [id, "x"] vs [id, nil] as heterogeneous.
+func TransitionToStreamMode(tree *build.TreeNode) {
+	if tree == nil {
+		return
+	}
+	for _, value := range tree.Dynamics {
+		node, ok := value.(*build.TreeNode)
+		if !ok || !node.HasRange() || node.Range == nil {
+			continue
+		}
+		rd := node.Range
+		if rd.StreamState != nil {
+			continue
+		}
+		if len(rd.Items) == 0 {
+			continue
+		}
+
+		firstItem, ok := rd.Items[0].(*build.TreeNode)
+		if !ok {
+			continue
+		}
+		ref := build.CalculateStaticsFingerprint(firstItem)
+		homogeneous := true
+		for _, item := range rd.Items[1:] {
+			itemNode, ok := item.(*build.TreeNode)
+			if !ok || build.CalculateStaticsFingerprint(itemNode) != ref {
+				homogeneous = false
+				break
+			}
+		}
+		if !homogeneous {
+			continue
+		}
+
+		keyPos := FindKeyPositionFromStatics(rd.Statics)
+		keysList := make([]string, len(rd.Items))
+		hashes := make([]uint64, len(rd.Items))
+		for i, item := range rd.Items {
+			itemNode := item.(*build.TreeNode)
+			if keyStr, ok := getItemKeyWithPos(itemNode, keyPos); ok {
+				keysList[i] = keyStr
+			}
+			hashes[i] = keys.ItemHashUint64(itemNode.Dynamics)
+		}
+		rd.StreamState = &build.RangeStreamState{
+			Keys:        keysList,
+			Hashes:      hashes,
+			Fingerprint: ref,
+		}
+		rd.Items = nil
+	}
+}

--- a/internal/diff/transition_test.go
+++ b/internal/diff/transition_test.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/livetemplate/livetemplate/internal/build"
@@ -34,7 +35,7 @@ func homoItemRangeTree(count int) *build.TreeNode {
 }
 
 func keyForIdx(i int) string {
-	return string(rune('a' + i))
+	return strconv.Itoa(i)
 }
 
 func TestTransitionToStreamMode_HomogeneousFires(t *testing.T) {

--- a/internal/diff/transition_test.go
+++ b/internal/diff/transition_test.go
@@ -1,0 +1,184 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/livetemplate/livetemplate/internal/build"
+	"github.com/livetemplate/livetemplate/internal/keys"
+)
+
+// homoItemRangeTree builds a top-level tree containing one Range with
+// `count` homogeneous items. Each item has Dynamics [keyStr, "label-N"]
+// and Statics [`<li data-key="`, `">`, `</li>`].
+func homoItemRangeTree(count int) *build.TreeNode {
+	itemStatics := []string{`<li data-key="`, `">`, `</li>`}
+	items := make([]interface{}, count)
+	for i := 0; i < count; i++ {
+		items[i] = &build.TreeNode{
+			Statics:  itemStatics,
+			Dynamics: []interface{}{keyForIdx(i), "label-" + keyForIdx(i)},
+		}
+	}
+	return &build.TreeNode{
+		Statics: []string{"<ul>", "</ul>"},
+		Dynamics: []interface{}{
+			&build.TreeNode{
+				Statics: []string{"<ul>", "</ul>"},
+				Range: &build.RangeData{
+					Items:   items,
+					Statics: itemStatics,
+				},
+			},
+		},
+	}
+}
+
+func keyForIdx(i int) string {
+	return string(rune('a' + i))
+}
+
+func TestTransitionToStreamMode_HomogeneousFires(t *testing.T) {
+	tree := homoItemRangeTree(3)
+	rangeNode := tree.Dynamics[0].(*build.TreeNode)
+	originalItems := rangeNode.Range.Items
+
+	TransitionToStreamMode(tree)
+
+	if rangeNode.Range.Items != nil {
+		t.Errorf("Items should be nil post-transition, got %v", rangeNode.Range.Items)
+	}
+	if rangeNode.Range.StreamState == nil {
+		t.Fatalf("StreamState should be populated post-transition")
+	}
+	ss := rangeNode.Range.StreamState
+	if len(ss.Keys) != 3 || len(ss.Hashes) != 3 {
+		t.Errorf("StreamState should have 3 keys and 3 hashes, got Keys=%v Hashes=%v", ss.Keys, ss.Hashes)
+	}
+	if ss.Fingerprint == "" {
+		t.Errorf("StreamState.Fingerprint should be set")
+	}
+	// Hashes must be deterministic from the original items' dynamics.
+	for i, item := range originalItems {
+		expected := keys.ItemHashUint64(item.(*build.TreeNode).Dynamics)
+		if ss.Hashes[i] != expected {
+			t.Errorf("Hashes[%d] = %d, want %d", i, ss.Hashes[i], expected)
+		}
+	}
+}
+
+func TestTransitionToStreamMode_HeterogeneousDefers(t *testing.T) {
+	tree := homoItemRangeTree(2)
+	rangeNode := tree.Dynamics[0].(*build.TreeNode)
+	// Make the second item structurally different by adding a nested *TreeNode
+	// at a new dynamic position — this changes its statics fingerprint.
+	item2 := rangeNode.Range.Items[1].(*build.TreeNode)
+	item2.Statics = []string{`<li data-key="`, `">`, `<span>`, `</span></li>`}
+	item2.Dynamics = append(item2.Dynamics, &build.TreeNode{Statics: []string{"badge"}})
+
+	TransitionToStreamMode(tree)
+
+	if rangeNode.Range.StreamState != nil {
+		t.Errorf("StreamState should be nil for heterogeneous range (deferred to legacy)")
+	}
+	if rangeNode.Range.Items == nil {
+		t.Errorf("Items should remain populated for het-deferred range")
+	}
+}
+
+func TestTransitionToStreamMode_EmptyDefers(t *testing.T) {
+	tree := homoItemRangeTree(0) // zero items
+	rangeNode := tree.Dynamics[0].(*build.TreeNode)
+
+	TransitionToStreamMode(tree)
+
+	if rangeNode.Range.StreamState != nil {
+		t.Errorf("StreamState should be nil for empty range (deferred per §5a empty-range edge case)")
+	}
+	if rangeNode.Range.Items == nil {
+		t.Errorf("Items should remain non-nil (empty slice) for empty-deferred range")
+	}
+}
+
+func TestTransitionToStreamMode_SingleItemFires(t *testing.T) {
+	tree := homoItemRangeTree(1)
+	rangeNode := tree.Dynamics[0].(*build.TreeNode)
+
+	TransitionToStreamMode(tree)
+
+	if rangeNode.Range.StreamState == nil {
+		t.Errorf("Single-item range is trivially homogeneous and should transition")
+	}
+	if len(rangeNode.Range.StreamState.Keys) != 1 {
+		t.Errorf("StreamState should have 1 key, got %d", len(rangeNode.Range.StreamState.Keys))
+	}
+}
+
+func TestTransitionToStreamMode_Idempotent(t *testing.T) {
+	tree := homoItemRangeTree(3)
+	rangeNode := tree.Dynamics[0].(*build.TreeNode)
+
+	TransitionToStreamMode(tree)
+	firstSS := rangeNode.Range.StreamState
+	if firstSS == nil {
+		t.Fatalf("Expected first transition to fire")
+	}
+
+	// Second invocation should be a no-op (StreamState already set).
+	TransitionToStreamMode(tree)
+	if rangeNode.Range.StreamState != firstSS {
+		t.Errorf("Idempotent: re-invocation should not replace StreamState pointer")
+	}
+}
+
+func TestTransitionToStreamMode_NestedRangesNotTransitioned(t *testing.T) {
+	// Outer range with one item; that item itself contains a nested range.
+	innerStatics := []string{`<sub data-key="`, `">`, `</sub>`}
+	innerItems := []interface{}{
+		&build.TreeNode{Statics: innerStatics, Dynamics: []interface{}{"x", "X"}},
+		&build.TreeNode{Statics: innerStatics, Dynamics: []interface{}{"y", "Y"}},
+	}
+	innerRangeNode := &build.TreeNode{
+		Statics: []string{"<div>", "</div>"},
+		Range: &build.RangeData{
+			Items:   innerItems,
+			Statics: innerStatics,
+		},
+	}
+
+	outerItemStatics := []string{`<li data-key="`, `">`, `</li>`}
+	outerItem := &build.TreeNode{
+		Statics:  outerItemStatics,
+		Dynamics: []interface{}{"a", innerRangeNode},
+	}
+
+	tree := &build.TreeNode{
+		Statics: []string{"<ul>", "</ul>"},
+		Dynamics: []interface{}{
+			&build.TreeNode{
+				Statics: []string{"<ul>", "</ul>"},
+				Range: &build.RangeData{
+					Items:   []interface{}{outerItem},
+					Statics: outerItemStatics,
+				},
+			},
+		},
+	}
+
+	TransitionToStreamMode(tree)
+
+	outerRange := tree.Dynamics[0].(*build.TreeNode).Range
+	if outerRange.StreamState == nil {
+		t.Errorf("Outer top-level range should transition")
+	}
+	if innerRangeNode.Range.StreamState != nil {
+		t.Errorf("Nested range MUST NOT transition (proposal §5a top-level only)")
+	}
+	if innerRangeNode.Range.Items == nil {
+		t.Errorf("Nested range Items must remain populated for legacy serialization")
+	}
+}
+
+func TestTransitionToStreamMode_NilTreeSafe(t *testing.T) {
+	// Must not panic on nil input.
+	TransitionToStreamMode(nil)
+}

--- a/internal/diff/tree_compare.go
+++ b/internal/diff/tree_compare.go
@@ -102,8 +102,14 @@ func handleTopLevelRange(
 }
 
 // handleMatchedRanges generates differential operations for matched range constructs.
-// Uses fingerprint comparison to determine if client needs range statics.
+// The IsStreamMode dispatch MUST run BEFORE any read of Range.Items —
+// otherwise a Phase-2 retained tree (Items==nil) falls through extractRangeData
+// to handleEmptyToItemsTransition, emitting a phantom ["a", items] op.
 func handleMatchedRanges(oldTree, newTree *TreeNode, changes *TreeNode) bool {
+	if oldTree.Range != nil && oldTree.Range.IsStreamMode() {
+		return handleStreamModeRange(oldTree, newTree, changes)
+	}
+
 	// Use fingerprint comparison to determine if client has range statics cached.
 	// If the structure fingerprints match, client already has the statics.
 	clientHasRangeStatics := !ClientNeedsStatics(oldTree, newTree)
@@ -120,17 +126,18 @@ func handleMatchedRanges(oldTree, newTree *TreeNode, changes *TreeNode) bool {
 			changes.Statics = newTree.Statics
 		}
 		return true
-	} else {
-		// No operations generated - check for empty range cases
-		if (newTree.Range == nil || len(newTree.Range.Items) == 0) &&
-			(oldTree.Range == nil || len(oldTree.Range.Items) == 0) {
-			// Both empty, no change
-			return true
-		}
-		// Fallback: return the new tree
-		*changes = *newTree
+	}
+
+	// No operations generated - check for empty range cases. The old side
+	// must NOT be stream-mode here (those routed through the dispatch above).
+	if (newTree.Range == nil || len(newTree.Range.Items) == 0) &&
+		(oldTree.Range == nil ||
+			(len(oldTree.Range.Items) == 0 && oldTree.Range.StreamState == nil)) {
 		return true
 	}
+	// Fallback: return the new tree
+	*changes = *newTree
+	return true
 }
 
 // compareDynamicSegments compares all dynamic fields between old and new trees.
@@ -332,8 +339,15 @@ func handleChangedField(
 }
 
 // handleRangeMatch handles changes in matched range constructs.
-// Uses fingerprint comparison to determine if client needs range statics.
+// The IsStreamMode dispatch reaches stream mode only when the nested range
+// is itself a top-level range of a different lastTree slot (the recursive case).
 func handleRangeMatch(k int, oldValue, newValue interface{}, changes *TreeNode) {
+	if oldNode, ok := oldValue.(*TreeNode); ok &&
+		oldNode.Range != nil && oldNode.Range.IsStreamMode() {
+		handleStreamModeRangeMatch(k, oldNode, newValue, changes)
+		return
+	}
+
 	// Use fingerprint comparison to determine if client has range statics cached.
 	clientHasRangeStatics := !clientNeedsStaticsForValue(oldValue, newValue)
 

--- a/internal/diff/tree_compare.go
+++ b/internal/diff/tree_compare.go
@@ -114,29 +114,25 @@ func handleMatchedRanges(oldTree, newTree *TreeNode, changes *TreeNode) bool {
 	// If the structure fingerprints match, client already has the statics.
 	clientHasRangeStatics := !ClientNeedsStatics(oldTree, newTree)
 
-	// Strip statics if client already has them cached
+	// Strip statics if client already has them cached.
+	// nil signals "cannot express; full-tree fallback"; empty (non-nil) means no-change.
 	diffOps := GenerateRangeDifferentialOperations(oldTree, newTree, clientHasRangeStatics)
 
-	if len(diffOps) > 0 {
-		// Return the operations directly - the entire tree is the range
-		changes.Range = &RangeData{Items: diffOps}
+	if diffOps == nil {
+		if (newTree.Range == nil || len(newTree.Range.Items) == 0) &&
+			(oldTree.Range == nil || len(oldTree.Range.Items) == 0) {
+			return true
+		}
+		*changes = *newTree
+		return true
+	}
 
-		// Only include root-level statics if client needs them (structure changed)
+	if len(diffOps) > 0 {
+		changes.Range = &RangeData{Items: diffOps}
 		if !clientHasRangeStatics {
 			changes.Statics = newTree.Statics
 		}
-		return true
 	}
-
-	// No operations generated - check for empty range cases. The old side
-	// must NOT be stream-mode here (those routed through the dispatch above).
-	if (newTree.Range == nil || len(newTree.Range.Items) == 0) &&
-		(oldTree.Range == nil ||
-			(len(oldTree.Range.Items) == 0 && oldTree.Range.StreamState == nil)) {
-		return true
-	}
-	// Fallback: return the new tree
-	*changes = *newTree
 	return true
 }
 

--- a/internal/fuzz/invariants/helpers.go
+++ b/internal/fuzz/invariants/helpers.go
@@ -24,12 +24,15 @@ func TreeToMap(tree *build.TreeNode) map[string]any {
 	}
 
 	if tree.HasRange() && tree.Range != nil {
-		// Convert range items recursively
-		convertedItems := make([]any, len(tree.Range.Items))
-		for i, item := range tree.Range.Items {
-			convertedItems[i] = convertValue(item)
+		// Stream-mode trees omit "d" entirely (see TreeNode.MarshalJSON);
+		// emitting "d": [] would diverge from the wire shape.
+		if tree.Range.Items != nil {
+			convertedItems := make([]any, len(tree.Range.Items))
+			for i, item := range tree.Range.Items {
+				convertedItems[i] = convertValue(item)
+			}
+			result["d"] = convertedItems
 		}
-		result["d"] = convertedItems
 		if tree.Range.Statics != nil {
 			result["s"] = tree.Range.Statics
 		}

--- a/internal/fuzz/invariants/verifier.go
+++ b/internal/fuzz/invariants/verifier.go
@@ -227,7 +227,7 @@ func verifyTreeStructureRecursive(tree *build.TreeNode, path string, v *Verifier
 		}
 	}
 
-	// Check range items
+	// Check range items. Stream-mode ranges have nil Items, so the loop is a no-op.
 	if tree.HasRange() && tree.Range != nil {
 		for i, item := range tree.Range.Items {
 			if itemTree, ok := item.(*build.TreeNode); ok {
@@ -392,11 +392,21 @@ func extractAllRanges(tree *build.TreeNode, path string) map[string]*build.Range
 	return ranges
 }
 
-// buildIDKeyMap builds a map from item IDs to their keys.
+// buildIDKeyMap builds a map from item IDs to their keys. For stream-mode
+// trees, the key column IS the identifier, so id and key collapse.
 func buildIDKeyMap(rangeData *build.RangeData) map[string]string {
 	idToKey := make(map[string]string)
 
 	if rangeData == nil {
+		return idToKey
+	}
+
+	if rangeData.IsStreamMode() {
+		for _, k := range rangeData.StreamState.Keys {
+			if k != "" {
+				idToKey[k] = k
+			}
+		}
 		return idToKey
 	}
 

--- a/internal/keys/generator.go
+++ b/internal/keys/generator.go
@@ -168,6 +168,25 @@ func (kg *Generator) LoadExistingKeys(oldRangeData []interface{}) error {
 	return nil
 }
 
+// LoadExistingKeysFromSlice loads existing keys from a stream-mode RangeStreamState.Keys
+// slice and updates the counter. Same numeric-key-max-tracking logic as
+// LoadExistingKeys but reads keys directly from the slice instead of extracting
+// them from per-item dynamics. Non-numeric keys are skipped.
+//
+// Used by LoadExistingKeyMappings on stream-mode trees where Range.Items is nil
+// and the canonical key list lives on Range.StreamState.Keys.
+func (kg *Generator) LoadExistingKeysFromSlice(existingKeys []string) error {
+	kg.mu.Lock()
+	defer kg.mu.Unlock()
+
+	for _, keyStr := range existingKeys {
+		if keyInt, err := strconv.Atoi(keyStr); err == nil && keyInt > kg.counter {
+			kg.counter = keyInt
+		}
+	}
+	return nil
+}
+
 // DetectIDKey detects which position in the dynamics contains the item ID
 // by scanning the statics array for key attribute patterns.
 // Returns the position as a string-formatted index (e.g., "0", "1", "2")

--- a/internal/keys/generator.go
+++ b/internal/keys/generator.go
@@ -168,13 +168,7 @@ func (kg *Generator) LoadExistingKeys(oldRangeData []interface{}) error {
 	return nil
 }
 
-// LoadExistingKeysFromSlice loads existing keys from a stream-mode RangeStreamState.Keys
-// slice and updates the counter. Same numeric-key-max-tracking logic as
-// LoadExistingKeys but reads keys directly from the slice instead of extracting
-// them from per-item dynamics. Non-numeric keys are skipped.
-//
-// Used by LoadExistingKeyMappings on stream-mode trees where Range.Items is nil
-// and the canonical key list lives on Range.StreamState.Keys.
+// LoadExistingKeysFromSlice mirrors LoadExistingKeys but reads keys directly from a slice (stream-mode source).
 func (kg *Generator) LoadExistingKeysFromSlice(existingKeys []string) error {
 	kg.mu.Lock()
 	defer kg.mu.Unlock()

--- a/internal/keys/loader.go
+++ b/internal/keys/loader.go
@@ -30,7 +30,11 @@ func LoadExistingKeyMappings(gen *Generator, lastTree *build.TreeNode) error {
 		// Check if this is a TreeNode with Range data
 		if node, ok := value.(*build.TreeNode); ok {
 			if node.HasRange() && node.Range != nil {
-				if err := gen.LoadExistingKeys(node.Range.Items); err != nil {
+				if node.Range.IsStreamMode() {
+					if err := gen.LoadExistingKeysFromSlice(node.Range.StreamState.Keys); err != nil {
+						return fmt.Errorf("loadExistingKeyMappings (stream): %w", err)
+					}
+				} else if err := gen.LoadExistingKeys(node.Range.Items); err != nil {
 					return fmt.Errorf("loadExistingKeyMappings: %w", err)
 				}
 			}

--- a/streaming_range_phase3_test.go
+++ b/streaming_range_phase3_test.go
@@ -209,11 +209,23 @@ func TestStreamMode_HetRangeFallback(t *testing.T) {
 	out := buf.String()
 
 	// Het-fallback wire shape: the changes tree carries the new range as a
-	// nested tree at the range's dynamic position (NOT a `["a"]`/`["i"]` op
-	// array). Look for the new item's text "b" inside the payload — it must
-	// appear because the fallback emits the full new range, including all items.
-	if !strings.Contains(out, `"b"`) {
-		t.Errorf("het-fallback should include the new item's text in full-tree payload; got: %s", out)
+	// nested tree at the range's dynamic position — NOT granular `["a"]`/`["u"]`
+	// ops. The retained tree's range position must hold a *TreeNode (the full
+	// new range) whose Range.Items includes an entry with key "2" and Text "b".
+	rangeNode := tmpl.lastTree.Dynamics[0].(*build.TreeNode)
+	if rangeNode.Range == nil || len(rangeNode.Range.Items) != 2 {
+		t.Fatalf("retained range should have 2 items after het-fallback; got: %#v", rangeNode.Range)
+	}
+	item2 := rangeNode.Range.Items[1].(*build.TreeNode)
+	if got := item2.Dynamics[0]; got != "2" {
+		t.Errorf("item[1] key should be %q, got %q", "2", got)
+	}
+	if got := item2.Dynamics[1]; got != "b" {
+		t.Errorf("item[1] text should be %q, got %q", "b", got)
+	}
+	// Wire output: no granular range ops emitted.
+	if strings.Contains(out, `["u",`) || strings.Contains(out, `["a",`) || strings.Contains(out, `["i",`) {
+		t.Errorf("het-fallback must NOT emit granular range ops; got: %s", out)
 	}
 }
 

--- a/streaming_range_phase3_test.go
+++ b/streaming_range_phase3_test.go
@@ -1,0 +1,317 @@
+package livetemplate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/livetemplate/internal/build"
+)
+
+// homoTodo is a homogeneous range item — no conditional inside, so all items
+// share the same statics fingerprint after the transition.
+type homoTodo struct {
+	ID   string
+	Text string
+}
+
+type homoTodoState struct {
+	Todos []homoTodo
+}
+
+const homoTodoTemplate = `<ul>{{range .Todos}}<li data-key="{{.ID}}">{{.Text}}</li>{{end}}</ul>`
+
+// renderTwice renders the template twice with the given states and returns
+// the JSON of the second render (the changes tree).
+func renderTwice(t *testing.T, tmpl *Template, s1, s2 interface{}) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteUpdates(&buf, s1); err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	buf.Reset()
+	if err := tmpl.ExecuteUpdates(&buf, s2); err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	return buf.String()
+}
+
+// TestStreamMode_FiresOnSecondRender verifies that after a homogeneous first
+// render, the second render's diff routes through stream mode rather than the
+// legacy GenerateRangeDifferentialOperations path. Asserts via the wire shape
+// of an update op (stream mode emits whole-item dynamics; legacy emits partial
+// deltas).
+func TestStreamMode_FiresOnSecondRender(t *testing.T) {
+	tmpl := Must(New("stream-fires"))
+	if _, err := tmpl.Parse(homoTodoTemplate); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	s1 := homoTodoState{Todos: []homoTodo{
+		{ID: "1", Text: "first"},
+		{ID: "2", Text: "second"},
+	}}
+	s2 := homoTodoState{Todos: []homoTodo{
+		{ID: "1", Text: "FIRST"}, // text changed
+		{ID: "2", Text: "second"},
+	}}
+
+	out := renderTwice(t, tmpl, s1, s2)
+
+	// Stream-mode emits whole-item dynamics; legacy emits partial deltas.
+	if !strings.Contains(out, `["u","1",`) {
+		t.Fatalf("expected stream-mode [\"u\", \"1\", ...] op, got: %s", out)
+	}
+	// Regression gate (test plan item 8): a stream-mode no-content-add render
+	// must NOT emit ["a", ...] — that would mean dispatch fell through to
+	// extractRangeData → handleEmptyToItemsTransition on a nil Items tree.
+	if strings.Contains(out, `["a",`) {
+		t.Errorf("unexpected [\"a\", ...] op — extractRangeData fall-through regression; output: %s", out)
+	}
+}
+
+// TestStreamMode_ReconnectResyncEmitsFullTree (test plan item 4) — simulates
+// connection drop by clearing lastTree, then renders again. Result MUST be a
+// full tree (statics + items), not stream-mode update ops.
+func TestStreamMode_ReconnectResyncEmitsFullTree(t *testing.T) {
+	tmpl := Must(New("reconnect"))
+	if _, err := tmpl.Parse(homoTodoTemplate); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	state := homoTodoState{Todos: []homoTodo{
+		{ID: "1", Text: "first"},
+		{ID: "2", Text: "second"},
+	}}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteUpdates(&buf, state); err != nil {
+		t.Fatalf("initial render: %v", err)
+	}
+	if err := tmpl.ExecuteUpdates(&bytes.Buffer{}, state); err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+
+	// Simulate reconnect: drop lastTree + reset hasInitialTree.
+	tmpl.mu.Lock()
+	tmpl.lastTree = nil
+	tmpl.hasInitialTree = false
+	tmpl.mu.Unlock()
+
+	buf.Reset()
+	if err := tmpl.ExecuteUpdates(&buf, state); err != nil {
+		t.Fatalf("post-reconnect render: %v", err)
+	}
+	resync := buf.String()
+
+	// First render after reconnect MUST include statics — the client lost them.
+	if !strings.Contains(resync, `"s":[`) {
+		t.Errorf("post-reconnect render missing statics; got: %s", resync)
+	}
+	// MUST NOT contain stream-mode update ops — those would assume the client
+	// has retained item state, but a reconnected client has nothing.
+	if strings.Contains(resync, `["u","1",`) || strings.Contains(resync, `["u","2",`) {
+		t.Errorf("post-reconnect render should NOT contain stream-mode update ops; got: %s", resync)
+	}
+}
+
+// TestStreamMode_FullDynamicsMapInvariant (test plan item 9) — every stream-mode
+// ["u"] payload must include every dynamic position (with "" for absent / nil),
+// not just the changed positions. Proposal §5c.
+func TestStreamMode_FullDynamicsMapInvariant(t *testing.T) {
+	// Template with multiple dynamic positions per item — Done is intentionally
+	// kept as a scalar boolean (no {{if}}) so items stay homogeneous and stream
+	// mode actually fires.
+	const tmplSrc = `<ul>{{range .Items}}<li data-key="{{.ID}}">{{.Text}} {{.Author}} {{.Tag}}</li>{{end}}</ul>`
+	type item struct {
+		ID, Text, Author, Tag string
+	}
+	type state struct {
+		Items []item
+	}
+
+	tmpl := Must(New("full-dyn-map"))
+	if _, err := tmpl.Parse(tmplSrc); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	s1 := state{Items: []item{
+		{ID: "1", Text: "alpha", Author: "alice", Tag: "x"},
+		{ID: "2", Text: "beta", Author: "bob", Tag: "y"},
+	}}
+	s2 := state{Items: []item{
+		{ID: "1", Text: "ALPHA", Author: "alice", Tag: "x"}, // only Text changed
+		{ID: "2", Text: "beta", Author: "bob", Tag: "y"},
+	}}
+
+	out := renderTwice(t, tmpl, s1, s2)
+
+	// Locate the ["u","1",{...}] op and verify the payload map carries every
+	// non-key position (1, 2, 3 — position 0 is the key column, omitted).
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse failed: %v\noutput: %s", err, out)
+	}
+	rangeOps := findRangeOps(parsed)
+	if rangeOps == nil {
+		t.Fatalf("no range ops found in output: %s", out)
+	}
+	var updateOp []interface{}
+	for _, op := range rangeOps {
+		if arr, ok := op.([]interface{}); ok && len(arr) >= 3 && arr[0] == "u" && arr[1] == "1" {
+			updateOp = arr
+			break
+		}
+	}
+	if updateOp == nil {
+		t.Fatalf(`no ["u", "1", ...] op found in: %s`, out)
+	}
+	payload, ok := updateOp[2].(map[string]interface{})
+	if !ok {
+		t.Fatalf("update op payload is not a map: %T", updateOp[2])
+	}
+	// Per §5c: every non-key position present. Item template positions: 0=ID
+	// (key, omitted), 1=Text, 2=Author, 3=Tag. Payload must have 1, 2, 3 — not
+	// just position 1 (the changed one).
+	for _, pos := range []string{"1", "2", "3"} {
+		if _, present := payload[pos]; !present {
+			t.Errorf("payload missing position %q (full-dynamics-map invariant); payload: %v", pos, payload)
+		}
+	}
+}
+
+// TestStreamMode_HetRangeFallback verifies that a range with a conditional
+// inside (which produces structurally heterogeneous items) does NOT emit
+// stream-mode ops once item structures diverge. Per proposal §5d, the diff
+// path falls back to a full-tree replacement — the dispatch routes through
+// handleEmptyRangeDiff, which emits the new range tree at the dynamic position.
+func TestStreamMode_HetRangeFallback(t *testing.T) {
+	const tmplSrc = `<ul>{{range .Items}}<li data-key="{{.ID}}">{{.Text}}{{if .Flagged}}<span>!</span>{{end}}</li>{{end}}</ul>`
+	type item struct {
+		ID, Text string
+		Flagged  bool
+	}
+	type state struct {
+		Items []item
+	}
+
+	tmpl := Must(New("het-fallback"))
+	if _, err := tmpl.Parse(tmplSrc); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// Render 1: one item, all flagged → trivially homogeneous → transitions.
+	s1 := state{Items: []item{{ID: "1", Text: "a", Flagged: true}}}
+	// Render 2: add an unflagged item → heterogeneous (flagged vs non-flagged
+	// items have different child-tree structure → divergent statics fingerprints).
+	s2 := state{Items: []item{
+		{ID: "1", Text: "a", Flagged: true},
+		{ID: "2", Text: "b", Flagged: false},
+	}}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteUpdates(&buf, s1); err != nil {
+		t.Fatalf("render 1: %v", err)
+	}
+	buf.Reset()
+	if err := tmpl.ExecuteUpdates(&buf, s2); err != nil {
+		t.Fatalf("render 2: %v", err)
+	}
+	out := buf.String()
+
+	// Het-fallback wire shape: the changes tree carries the new range as a
+	// nested tree at the range's dynamic position (NOT a `["a"]`/`["i"]` op
+	// array). Look for the new item's text "b" inside the payload — it must
+	// appear because the fallback emits the full new range, including all items.
+	if !strings.Contains(out, `"b"`) {
+		t.Errorf("het-fallback should include the new item's text in full-tree payload; got: %s", out)
+	}
+}
+
+// findRangeOps walks the parsed wire tree looking for a position whose value
+// is a JSON array (stream-mode op array). Returns the ops slice or nil.
+func findRangeOps(node map[string]interface{}) []interface{} {
+	for _, v := range node {
+		if arr, ok := v.([]interface{}); ok {
+			return arr
+		}
+		if nested, ok := v.(map[string]interface{}); ok {
+			if found := findRangeOps(nested); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+// TestStreamMode_MemoryRegression (test plan item 2) — measures the heap delta
+// from nilling Range.Items after transition. Renders the SAME state twice;
+// render 2's no-change diff hits the early-return so t.lastTree stays the
+// (now-transitioned) render-1 tree, observable in the assertions.
+func TestStreamMode_MemoryRegression(t *testing.T) {
+	if testing.Short() {
+		t.Skip("memory regression test skipped in -short")
+	}
+
+	for _, n := range []int{10, 100, 1000, 10000} {
+		t.Run(fmt.Sprintf("N=%d", n), func(t *testing.T) {
+			tmpl := Must(New("mem-" + fmt.Sprint(n)))
+			if _, err := tmpl.Parse(homoTodoTemplate); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			items := make([]homoTodo, n)
+			for i := 0; i < n; i++ {
+				items[i] = homoTodo{ID: fmt.Sprintf("k%d", i), Text: fmt.Sprintf("text-%d", i)}
+			}
+			state := homoTodoState{Todos: items}
+
+			// First render: builds initial tree (Items populated, no transition yet).
+			if err := tmpl.ExecuteUpdates(&bytes.Buffer{}, state); err != nil {
+				t.Fatalf("render 1: %v", err)
+			}
+
+			// Snapshot heap with items retained in lastTree.
+			runtime.GC()
+			runtime.GC()
+			var withItems runtime.MemStats
+			runtime.ReadMemStats(&withItems)
+
+			// Second render: top-of-buildTree transition fires — Items becomes nil
+			// on lastTree's range, replaced by StreamState.
+			if err := tmpl.ExecuteUpdates(&bytes.Buffer{}, state); err != nil {
+				t.Fatalf("render 2: %v", err)
+			}
+
+			// Verify transition fired.
+			rangeNode := tmpl.lastTree.Dynamics[0].(*build.TreeNode)
+			if rangeNode.Range.StreamState == nil {
+				t.Fatalf("expected stream-mode after second render, but StreamState is nil")
+			}
+			if rangeNode.Range.Items != nil {
+				t.Fatalf("expected Items=nil after transition, got len=%d", len(rangeNode.Range.Items))
+			}
+
+			runtime.GC()
+			runtime.GC()
+			var afterTransition runtime.MemStats
+			runtime.ReadMemStats(&afterTransition)
+
+			// Heap accounting is noisy but the delta should be substantial at
+			// large N. We log the numbers (audit-checkpoint capture) and assert
+			// only a sanity floor — the proposal's ≥4× claim is the design
+			// target, not a CI gate (per-allocator variance in Go can swing
+			// individual measurements by 20-30%).
+			delta := int64(withItems.HeapAlloc) - int64(afterTransition.HeapAlloc)
+			perItem := float64(delta) / float64(n)
+			t.Logf("N=%d: heap with items=%d, after transition=%d, delta=%d (%.1f bytes/item)",
+				n, withItems.HeapAlloc, afterTransition.HeapAlloc, delta, perItem)
+
+			// Sanity floor at large N: transition must shrink the heap, not grow it.
+			// Small N can be dominated by allocator noise, so only assert at N>=1000.
+			if n >= 1000 && delta <= 0 {
+				t.Errorf("expected heap to shrink after transition at N=%d; delta=%d", n, delta)
+			}
+		})
+	}
+}

--- a/streaming_range_phase3_test.go
+++ b/streaming_range_phase3_test.go
@@ -11,8 +11,7 @@ import (
 	"github.com/livetemplate/livetemplate/internal/build"
 )
 
-// homoTodo is a homogeneous range item — no conditional inside, so all items
-// share the same statics fingerprint after the transition.
+// homoTodo is a homogeneous range item (no conditional inside).
 type homoTodo struct {
 	ID   string
 	Text string
@@ -24,8 +23,7 @@ type homoTodoState struct {
 
 const homoTodoTemplate = `<ul>{{range .Todos}}<li data-key="{{.ID}}">{{.Text}}</li>{{end}}</ul>`
 
-// renderTwice renders the template twice with the given states and returns
-// the JSON of the second render (the changes tree).
+// renderTwice renders twice and returns the second render's JSON.
 func renderTwice(t *testing.T, tmpl *Template, s1, s2 interface{}) string {
 	t.Helper()
 	var buf bytes.Buffer
@@ -39,11 +37,7 @@ func renderTwice(t *testing.T, tmpl *Template, s1, s2 interface{}) string {
 	return buf.String()
 }
 
-// TestStreamMode_FiresOnSecondRender verifies that after a homogeneous first
-// render, the second render's diff routes through stream mode rather than the
-// legacy GenerateRangeDifferentialOperations path. Asserts via the wire shape
-// of an update op (stream mode emits whole-item dynamics; legacy emits partial
-// deltas).
+// TestStreamMode_FiresOnSecondRender — after a homogeneous first render, the second render must route through stream mode.
 func TestStreamMode_FiresOnSecondRender(t *testing.T) {
 	tmpl := Must(New("stream-fires"))
 	if _, err := tmpl.Parse(homoTodoTemplate); err != nil {
@@ -72,9 +66,7 @@ func TestStreamMode_FiresOnSecondRender(t *testing.T) {
 	}
 }
 
-// TestStreamMode_ReconnectResyncEmitsFullTree (test plan item 4) — simulates
-// connection drop by clearing lastTree, then renders again. Result MUST be a
-// full tree (statics + items), not stream-mode update ops.
+// TestStreamMode_ReconnectResyncEmitsFullTree (item 4) — clear lastTree, render again, expect full tree (not stream ops).
 func TestStreamMode_ReconnectResyncEmitsFullTree(t *testing.T) {
 	tmpl := Must(New("reconnect"))
 	if _, err := tmpl.Parse(homoTodoTemplate); err != nil {
@@ -181,11 +173,7 @@ func TestStreamMode_FullDynamicsMapInvariant(t *testing.T) {
 	}
 }
 
-// TestStreamMode_HetRangeFallback verifies that a range with a conditional
-// inside (which produces structurally heterogeneous items) does NOT emit
-// stream-mode ops once item structures diverge. Per proposal §5d, the diff
-// path falls back to a full-tree replacement — the dispatch routes through
-// handleEmptyRangeDiff, which emits the new range tree at the dynamic position.
+// TestStreamMode_HetRangeFallback — once item structures diverge ({{if}} inside range), §5d fallback emits the full new range tree.
 func TestStreamMode_HetRangeFallback(t *testing.T) {
 	const tmplSrc = `<ul>{{range .Items}}<li data-key="{{.ID}}">{{.Text}}{{if .Flagged}}<span>!</span>{{end}}</li>{{end}}</ul>`
 	type item struct {
@@ -230,11 +218,18 @@ func TestStreamMode_HetRangeFallback(t *testing.T) {
 }
 
 // findRangeOps walks the parsed wire tree looking for a position whose value
-// is a JSON array (stream-mode op array). Returns the ops slice or nil.
+// is an op-array (each element is itself a []interface{} op tuple). Skips
+// reserved wire keys ("s" statics, "f" fingerprint, "m" metadata) — Go map
+// iteration is randomized, so the candidate must be shape-validated.
 func findRangeOps(node map[string]interface{}) []interface{} {
-	for _, v := range node {
-		if arr, ok := v.([]interface{}); ok {
-			return arr
+	for k, v := range node {
+		if k == "s" || k == "f" || k == "m" {
+			continue
+		}
+		if arr, ok := v.([]interface{}); ok && len(arr) > 0 {
+			if _, isOpTuple := arr[0].([]interface{}); isOpTuple {
+				return arr
+			}
 		}
 		if nested, ok := v.(map[string]interface{}); ok {
 			if found := findRangeOps(nested); found != nil {

--- a/template.go
+++ b/template.go
@@ -1656,6 +1656,12 @@ func (t *Template) buildTree(data interface{}, messages map[string]string) (*tre
 		t.keyGen = compat.NewKeyGenerator()
 	}
 
+	// Transition the previous render's retained tree at the START of this
+	// render. Doing it at the lastTree assignment sites would alias the wire
+	// output on the first render. Placement before LoadExistingKeyMappings
+	// lets the loader exercise the stream-mode key path.
+	diff.TransitionToStreamMode(t.lastTree)
+
 	// Load existing key mappings if available
 	if t.lastTree != nil {
 		if err := keys.LoadExistingKeyMappings(t.keyGen, t.lastTree); err != nil {


### PR DESCRIPTION
## Summary

Phase 3 of the streaming range refactor — the irreversible cutover. Wires `GenerateRangeStreamOperations` (built in Phase 2 #363) into production. Stream mode is now the default for homogeneous ranges; the legacy `GenerateRangeDifferentialOperations` path is reached only via the het-range fallback per proposal §5d.

- New `internal/diff/transition.go::TransitionToStreamMode` — top-level walker that builds `RangeStreamState` and nils `Range.Items` for homogeneous ranges
- Dispatch in `internal/diff/tree_compare.go` at `handleMatchedRanges` + `handleRangeMatch` — runs BEFORE any read of `Range.Items` (the regression gate from test plan item 8)
- Adapter helpers in `internal/diff/range_ops.go` (`handleStreamModeRange`, `handleStreamModeRangeMatch`, `dispatchStreamMode`, `extractStreamModeNewSide`)
- Single transition site at top of `template.go::buildTree` (before `LoadExistingKeyMappings`) — runs on the previous render's `lastTree`, avoiding the wire-aliasing pitfall at the `lastTree =` assignment slots
- Read-site adaptations: `helpers_value.go::HasRangeItems`, `keys/loader.go` (+ new `LoadExistingKeysFromSlice`), `fuzz/invariants/{verifier,helpers}.go`

## Test plan

- [x] `GOWORK=off go test ./...` — green
- [x] `GOWORK=off go test -race -count=1 ./internal/diff/... ./internal/keys/... ./internal/build/... ./internal/fuzz/...` — race-clean
- [x] `GOWORK=off go test -race -count=1 ./` — race-clean (root pkg, 457s; covers the `t.mu` chain through transition + diff + wire serialization)
- [x] Memory regression at N ∈ {10, 100, 1k, 10k}: ~273 bytes/item delta at N=10k, ~9.5x reduction vs legacy (well above proposal's >=4x target)
- [x] Sibling-repo verification: `examples/` full chromedp suite green; `lvt/e2e/` browser-tagged tests including `livetemplate_core_test.go` (TestTemplate_E2E_CompleteRenderingSequence covers add, remove, complete, sort, insert at start/middle, multi-op, no-change, performance)
- [x] Manual UX testing on iPhone over Tailscale (patterns server: lists, forms, navigation patterns)
- [x] Audit checkpoint appended to `docs/proposals/streaming-range-impl-audit.md`

## User-visible behavior change

Templates with `{{if}}` inside `{{range}}` (a common pattern) now produce **full-tree replacements** instead of granular ops once item structures diverge. This is proposal §5d "het-range fallback" — accepted by design. Functionally identical to the user; payloads are larger only on those renders.

## Phase 3 follow-ups (deferred)

- `prepare.go` StreamState propagation + `helpers_compare.go::rangeItemsEqual` extension — both planned per §10 but determined to be defensive code (call paths today never see populated StreamState through these functions). Reinstate if a real call site materialises (e.g., a broadcast path).
- Test plan item 10 (browser E2E in `lvt` repo) — out of scope; the Go-side wire-format invariants are tested here, and the client's existing `mergeRangeItem` already accepts whole-item maps so no client change required.
- Phase 4 cleanup: delete `CompareRangeItemsForChanges` and `compareRangeItemsWithKeyPos`; update `docs/specifications/tree-update-specification.md` per §5c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)