### PR TITLE
feat: streaming range Phase 4 — cleanup + spec update

### DIFF
--- a/docs/proposals/streaming-range-impl-audit.md
+++ b/docs/proposals/streaming-range-impl-audit.md
@@ -470,12 +470,12 @@ Het ranges with kept-item content changes now emit full-tree replacement instead
 ### Test count delta
 
 - 1 new unit test in `internal/diff/transition_test.go` (`TestTransitionToStreamMode_RootRangeFires`)
-- 3 new unit tests in `internal/diff/range_ops_test.go` (`_KeptItemContentChange_FallsBack`, `_StructuralAndContent_FallsBack`, `_PureStructural_StillEmitsOps`)
+- 5 new unit tests in `internal/diff/range_ops_test.go` (`_KeptItemContentChange_FallsBack`, `_StructuralAndContent_FallsBack`, `_PureStructural_StillEmitsOps`, `_StaticsOnlyChange_FallsBack`, `TestHasKeptItemChanged_NonTreeNodeReturnsTrue`)
 - 3 migrated tests in `internal/diff/range_ops_test.go` (`_Mixed`, `_UpdateAndReorder`, `_MultipleUpdatesAndReorder` — assert nil-return)
 - 16 deleted tests in `internal/diff/range_ops_test.go` (13 `TestCompareRangeItemsForChanges_*`, `TestGenerateUpdateOperations`, `TestGenerateRangeDifferentialOperations_Update`, `_UpdateNoReorder`)
 - 2 deleted subtests in `e2e_update_spec_test.go` (`update_single`, `mixed_operations`)
 
-**Net: 4 new + 3 migrated − 18 deleted = −11 tests.**
+**Net: 6 new + 3 migrated − 18 deleted = −9 tests.**
 
 The deletion delta is intentional: per-item ["u"] ops no longer exist as a wire shape, so tests that asserted them have no behavior left to verify. New tests cover the surviving fallback contract.
 

--- a/docs/proposals/streaming-range-impl-audit.md
+++ b/docs/proposals/streaming-range-impl-audit.md
@@ -426,6 +426,90 @@ Phase 4's cleanup audit can verify "no production caller of `compareRangeItemsWi
 
 ---
 
+## Phase 4 audit checkpoint
+
+**Date**: 2026-05-01
+**Branch**: `phase4/streaming-range-cleanup` → PR pending
+**Base commit**: `6d46c35e` (Phase 3 merge on `main`)
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `internal/diff/range_ops.go` | Deleted `generateUpdateOps`, `CompareRangeItemsForChanges`, `compareRangeItemsWithKeyPos`, `handleNestedTreeNodeChange` (~120 lines). Removed `operations = generateUpdateOps(ctx, operations)` call site. Added new helper `hasKeptItemContentChanged(ctx)` and an early-return guard in `GenerateRangeDifferentialOperations` that signals nil-return on any kept-item content hash mismatch — `handleMatchedRanges` then falls through to `*changes = *newTree` per §5d |
+| `internal/diff/helpers_value.go` | Deleted `isMeaningfulValue` (~20 lines, sole caller was the deleted `compareRangeItemsWithKeyPos`) |
+| `internal/diff/transition.go` | **Phase 3 coverage gap closed**: `TransitionToStreamMode` now transitions root-level ranges in addition to direct-child ranges in Dynamics. Templates without wrapper elements (e.g., `{{range .Items}}<li>...{{end}}` rendered standalone) now stream-mode correctly. Extracted `transitionRangeIfHomogeneous` helper for both call sites |
+| `internal/diff/transition_test.go` | Added `TestTransitionToStreamMode_RootRangeFires` covering the new root-range path |
+| `internal/diff/range_ops_test.go` | Deleted 13 `TestCompareRangeItemsForChanges_*` tests, `TestGenerateUpdateOperations`, `TestGenerateRangeDifferentialOperations_Update`. Migrated `_Mixed`, `_UpdateAndReorder`, `_MultipleUpdatesAndReorder` to assert nil-return (full-tree fallback signal). Deleted `_UpdateNoReorder` (covered by new `_KeptItemContentChange_FallsBack`). Added 3 new tests: `_KeptItemContentChange_FallsBack`, `_StructuralAndContent_FallsBack`, `_PureStructural_StillEmitsOps` |
+| `e2e_update_spec_test.go` | Removed `update_single` and `mixed_operations` subtests of `TestUpdateSpecification_RangeOperations` — both asserted partial-delta `["u"]` shapes that no longer exist on the wire. Behavior covered by the new internal/diff tests above |
+| `docs/specifications/tree-update-specification.md` | Replaced "Only changed fields are included in the changes object." (line 377) with the §5c full-snapshot contract + the §232 consumer-side replace-not-merge contract. Added one example showing `""` encoding for cleared fields |
+| `docs/proposals/streaming-range-impl-audit.md` | Appended this Phase 4 checkpoint section |
+
+### Behavioral changes
+
+- **Het-range content updates**: pre-Phase-4, kept-item content changes for het ranges emitted partial-delta `["u", key, {changed-fields-only}]` ops via `generateUpdateOps`. Post-Phase-4, those changes signal nil-return → `handleMatchedRanges` falls through to `*changes = *newTree` (full-tree replacement). This matches the §5d contract that het ranges are handled by full-tree emission.
+- **Het-range pure-structural changes**: unchanged — pure adds/removes/reorders without kept-item content drift still emit compact `["a"]`/`["i"]`/`["r"]`/`["o"]` ops via the surviving `generateRemovalOps`/`generateInsertionOps`/reorder path. Approach A from the plan preserves this wire-size win.
+- **Wrapper-less template streams correctly**: pre-Phase-4, templates whose root tree IS the range (no wrapper element) silently went through the legacy partial-delta path because `TransitionToStreamMode` only walked `tree.Dynamics`. Post-Phase-4, root ranges transition like any other top-level range and emit stream-mode `["u"]` ops with full snapshots.
+
+### Wire regression accepted
+
+Het ranges with kept-item content changes now emit full-tree replacement instead of partial-delta `["u"]` ops. Pure-structural changes to het ranges (add-only, remove-only, reorder-only) still emit compact ops via the surviving structural path — Approach A from the plan preserves this wire-size win. Homogeneous ranges are unaffected: they transition to stream mode on render 2 and emit compact `["u"]` with full snapshots per §5c. The wire regression is bounded to the het-range subset and is acceptable per §5d's "het ranges always full-tree" contract.
+
+### Per Phase 4 audit checkpoint requirement
+
+> Per proposal §323 Phase 4 audit checkpoint: "`grep CompareRangeItemsForChanges` and `grep compareRangeItemsWithKeyPos` return no hits. Spec doc diff matches the §5c/§8 language exactly. CI green across all suites."
+
+- **`grep CompareRangeItemsForChanges`**: zero hits (`grep -rn "CompareRangeItemsForChanges" .worktrees/streaming-range-phase4 --include="*.go"` returns empty).
+- **`grep compareRangeItemsWithKeyPos`**: zero hits.
+- **`grep handleNestedTreeNodeChange`**: zero hits (cascade deletion).
+- **`grep isMeaningfulValue`**: zero hits (cascade deletion).
+- **`grep generateUpdateOps`**: zero hits (cascade deletion).
+- **Spec doc diff**: replaces "Only changed fields are included in the changes object." with the §5c producer contract ("MAY include unchanged fields, MUST include every dynamic position present on either the old or new item") plus the §232 consumer contract ("the receiver MUST treat `['u']` as a full snapshot — replace, do not merge"). Both verbatim from the proposal.
+- **CI green**: full suite green; race detector clean (root pkg ~526s, internal/diff ~1.7s); examples sibling-repo green; lvt and tinkerdown failures are pre-existing environment issues (`sqlc not installed`, missing local script files) unrelated to Phase 4.
+
+### Test count delta
+
+- 1 new unit test in `internal/diff/transition_test.go` (`TestTransitionToStreamMode_RootRangeFires`)
+- 3 new unit tests in `internal/diff/range_ops_test.go` (`_KeptItemContentChange_FallsBack`, `_StructuralAndContent_FallsBack`, `_PureStructural_StillEmitsOps`)
+- 3 migrated tests in `internal/diff/range_ops_test.go` (`_Mixed`, `_UpdateAndReorder`, `_MultipleUpdatesAndReorder` — assert nil-return)
+- 16 deleted tests in `internal/diff/range_ops_test.go` (13 `TestCompareRangeItemsForChanges_*`, `TestGenerateUpdateOperations`, `TestGenerateRangeDifferentialOperations_Update`, `_UpdateNoReorder`)
+- 2 deleted subtests in `e2e_update_spec_test.go` (`update_single`, `mixed_operations`)
+
+**Net: 4 new + 3 migrated − 18 deleted = −11 tests.**
+
+The deletion delta is intentional: per-item ["u"] ops no longer exist as a wire shape, so tests that asserted them have no behavior left to verify. New tests cover the surviving fallback contract.
+
+### Verification commands re-run
+
+```
+GOWORK=off go test -count=1 ./...                                  # green (108s root pkg, all internal pkgs <1s)
+GOWORK=off go test -race -count=1 ./internal/diff/... ./internal/keys/... ./internal/build/... ./internal/fuzz/...   # race-clean
+GOWORK=off go test -race -count=1 ./                               # race-clean (root pkg, 526s)
+grep -rn "CompareRangeItemsForChanges\|compareRangeItemsWithKeyPos\|handleNestedTreeNodeChange\|isMeaningfulValue\|generateUpdateOps" internal/ --include="*.go"   # zero hits
+```
+
+Sibling-repo verification (with `go.work` temporarily pointing at the worktree):
+- `examples` via `go test ./...`: all 13 packages green (counter, todos, patterns at 231s, chat, dialog-patterns, flash-messages, live-preview, login, progressive-enhancement, shared-notepad, ws-disabled, avatar-upload). The `patterns` and `todos` packages exercise chromedp E2E via `e2etest.StartDockerChrome()`.
+- `examples` via `bash test-all.sh`: all 12 working examples green WITH `-race` flag (same coverage as `go test ./...` but race-checked).
+- `lvt`: 4 failures all `sqlc not installed` — pre-existing environment issue, not Phase 4 regressions.
+- `tinkerdown`: 2 failures both missing local script files (`./env.sh`, `./empty_lines.sh`) — pre-existing environment issues, not Phase 4 regressions.
+- `livetemplate/e2e/docker/multi_instance_test.go`: pre-existing infra gap — Dockerfile pins `golang:1.24-alpine` but the project's `go.mod` requires `go 1.26.0` (since before Phase 1). Test fails on `main` for the same reason. Not a Phase 4 regression; gated by a Dockerfile bump that's out of scope.
+
+### Phase 4 follow-ups
+
+- **Stream-mode benchmarks** (`BenchmarkRangeDiff_Stream_*`): Phase 5 deliverable.
+- **`LargeTableController` example**: Phase 6 deliverable.
+- **`fuzz_diff_test.go` regeneration**: not needed — full suite (including `internal/fuzz/invariants` and root-pkg fuzz tests) is green.
+- **Browser E2E in `lvt` repo**: not needed for Phase 4 — no new wire shapes were introduced; the `["u"]` op contract change shipped in Phase 3 and the Phase 3 audit verified client compatibility.
+
+### Phase 5 unblocked
+
+Phase 5 deliverable per proposal §325: add `internal/diff/range_ops_bench_test.go` with `BenchmarkRangeDiff_Stream_{Append,Update,Reorder}_{Small,Medium,Large}` benchmarks at N ∈ {10, 100, 10k}; capture the per-item retained-byte numbers via the existing `TestStreamMode_MemoryRegression` helper; update §7 in the proposal with measured values; mark the proposal status `Implemented` in the header.
+
+The cleanup is complete; the wire contract is consistent end-to-end; all stale partial-delta producers are gone. Phase 5 can begin measuring.
+
+---
+
 ## Audit sign-off
 
 All six §15 gates close as recorded. Phase 1 (foundational types) is unblocked under the proposal's audit-checkpoint sequencing. The two open questions retain explicit owners (OQ1 closed by decision; OQ2 owned by Phase 5 measurement).

--- a/docs/specifications/tree-update-specification.md
+++ b/docs/specifications/tree-update-specification.md
@@ -374,11 +374,23 @@ Example:
 #### Update Operation
 Format: `["u", itemId, changes]`
 
-Only changed fields are included in the changes object.
+The `changes` object MAY include unchanged fields and MUST include every dynamic
+position present on either the old or new item. Absent positions are encoded as
+the empty string `""`.
 
-Example:
+**Consumer contract:** the receiver MUST treat `["u"]` as a full snapshot —
+replace the item's dynamics with the `changes` object, do not merge only the
+keys present in the payload. A partial-merge implementation will display stale
+values on positions that should have been cleared.
+
+Example (full-snapshot form):
 ```json
-["u", "item-1", {"2": "Updated Text"}]
+["u", "item-1", {"0": "id-1", "1": "Author A", "2": "Updated Text"}]
+```
+
+Example (with cleared field encoded as `""`):
+```json
+["u", "item-1", {"0": "id-1", "1": "", "2": "Updated Text"}]
 ```
 
 #### Reorder Operation

--- a/docs/specifications/tree-update-specification.md
+++ b/docs/specifications/tree-update-specification.md
@@ -375,22 +375,23 @@ Example:
 Format: `["u", itemId, changes]`
 
 The `changes` object MAY include unchanged fields and MUST include every dynamic
-position present on either the old or new item. Absent positions are encoded as
-the empty string `""`.
+position present on either the old or new item, **except the key position** —
+the key is encoded by `itemId` itself and MUST NOT appear inside `changes`.
+Absent positions are encoded as the empty string `""`.
 
 **Consumer contract:** the receiver MUST treat `["u"]` as a full snapshot —
-replace the item's dynamics with the `changes` object, do not merge only the
-keys present in the payload. A partial-merge implementation will display stale
-values on positions that should have been cleared.
+replace the item's non-key dynamics with the `changes` object, do not merge
+only the keys present in the payload. A partial-merge implementation will
+display stale values on positions that should have been cleared.
 
-Example (full-snapshot form):
+Example (key at position 0; full snapshot of positions 1–2):
 ```json
-["u", "item-1", {"0": "id-1", "1": "Author A", "2": "Updated Text"}]
+["u", "item-1", {"1": "Author A", "2": "Updated Text"}]
 ```
 
 Example (with cleared field encoded as `""`):
 ```json
-["u", "item-1", {"0": "id-1", "1": "", "2": "Updated Text"}]
+["u", "item-1", {"1": "", "2": "Updated Text"}]
 ```
 
 #### Reorder Operation

--- a/e2e_update_spec_test.go
+++ b/e2e_update_spec_test.go
@@ -377,27 +377,12 @@ func TestUpdateSpecification_RangeOperations(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "update_single",
-			initial: []Item{
-				{ID: "1", Text: "Original"},
-			},
-			update: []Item{
-				{ID: "1", Text: "Updated"},
-			},
-			validateOp: func(t *testing.T, ops []interface{}) {
-				if len(ops) != 1 {
-					t.Fatalf("Expected 1 operation, got %d", len(ops))
-				}
-				op := ops[0].([]interface{})
-				if op[0] != "u" {
-					t.Errorf("Expected update 'u', got %v", op[0])
-				}
-				if op[1] != "1" {
-					t.Errorf("Expected to update ID '1', got %v", op[1])
-				}
-			},
-		},
+		// "update_single" + "mixed_operations" subtests removed in Phase 4: the
+		// per-item ["u"] producer was deleted, so kept-item content changes now
+		// take the full-tree fallback. Coverage moved to internal/diff:
+		// TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack
+		// and TestGenerateRangeDifferentialOperations_StructuralAndContent_FallsBack,
+		// plus TestStreamMode_HetRangeFallback in streaming_range_phase3_test.go.
 		{
 			name: "reorder",
 			initial: []Item{
@@ -424,47 +409,6 @@ func TestUpdateSpecification_RangeOperations(t *testing.T) {
 				}
 				if order[0] != "3" || order[1] != "1" || order[2] != "2" {
 					t.Errorf("Incorrect order: %v", order)
-				}
-			},
-		},
-		{
-			name: "mixed_operations",
-			initial: []Item{
-				{ID: "1", Text: "First"},
-				{ID: "2", Text: "Second"},
-			},
-			update: []Item{
-				{ID: "1", Text: "Updated First"},
-				{ID: "3", Text: "Third"},
-			},
-			validateOp: func(t *testing.T, ops []interface{}) {
-				// Should have remove and update/insert operations
-				if len(ops) < 2 {
-					t.Fatalf("Expected at least 2 operations, got %d", len(ops))
-				}
-
-				foundRemove := false
-				foundInsert := false
-				foundUpdate := false
-
-				for _, op := range ops {
-					opArray := op.([]interface{})
-					opType := opArray[0].(string)
-					switch opType {
-					case "r":
-						foundRemove = true
-					case "i":
-						foundInsert = true
-					case "u":
-						foundUpdate = true
-					}
-				}
-
-				if !foundRemove {
-					t.Error("Expected remove operation not found")
-				}
-				if !foundInsert && !foundUpdate {
-					t.Error("Expected insert or update operation not found")
 				}
 			},
 		},

--- a/e2e_update_spec_test.go
+++ b/e2e_update_spec_test.go
@@ -377,12 +377,10 @@ func TestUpdateSpecification_RangeOperations(t *testing.T) {
 				}
 			},
 		},
-		// "update_single" + "mixed_operations" subtests removed in Phase 4: the
-		// per-item ["u"] producer was deleted, so kept-item content changes now
-		// take the full-tree fallback. Coverage moved to internal/diff:
+		// Kept-item content changes take the full-tree fallback (no per-item ["u"]
+		// producer for het ranges). Coverage in internal/diff:
 		// TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack
-		// and TestGenerateRangeDifferentialOperations_StructuralAndContent_FallsBack,
-		// plus TestStreamMode_HetRangeFallback in streaming_range_phase3_test.go.
+		// and TestGenerateRangeDifferentialOperations_StructuralAndContent_FallsBack.
 		{
 			name: "reorder",
 			initial: []Item{

--- a/internal/diff/helpers_value.go
+++ b/internal/diff/helpers_value.go
@@ -16,27 +16,6 @@ func IsEmpty(v interface{}) bool {
 	}
 }
 
-// isMeaningfulValue checks if a value is meaningful (not empty/nil) and should
-// be reported when removed. This is used in CompareRangeItemsForChanges to
-// determine if removing a field should generate a change notification.
-func isMeaningfulValue(v interface{}) bool {
-	if v == nil {
-		return false
-	}
-	switch val := v.(type) {
-	case string:
-		return val != ""
-	case *TreeNode:
-		return true
-	case map[string]interface{}:
-		return len(val) > 0
-	case []interface{}:
-		return len(val) > 0
-	default:
-		return true
-	}
-}
-
 // hasDynamicsChanged checks if the set of dynamic positions differs between oldTree and newTree.
 func hasDynamicsChanged(oldTree, newTree *TreeNode) bool {
 	oldHasDynamics := oldTree != nil && oldTree.HasDynamics()

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -121,9 +121,9 @@ func GenerateRangeDifferentialOperations(oldValue, newValue interface{}, stripSt
 		return nil
 	}
 
-	// Phase 4 (proposal §5c/§5d): partial-delta ["u"] ops are no longer on the
-	// wire — content-only changes for kept items must signal full-tree replacement
-	// via nil-return. handleMatchedRanges falls through to *changes = *newTree.
+	// Per spec §5c/§5d, kept-item changes (content or statics) cannot be encoded
+	// as differential ops — signal nil-return so the caller emits a full-tree
+	// replacement (handleMatchedRanges falls through to *changes = *newTree).
 	if hasKeptItemContentChanged(ctx) {
 		return nil
 	}
@@ -456,10 +456,14 @@ func generateRemovalOps(ctx *rangeContext, operations []interface{}) []interface
 }
 
 // hasKeptItemContentChanged reports whether any item present in both renders
-// has a different content hash. The legacy per-item ["u"] producer was deleted
-// in Phase 4; with no path to encode kept-item content changes as differential
-// ops, the diff engine signals nil-return on any such change so the caller
-// emits a full-tree replacement (proposal §5d).
+// has a different content hash OR a different statics fingerprint. The diff
+// engine has no per-item ["u"] producer for het ranges, so any kept-item
+// change must signal nil-return to trigger full-tree replacement.
+//
+// Statics fingerprint covers conditional-branch flips inside the item (e.g.,
+// {{if .Done}}<s>{{end}} toggling between empty and `<s>...</s>`), which leave
+// Dynamics identical but change the rendered structure. Hash covers content
+// changes within the same structure.
 //
 // Non-*TreeNode items default to "changed" — the safety bias is toward fallback.
 func hasKeptItemContentChanged(ctx *rangeContext) bool {
@@ -472,6 +476,9 @@ func hasKeptItemContentChanged(ctx *rangeContext) bool {
 		oldNode, oldOk := oldItem.(*TreeNode)
 		newNode, newOk := newItem.(*TreeNode)
 		if !oldOk || !newOk {
+			return true
+		}
+		if build.CalculateStaticsFingerprint(oldNode) != build.CalculateStaticsFingerprint(newNode) {
 			return true
 		}
 		if keys.ItemHashUint64(oldNode.Dynamics) != keys.ItemHashUint64(newNode.Dynamics) {

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -121,10 +121,8 @@ func GenerateRangeDifferentialOperations(oldValue, newValue interface{}, stripSt
 		return nil
 	}
 
-	// Per spec §5c/§5d, kept-item changes (content or statics) cannot be encoded
-	// as differential ops — signal nil-return so the caller emits a full-tree
-	// replacement (handleMatchedRanges falls through to *changes = *newTree).
-	if hasKeptItemContentChanged(ctx) {
+	// Kept-item changes can't be encoded as differential ops; full-tree fallback (spec §5c/§5d).
+	if hasKeptItemChanged(ctx) {
 		return nil
 	}
 
@@ -455,18 +453,12 @@ func generateRemovalOps(ctx *rangeContext, operations []interface{}) []interface
 	return operations
 }
 
-// hasKeptItemContentChanged reports whether any item present in both renders
-// has a different content hash OR a different statics fingerprint. The diff
-// engine has no per-item ["u"] producer for het ranges, so any kept-item
-// change must signal nil-return to trigger full-tree replacement.
-//
-// Statics fingerprint covers conditional-branch flips inside the item (e.g.,
-// {{if .Done}}<s>{{end}} toggling between empty and `<s>...</s>`), which leave
-// Dynamics identical but change the rendered structure. Hash covers content
-// changes within the same structure.
-//
-// Non-*TreeNode items default to "changed" — the safety bias is toward fallback.
-func hasKeptItemContentChanged(ctx *rangeContext) bool {
+// hasKeptItemChanged reports whether any item present in both renders has a
+// different statics fingerprint or content hash. Both checks matter: statics
+// catch conditional-branch flips (e.g. {{if .Done}}<s>{{end}}) that leave
+// Dynamics identical; hash catches content changes within the same structure.
+// Non-*TreeNode items default to true (safety-biased fallback).
+func hasKeptItemChanged(ctx *rangeContext) bool {
 	for _, key := range ctx.newKeys {
 		oldItem, exists := ctx.oldByKey[key]
 		if !exists {

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -121,6 +121,13 @@ func GenerateRangeDifferentialOperations(oldValue, newValue interface{}, stripSt
 		return nil
 	}
 
+	// Phase 4 (proposal §5c/§5d): partial-delta ["u"] ops are no longer on the
+	// wire — content-only changes for kept items must signal full-tree replacement
+	// via nil-return. handleMatchedRanges falls through to *changes = *newTree.
+	if hasKeptItemContentChanged(ctx) {
+		return nil
+	}
+
 	if isPureReorderingCtx(ctx) {
 		return []interface{}{[]interface{}{"o", ctx.newKeys}}
 	}
@@ -133,7 +140,6 @@ func GenerateRangeDifferentialOperations(oldValue, newValue interface{}, stripSt
 
 	operations := make([]interface{}, 0, 4)
 	operations = generateRemovalOps(ctx, operations)
-	operations = generateUpdateOps(ctx, operations)
 	operations = generateInsertionOps(ctx, operations)
 
 	if sameKeySet(ctx.oldKeys, ctx.newKeys) && HasReordering(ctx.oldKeys, ctx.newKeys) {
@@ -449,23 +455,30 @@ func generateRemovalOps(ctx *rangeContext, operations []interface{}) []interface
 	return operations
 }
 
-func generateUpdateOps(ctx *rangeContext, operations []interface{}) []interface{} {
-	sortedNewKeys := make([]string, len(ctx.newKeys))
-	copy(sortedNewKeys, ctx.newKeys)
-	sort.Strings(sortedNewKeys)
-
-	for _, key := range sortedNewKeys {
+// hasKeptItemContentChanged reports whether any item present in both renders
+// has a different content hash. The legacy per-item ["u"] producer was deleted
+// in Phase 4; with no path to encode kept-item content changes as differential
+// ops, the diff engine signals nil-return on any such change so the caller
+// emits a full-tree replacement (proposal §5d).
+//
+// Non-*TreeNode items default to "changed" — the safety bias is toward fallback.
+func hasKeptItemContentChanged(ctx *rangeContext) bool {
+	for _, key := range ctx.newKeys {
+		oldItem, exists := ctx.oldByKey[key]
+		if !exists {
+			continue
+		}
 		newItem := ctx.newByKey[key]
-		if oldItem, exists := ctx.oldByKey[key]; exists {
-			changes := compareRangeItemsWithKeyPos(oldItem, newItem, ctx.keyPos)
-			if len(changes) > 0 {
-				// Include all changes, even empty strings — they signal field removal
-				// (e.g., removing "checked" attribute when toggling a checkbox off).
-				operations = append(operations, []interface{}{"u", key, changes})
-			}
+		oldNode, oldOk := oldItem.(*TreeNode)
+		newNode, newOk := newItem.(*TreeNode)
+		if !oldOk || !newOk {
+			return true
+		}
+		if keys.ItemHashUint64(oldNode.Dynamics) != keys.ItemHashUint64(newNode.Dynamics) {
+			return true
 		}
 	}
-	return operations
+	return false
 }
 
 func generateInsertionOps(ctx *rangeContext, operations []interface{}) []interface{} {
@@ -579,127 +592,6 @@ func handleIndividualInsertionsCtx(ctx *rangeContext, operations []interface{}) 
 		}
 	}
 	return operations
-}
-
-// CompareRangeItemsForChanges compares two range items and returns a map of field changes.
-func CompareRangeItemsForChanges(oldItem, newItem interface{}, statics interface{}) map[string]interface{} {
-	keyPos := FindKeyPositionFromStatics(statics)
-	return compareRangeItemsWithKeyPos(oldItem, newItem, keyPos)
-}
-
-func compareRangeItemsWithKeyPos(oldItem, newItem interface{}, keyPos int) map[string]interface{} {
-	changes := make(map[string]interface{})
-
-	oldItemNode, ok1 := oldItem.(*TreeNode)
-	newItemNode, ok2 := newItem.(*TreeNode)
-
-	if !ok1 || !ok2 {
-		return changes
-	}
-
-	for i, newValue := range newItemNode.Dynamics {
-		if newValue == nil {
-			continue
-		}
-		if keyPos >= 0 && i == keyPos {
-			continue
-		}
-
-		fieldKey := build.PositionKey(i)
-		oldValue, exists := oldItemNode.GetDynamic(i)
-		if !exists || !DeepEqual(oldValue, newValue) {
-			if newTreeNode, ok := newValue.(*TreeNode); ok {
-				handleNestedTreeNodeChange(fieldKey, oldValue, newTreeNode, exists, changes)
-			} else {
-				changes[fieldKey] = newValue
-			}
-		}
-	}
-
-	// Check for fields removed (in old but not in new), e.g. unchecking a checkbox.
-	for i, oldValue := range oldItemNode.Dynamics {
-		if oldValue == nil {
-			continue
-		}
-		if keyPos >= 0 && i == keyPos {
-			continue
-		}
-		// Check if the position exists and is non-nil in new
-		var newExists bool
-		if i < len(newItemNode.Dynamics) && newItemNode.Dynamics[i] != nil {
-			newExists = true
-		}
-		if !newExists {
-			if isMeaningfulValue(oldValue) {
-				changes[build.PositionKey(i)] = ""
-			}
-		}
-	}
-
-	return changes
-}
-
-// handleNestedTreeNodeChange handles changes in nested TreeNode fields.
-// Uses fingerprint comparison to detect static structure changes.
-func handleNestedTreeNodeChange(
-	fieldKey string,
-	oldValue interface{},
-	newTreeNode *TreeNode,
-	exists bool,
-	changes map[string]interface{},
-) {
-	// Check if old value is also a TreeNode
-	oldTreeNode, oldIsTree := oldValue.(*TreeNode)
-
-	// If old value is NOT a TreeNode (e.g., empty string "", nil, or non-existent),
-	// but new value IS a TreeNode, we need to send the full new TreeNode WITH statics,
-	// because the client doesn't have these statics cached for this field.
-	// This handles transitions like:
-	// - "" -> {"s":["checked"]} (empty string to TreeNode)
-	// - nil -> {"s":["checked"]} (non-existent field to TreeNode)
-	if !oldIsTree {
-		// Transition from non-TreeNode (or non-existent) to TreeNode - send full new value with statics
-		changes[fieldKey] = PrepareTreeForClient(newTreeNode, false)
-		return
-	}
-
-	stripped := PrepareTreeForClient(newTreeNode, true)
-
-	// If stripping results in empty, check if this is a meaningful change
-	if IsEmpty(stripped) {
-		// Check if old value would also strip to empty
-		if exists && oldIsTree {
-			oldStripped := PrepareTreeForClient(oldTreeNode, true)
-			if IsEmpty(oldStripped) {
-				// Both old and new strip to empty (static-only).
-				// Use fingerprint comparison to detect if statics changed.
-				// e.g., old: {"s":["checked"]} vs new: {"s":[]}
-				// Both strip to empty but the visual output is different.
-				if ClientNeedsStatics(oldTreeNode, newTreeNode) {
-					// Structure fingerprints differ - statics changed.
-					// Send the full new TreeNode WITH statics so client can update structure.
-					// This handles cases like conditional branch changes within range items.
-					changes[fieldKey] = PrepareTreeForClient(newTreeNode, false)
-				}
-				// If fingerprints are the same, truly no change - skip it
-				return
-			}
-		}
-		// Old doesn't exist or had dynamics, send empty string to indicate removal of dynamics
-		changes[fieldKey] = ""
-	} else {
-		// Check if structure changed (different statics needed) even when dynamics exist.
-		// This handles conditional branch changes within range items where both the
-		// structure (statics) AND content (dynamics) change simultaneously.
-		// e.g., {{if .HasError}}<span class="error-message">{{.Error}}</span>{{else}}<span class="status">Pending</span>{{end}}
-		// When HasError changes, we need to send new statics, not just new dynamics.
-		if oldIsTree && ClientNeedsStatics(oldTreeNode, newTreeNode) {
-			// Statics changed - send full tree with new statics
-			changes[fieldKey] = PrepareTreeForClient(newTreeNode, false)
-		} else {
-			changes[fieldKey] = stripped
-		}
-	}
 }
 
 // stripStaticsFromOperations removes statics from all operations.

--- a/internal/diff/range_ops_test.go
+++ b/internal/diff/range_ops_test.go
@@ -143,57 +143,6 @@ func TestGenerateRangeDifferentialOperations_Removal(t *testing.T) {
 	}
 }
 
-// TestGenerateRangeDifferentialOperations_Update tests item update operations.
-func TestGenerateRangeDifferentialOperations_Update(t *testing.T) {
-	item1Old := &TreeNode{
-		Dynamics: []interface{}{"id1", "Old Name"},
-	}
-	item1New := &TreeNode{
-		Dynamics: []interface{}{"id1", "New Name"},
-	}
-
-	statics := []string{`<li data-key="`, `">`, `</li>`}
-
-	oldValue := &TreeNode{
-		Statics: statics,
-		Range: &RangeData{
-			Items: []interface{}{item1Old},
-		},
-	}
-
-	newValue := &TreeNode{
-		Statics: statics,
-		Range: &RangeData{
-			Items: []interface{}{item1New},
-		},
-	}
-
-	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
-
-	// Should have one update operation
-	found := false
-	for _, op := range ops {
-		opArray, ok := op.([]interface{})
-		if ok && len(opArray) >= 2 && opArray[0] == "u" && opArray[1] == "id1" {
-			found = true
-			// Check that changes are included
-			if len(opArray) > 2 {
-				changes, ok := opArray[2].(map[string]interface{})
-				if !ok {
-					t.Errorf("Changes should be map, got %T", opArray[2])
-				} else if changes["1"] != "New Name" {
-					t.Errorf("Changes['1'] = %v, want 'New Name'", changes["1"])
-				}
-			}
-			break
-		}
-	}
-
-	if !found {
-		t.Errorf("Expected update operation ['u', 'id1', changes], operations: %v", ops)
-	}
-}
-
 // TestGenerateRangeDifferentialOperations_Insertion tests item insertion (append).
 func TestGenerateRangeDifferentialOperations_Insertion(t *testing.T) {
 	item1 := &TreeNode{
@@ -236,74 +185,32 @@ func TestGenerateRangeDifferentialOperations_Insertion(t *testing.T) {
 	}
 }
 
-// TestGenerateRangeDifferentialOperations_Mixed tests mixed operations (removal + update + insertion).
+// TestGenerateRangeDifferentialOperations_Mixed verifies that a render combining
+// structural changes (id1/id3 removed, id4 added) with a kept-item content change
+// (id2: "Old Name" → "New Name") signals nil-return so the caller emits a full-tree
+// replacement. Per Phase 4 (proposal §5d), kept-item content changes can no longer
+// be encoded as differential ops.
 func TestGenerateRangeDifferentialOperations_Mixed(t *testing.T) {
-	item1 := &TreeNode{
-		Dynamics: []interface{}{"id1", "Name 1"},
-	}
-	item2Old := &TreeNode{
-		Dynamics: []interface{}{"id2", "Old Name"},
-	}
-	item2New := &TreeNode{
-		Dynamics: []interface{}{"id2", "New Name"},
-	}
-	item3 := &TreeNode{
-		Dynamics: []interface{}{"id3", "Name 3"},
-	}
-	item4 := &TreeNode{
-		Dynamics: []interface{}{"id4", "Name 4"},
-	}
+	item1 := &TreeNode{Dynamics: []interface{}{"id1", "Name 1"}}
+	item2Old := &TreeNode{Dynamics: []interface{}{"id2", "Old Name"}}
+	item2New := &TreeNode{Dynamics: []interface{}{"id2", "New Name"}}
+	item3 := &TreeNode{Dynamics: []interface{}{"id3", "Name 3"}}
+	item4 := &TreeNode{Dynamics: []interface{}{"id4", "Name 4"}}
 
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 
 	oldValue := &TreeNode{
 		Statics: statics,
-		Range: &RangeData{
-			Items: []interface{}{item1, item2Old, item3},
-		},
+		Range:   &RangeData{Items: []interface{}{item1, item2Old, item3}},
 	}
-
 	newValue := &TreeNode{
 		Statics: statics,
-		Range: &RangeData{
-			Items: []interface{}{item2New, item4}, // id1 removed, id2 updated, id3 removed, id4 added
-		},
+		Range:   &RangeData{Items: []interface{}{item2New, item4}},
 	}
 
 	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
-
-	// Should have: 2 removals, 1 update, 1 append/insert
-	hasRemoval := false
-	hasUpdate := false
-	hasInsertion := false
-
-	for _, op := range ops {
-		opArray, ok := op.([]interface{})
-		if !ok {
-			continue
-		}
-		if len(opArray) < 2 {
-			continue
-		}
-
-		switch opArray[0] {
-		case "r":
-			hasRemoval = true
-		case "u":
-			hasUpdate = true
-		case "a", "p", "i":
-			hasInsertion = true
-		}
-	}
-
-	if !hasRemoval {
-		t.Error("Expected at least one removal operation")
-	}
-	if !hasUpdate {
-		t.Error("Expected update operation")
-	}
-	if !hasInsertion {
-		t.Error("Expected insertion operation")
+	if ops != nil {
+		t.Errorf("Expected nil-return (full-tree fallback signal), got ops: %v", ops)
 	}
 }
 
@@ -561,46 +468,6 @@ func TestGenerateRemovalOperations(t *testing.T) {
 	}
 }
 
-// TestGenerateUpdateOperations tests update operation generation.
-func TestGenerateUpdateOperations(t *testing.T) {
-	oldItems := []interface{}{
-		&TreeNode{Dynamics: []interface{}{"id1", "Old"}},
-	}
-
-	newItems := []interface{}{
-		&TreeNode{Dynamics: []interface{}{"id1", "New"}},
-	}
-
-	statics := []string{`<li data-key="`, `">`, `</li>`}
-	operations := []interface{}{}
-
-	ctx := newRangeContext(oldItems, newItems, statics, nil)
-	ops := generateUpdateOps(ctx, operations)
-
-	// Should generate one update operation
-	if len(ops) != 1 {
-		t.Fatalf("Expected 1 update operation, got %d: %v", len(ops), ops)
-	}
-
-	opArray, ok := ops[0].([]interface{})
-	if !ok || len(opArray) < 3 {
-		t.Fatalf("Expected ['u', 'id1', changes], got %v", ops[0])
-	}
-
-	if opArray[0] != "u" || opArray[1] != "id1" {
-		t.Errorf("Operation = %v, want ['u', 'id1', ...]", opArray)
-	}
-
-	changes, ok := opArray[2].(map[string]interface{})
-	if !ok {
-		t.Fatalf("Changes should be map, got %T", opArray[2])
-	}
-
-	if changes["1"] != "New" {
-		t.Errorf("changes['1'] = %v, want 'New'", changes["1"])
-	}
-}
-
 // TestGenerateInsertionOperations_Prepend tests prepend insertion.
 func TestGenerateInsertionOperations_Prepend(t *testing.T) {
 	oldItems := []interface{}{
@@ -696,25 +563,6 @@ func TestGenerateInsertionOperations_Complex(t *testing.T) {
 	}
 }
 
-// TestCompareRangeItemsForChanges_NoDiff tests no changes between items.
-func TestCompareRangeItemsForChanges_NoDiff(t *testing.T) {
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"id1", "Name"},
-	}
-
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"id1", "Name"},
-	}
-
-	statics := []string{`<li data-key="`, `">`, `</li>`}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	if len(changes) != 0 {
-		t.Errorf("Expected no changes, got: %v", changes)
-	}
-}
-
 // TestGenerateRangeDifferentialOperations_NilInputs tests handling of nil inputs.
 func TestGenerateRangeDifferentialOperations_NilInputs(t *testing.T) {
 	tests := []struct {
@@ -777,303 +625,82 @@ func TestGenerateRangeDifferentialOperations_NilRangeData(t *testing.T) {
 	}
 }
 
-// TestCompareRangeItemsForChanges_NilInputs tests nil input handling.
-func TestCompareRangeItemsForChanges_NilInputs(t *testing.T) {
+// TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack
+// covers a single item present on both renders whose content changed. Phase 4
+// removed the per-item ["u"] producer, so the diff engine must signal nil-return
+// to trigger full-tree replacement.
+func TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
-
-	tests := []struct {
-		name     string
-		oldItem  interface{}
-		newItem  interface{}
-		expected int
-	}{
-		{"both nil", nil, nil, 0},
-		{"old nil", nil, &TreeNode{Dynamics: []interface{}{"id1"}}, 0},
-		{"new nil", &TreeNode{Dynamics: []interface{}{"id1"}}, nil, 0},
-		{"non-TreeNode old", "not a tree", &TreeNode{Dynamics: []interface{}{"id1"}}, 0},
-		{"non-TreeNode new", &TreeNode{Dynamics: []interface{}{"id1"}}, "not a tree", 0},
+	oldValue := &TreeNode{
+		Statics: statics,
+		Range:   &RangeData{Items: []interface{}{&TreeNode{Dynamics: []interface{}{"id1", "Old"}}}},
+	}
+	newValue := &TreeNode{
+		Statics: statics,
+		Range:   &RangeData{Items: []interface{}{&TreeNode{Dynamics: []interface{}{"id1", "New"}}}},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			changes := CompareRangeItemsForChanges(tt.oldItem, tt.newItem, statics)
-			if len(changes) != tt.expected {
-				t.Errorf("Expected %d changes, got %d: %v", tt.expected, len(changes), changes)
-			}
-		})
+	if ops := GenerateRangeDifferentialOperations(oldValue, newValue, false); ops != nil {
+		t.Errorf("Expected nil-return for kept-item content change, got: %v", ops)
 	}
 }
 
-// TestCompareRangeItemsForChanges_Changed tests detecting changes between items.
-func TestCompareRangeItemsForChanges_Changed(t *testing.T) {
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"id1", "Old Name", "Old Value"},
-	}
-
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"id1", "New Name", "Old Value"}, // Unchanged
-	}
-
+// TestGenerateRangeDifferentialOperations_StructuralAndContent_FallsBack covers
+// a render that adds an item AND mutates an existing item's content. The
+// content-change signal wins — full-tree replacement carries both correctly.
+func TestGenerateRangeDifferentialOperations_StructuralAndContent_FallsBack(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should detect change in position "1" only
-	if len(changes) != 1 {
-		t.Errorf("Expected 1 change, got %d: %v", len(changes), changes)
+	oldValue := &TreeNode{
+		Statics: statics,
+		Range:   &RangeData{Items: []interface{}{&TreeNode{Dynamics: []interface{}{"id1", "Old"}}}},
+	}
+	newValue := &TreeNode{
+		Statics: statics,
+		Range: &RangeData{Items: []interface{}{
+			&TreeNode{Dynamics: []interface{}{"id1", "New"}},
+			&TreeNode{Dynamics: []interface{}{"id2", "Fresh"}},
+		}},
 	}
 
-	if changes["1"] != "New Name" {
-		t.Errorf("changes['1'] = %v, want 'New Name'", changes["1"])
-	}
-
-	// Position "0" (key) should be skipped
-	if _, hasKey := changes["0"]; hasKey {
-		t.Error("Key field should not be in changes")
-	}
-
-	// Position "2" (unchanged) should not be in changes
-	if _, has2 := changes["2"]; has2 {
-		t.Error("Unchanged field should not be in changes")
+	if ops := GenerateRangeDifferentialOperations(oldValue, newValue, false); ops != nil {
+		t.Errorf("Expected nil-return for combined structural+content change, got: %v", ops)
 	}
 }
 
-// TestCompareRangeItemsForChanges_NonTreeNodeToTreeNode tests transition from
-// non-TreeNode value (e.g., empty string) to TreeNode with statics.
-// This is the case for checkbox toggles: "" -> {"s":["checked"]}
-func TestCompareRangeItemsForChanges_NonTreeNodeToTreeNode(t *testing.T) {
-	// Old item has an empty string for the checkbox field
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"task1", "", "Task text"},
+// TestGenerateRangeDifferentialOperations_PureStructural_StillEmitsOps locks in
+// the wire-size win for het ranges that change only structurally — pure-add of
+// new items with no kept-item content drift must still emit a compact ['a'] op.
+func TestGenerateRangeDifferentialOperations_PureStructural_StillEmitsOps(t *testing.T) {
+	statics := []string{`<li data-key="`, `">`, `</li>`}
+	oldValue := &TreeNode{
+		Statics: statics,
+		Range:   &RangeData{Items: []interface{}{&TreeNode{Dynamics: []interface{}{"id1", "A"}}}},
+	}
+	newValue := &TreeNode{
+		Statics: statics,
+		Range: &RangeData{Items: []interface{}{
+			&TreeNode{Dynamics: []interface{}{"id1", "A"}},
+			&TreeNode{Dynamics: []interface{}{"id2", "B"}},
+		}},
 	}
 
-	// New item has a TreeNode with statics for the checkbox field
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{Statics: []string{"checked"}}, "Task text"},
+	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
+	if ops == nil {
+		t.Fatal("Expected ops for pure-structural change, got nil-fallback")
 	}
 
-	statics := []string{"<li>", "<input ", ">", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have 1 change for field "1"
-	if len(changes) != 1 {
-		t.Fatalf("Expected 1 change, got %d: %v", len(changes), changes)
+	hasAppend := false
+	for _, op := range ops {
+		opArr, ok := op.([]interface{})
+		if !ok || len(opArr) < 2 {
+			continue
+		}
+		if opArr[0] == "a" || opArr[0] == "i" || opArr[0] == "p" {
+			hasAppend = true
+		}
 	}
-
-	// The change should include the full TreeNode with statics (not stripped)
-	change1, ok := changes["1"]
-	if !ok {
-		t.Fatal("Expected change for field '1'")
-	}
-
-	// PrepareTreeForClient returns *TreeNode when clientHasStatics=false
-	changeTree, ok := change1.(*TreeNode)
-	if !ok {
-		t.Fatalf("Expected *TreeNode for change, got %T: %v", change1, change1)
-	}
-
-	// Statics should be preserved (["checked"])
-	if len(changeTree.Statics) != 1 || changeTree.Statics[0] != "checked" {
-		t.Errorf("Expected statics ['checked'], got %v", changeTree.Statics)
-	}
-}
-
-// TestCompareRangeItemsForChanges_NonExistentToTreeNode tests transition from
-// non-existent field to TreeNode with statics.
-func TestCompareRangeItemsForChanges_NonExistentToTreeNode(t *testing.T) {
-	// Old item doesn't have the field at all
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"task1"},
-	}
-
-	// New item has a TreeNode with statics for the field
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{Statics: []string{"checked"}}},
-	}
-
-	statics := []string{"<li>", "<input ", ">", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have 1 change for field "1"
-	if len(changes) != 1 {
-		t.Fatalf("Expected 1 change, got %d: %v", len(changes), changes)
-	}
-
-	// The change should include the full TreeNode with statics
-	change1, ok := changes["1"]
-	if !ok {
-		t.Fatal("Expected change for field '1'")
-	}
-
-	// PrepareTreeForClient returns *TreeNode when clientHasStatics=false
-	changeTree, ok := change1.(*TreeNode)
-	if !ok {
-		t.Fatalf("Expected *TreeNode for change, got %T: %v", change1, change1)
-	}
-
-	// Statics should be preserved (["checked"])
-	if len(changeTree.Statics) != 1 || changeTree.Statics[0] != "checked" {
-		t.Errorf("Expected statics ['checked'], got %v", changeTree.Statics)
-	}
-}
-
-// TestCompareRangeItemsForChanges_StaticsDiffer tests detecting changes when
-// both old and new TreeNodes strip to empty but have different statics.
-// This is the core checkbox toggle scenario:
-// Old: {"s":["checked"]} -> strips to empty
-// New: {"s":[]} -> strips to empty
-// But they are visually different, so this IS a meaningful change.
-func TestCompareRangeItemsForChanges_StaticsDiffer(t *testing.T) {
-	// Old item has a checked checkbox (TreeNode with statics ["checked"])
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{Statics: []string{"checked"}}, "Task text"},
-	}
-
-	// New item has unchecked checkbox (TreeNode with empty statics)
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{Statics: []string{}}, "Task text"},
-	}
-
-	statics := []string{"<li>", "<input ", ">", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have 1 change for field "1" - the statics differ!
-	if len(changes) != 1 {
-		t.Fatalf("Expected 1 change (statics differ), got %d: %v", len(changes), changes)
-	}
-
-	// The change should be a TreeNode with the new statics so client can update structure
-	change1, ok := changes["1"]
-	if !ok {
-		t.Fatal("Expected change for field '1'")
-	}
-
-	// When statics differ, we send the full TreeNode with new statics so client can update
-	// This is the correct behavior - the client needs to see the new statics to render correctly
-	changeTree, isTree := change1.(*TreeNode)
-	if !isTree {
-		t.Fatalf("Expected *TreeNode for change, got %T: %v", change1, change1)
-	}
-
-	// The new statics should be empty (unchecked state)
-	if len(changeTree.Statics) != 0 {
-		t.Errorf("Expected empty statics for unchecked state, got %v", changeTree.Statics)
-	}
-}
-
-// TestCompareRangeItemsForChanges_StaticsSameNoChange tests that no change is
-// detected when both old and new TreeNodes have identical statics.
-func TestCompareRangeItemsForChanges_StaticsSameNoChange(t *testing.T) {
-	// Both have the same statics - no change should be detected
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{Statics: []string{"checked"}}, "Task text"},
-	}
-
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{Statics: []string{"checked"}}, "Task text"},
-	}
-
-	statics := []string{"<li>", "<input ", ">", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have no changes - statics are identical
-	if len(changes) != 0 {
-		t.Errorf("Expected no changes (statics same), got %d: %v", len(changes), changes)
-	}
-}
-
-// TestCompareRangeItemsForChanges_FieldRemoved tests detecting when a field
-// exists in old item but is removed from new item.
-// This handles cases like unchecking a checkbox where the "checked" attribute
-// field exists in old but is absent from new.
-func TestCompareRangeItemsForChanges_FieldRemoved(t *testing.T) {
-	// Old item has a field "1" with a TreeNode value
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{Statics: []string{"checked"}}, "Task text"},
-	}
-
-	// New item doesn't have field "1" at all (nil at position 1)
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"task1", nil, "Task text"},
-	}
-
-	statics := []string{"<li>", "<input ", ">", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have 1 change for field "1" - it was removed
-	if len(changes) != 1 {
-		t.Fatalf("Expected 1 change (field removed), got %d: %v", len(changes), changes)
-	}
-
-	// The change should be empty string to indicate removal
-	change1, ok := changes["1"]
-	if !ok {
-		t.Fatal("Expected change for field '1'")
-	}
-
-	if change1 != "" {
-		t.Errorf("Expected empty string for removed field, got %T: %v", change1, change1)
-	}
-}
-
-// TestCompareRangeItemsForChanges_FieldRemovedWithStringValue tests detecting
-// when a field with a string value is removed from new item.
-func TestCompareRangeItemsForChanges_FieldRemovedWithStringValue(t *testing.T) {
-	// Old item has a field "1" with a string value
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"task1", "some value", "Task text"},
-	}
-
-	// New item doesn't have field "1" at all (nil at position 1)
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"task1", nil, "Task text"},
-	}
-
-	statics := []string{"<li>", "", "", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have 1 change for field "1" - it was removed
-	if len(changes) != 1 {
-		t.Fatalf("Expected 1 change (field removed), got %d: %v", len(changes), changes)
-	}
-
-	// The change should be empty string to indicate removal
-	change1, ok := changes["1"]
-	if !ok {
-		t.Fatal("Expected change for field '1'")
-	}
-
-	if change1 != "" {
-		t.Errorf("Expected empty string for removed field, got %T: %v", change1, change1)
-	}
-}
-
-// TestCompareRangeItemsForChanges_EmptyFieldNotReported tests that removing
-// an already-empty field doesn't generate a spurious change.
-func TestCompareRangeItemsForChanges_EmptyFieldNotReported(t *testing.T) {
-	// Old item has a field "1" with empty string
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"task1", "", "Task text"},
-	}
-
-	// New item doesn't have field "1" at all (nil at position 1)
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"task1", nil, "Task text"},
-	}
-
-	statics := []string{"<li>", "", "", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have no changes - empty string to absent is not meaningful
-	if len(changes) != 0 {
-		t.Errorf("Expected no changes (empty to absent), got %d: %v", len(changes), changes)
+	if !hasAppend {
+		t.Errorf("Expected an append/insert op, got: %v", ops)
 	}
 }
 
@@ -1421,166 +1048,60 @@ func TestSameKeySet(t *testing.T) {
 // This was the core bug discovered during Phase 2 fuzz testing.
 // =============================================================================
 
-// TestGenerateRangeDifferentialOperations_UpdateAndReorder tests the case where
-// items change content AND change order simultaneously. This is the core bug
-// that was discovered during Phase 2 fuzz testing - previously only updates
-// were generated, missing the reorder operation.
+// TestGenerateRangeDifferentialOperations_UpdateAndReorder verifies content+reorder
+// renders take the full-tree fallback. Phase 4 removed the per-item ["u"] producer,
+// so the reorder cannot be emitted in isolation when kept items also changed content
+// — full-tree replacement carries both correctly.
 func TestGenerateRangeDifferentialOperations_UpdateAndReorder(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 
-	item1Old := &TreeNode{
-		Dynamics: []interface{}{"id1", "Alpha"},
-	}
-	item2 := &TreeNode{
-		Dynamics: []interface{}{"id2", "Beta"},
-	}
-	item3 := &TreeNode{
-		Dynamics: []interface{}{"id3", "Charlie"},
-	}
-	item1New := &TreeNode{
-		Dynamics: []interface{}{"id1", "Alpha Updated"}, // Content changed
-	}
-
 	oldValue := &TreeNode{
 		Statics: statics,
-		Range: &RangeData{
-			Items: []interface{}{item1Old, item2, item3}, // Order: id1, id2, id3
-		},
+		Range: &RangeData{Items: []interface{}{
+			&TreeNode{Dynamics: []interface{}{"id1", "Alpha"}},
+			&TreeNode{Dynamics: []interface{}{"id2", "Beta"}},
+			&TreeNode{Dynamics: []interface{}{"id3", "Charlie"}},
+		}},
 	}
-
 	newValue := &TreeNode{
 		Statics: statics,
-		Range: &RangeData{
-			Items: []interface{}{item2, item1New, item3}, // Order: id2, id1, id3 (reordered + id1 updated)
-		},
+		Range: &RangeData{Items: []interface{}{
+			&TreeNode{Dynamics: []interface{}{"id2", "Beta"}},
+			&TreeNode{Dynamics: []interface{}{"id1", "Alpha Updated"}},
+			&TreeNode{Dynamics: []interface{}{"id3", "Charlie"}},
+		}},
 	}
 
-	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
-
-	// Should have BOTH update AND reorder operations
-	hasUpdate := false
-	hasReorder := false
-
-	for _, op := range ops {
-		opArray, ok := op.([]interface{})
-		if !ok {
-			continue
-		}
-		switch opArray[0] {
-		case "u":
-			hasUpdate = true
-			// Verify update is for id1
-			if opArray[1] != "id1" {
-				t.Errorf("Expected update for 'id1', got %v", opArray[1])
-			}
-		case "o":
-			hasReorder = true
-			// Verify reorder has correct new order
-			newOrder := opArray[1].([]string)
-			expectedOrder := []string{"id2", "id1", "id3"}
-			if !reflect.DeepEqual(newOrder, expectedOrder) {
-				t.Errorf("Reorder keys = %v, want %v", newOrder, expectedOrder)
-			}
-		}
-	}
-
-	if !hasUpdate {
-		t.Error("Expected update operation for changed content")
-	}
-	if !hasReorder {
-		t.Error("Expected reorder operation for changed order - THIS IS THE BUG FIX")
+	if ops := GenerateRangeDifferentialOperations(oldValue, newValue, false); ops != nil {
+		t.Errorf("Expected nil-return for content+reorder change, got: %v", ops)
 	}
 }
 
-// TestGenerateRangeDifferentialOperations_MultipleUpdatesAndReorder tests
-// multiple items updating while also reordering.
+// TestGenerateRangeDifferentialOperations_MultipleUpdatesAndReorder same shape as
+// _UpdateAndReorder but with multiple kept-item content changes — also takes the
+// full-tree fallback per Phase 4.
 func TestGenerateRangeDifferentialOperations_MultipleUpdatesAndReorder(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 
-	item1Old := &TreeNode{Dynamics: []interface{}{"id1", "One"}}
-	item2Old := &TreeNode{Dynamics: []interface{}{"id2", "Two"}}
-	item3Old := &TreeNode{Dynamics: []interface{}{"id3", "Three"}}
-
-	item1New := &TreeNode{Dynamics: []interface{}{"id1", "One Updated"}}
-	item2New := &TreeNode{Dynamics: []interface{}{"id2", "Two Updated"}}
-	item3New := &TreeNode{Dynamics: []interface{}{"id3", "Three"}} // Unchanged
-
 	oldValue := &TreeNode{
 		Statics: statics,
-		Range:   &RangeData{Items: []interface{}{item1Old, item2Old, item3Old}},
+		Range: &RangeData{Items: []interface{}{
+			&TreeNode{Dynamics: []interface{}{"id1", "One"}},
+			&TreeNode{Dynamics: []interface{}{"id2", "Two"}},
+			&TreeNode{Dynamics: []interface{}{"id3", "Three"}},
+		}},
 	}
-
 	newValue := &TreeNode{
 		Statics: statics,
-		Range:   &RangeData{Items: []interface{}{item3New, item2New, item1New}}, // Reversed order
+		Range: &RangeData{Items: []interface{}{
+			&TreeNode{Dynamics: []interface{}{"id3", "Three"}},
+			&TreeNode{Dynamics: []interface{}{"id2", "Two Updated"}},
+			&TreeNode{Dynamics: []interface{}{"id1", "One Updated"}},
+		}},
 	}
 
-	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
-
-	// Count operation types
-	updateCount := 0
-	hasReorder := false
-
-	for _, op := range ops {
-		opArray := op.([]interface{})
-		switch opArray[0] {
-		case "u":
-			updateCount++
-		case "o":
-			hasReorder = true
-		}
-	}
-
-	// Should have 2 updates (id1 and id2 changed) and 1 reorder
-	if updateCount != 2 {
-		t.Errorf("Expected 2 update operations, got %d", updateCount)
-	}
-	if !hasReorder {
-		t.Error("Expected reorder operation - THIS IS THE BUG FIX")
-	}
-}
-
-// TestGenerateRangeDifferentialOperations_UpdateNoReorder tests that no reorder
-// is generated when items update but order stays the same.
-func TestGenerateRangeDifferentialOperations_UpdateNoReorder(t *testing.T) {
-	statics := []string{`<li data-key="`, `">`, `</li>`}
-
-	item1Old := &TreeNode{Dynamics: []interface{}{"id1", "Old"}}
-	item2 := &TreeNode{Dynamics: []interface{}{"id2", "Same"}}
-
-	item1New := &TreeNode{Dynamics: []interface{}{"id1", "New"}}
-
-	oldValue := &TreeNode{
-		Statics: statics,
-		Range:   &RangeData{Items: []interface{}{item1Old, item2}},
-	}
-
-	newValue := &TreeNode{
-		Statics: statics,
-		Range:   &RangeData{Items: []interface{}{item1New, item2}}, // Same order
-	}
-
-	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
-
-	// Should only have update, no reorder
-	hasUpdate := false
-	hasReorder := false
-
-	for _, op := range ops {
-		opArray := op.([]interface{})
-		switch opArray[0] {
-		case "u":
-			hasUpdate = true
-		case "o":
-			hasReorder = true
-		}
-	}
-
-	if !hasUpdate {
-		t.Error("Expected update operation")
-	}
-	if hasReorder {
-		t.Error("Should NOT have reorder operation when order is unchanged")
+	if ops := GenerateRangeDifferentialOperations(oldValue, newValue, false); ops != nil {
+		t.Errorf("Expected nil-return for multi-content+reorder change, got: %v", ops)
 	}
 }
 
@@ -1667,186 +1188,6 @@ func TestGenerateRangeDifferentialOperations_InsertionNoReorder(t *testing.T) {
 	}
 	if hasReorder {
 		t.Error("Should NOT have reorder when key sets differ (items were added)")
-	}
-}
-
-// =============================================================================
-// CONDITIONAL BRANCH CHANGE TESTS
-// Tests for the Phase 6 bug fix where conditionals change within range items,
-// requiring both statics AND dynamics to be sent.
-// =============================================================================
-
-// TestCompareRangeItemsForChanges_ConditionalBranchChange tests the case where
-// a conditional branch changes within a range item, causing both statics AND
-// dynamics to change. The old behavior sent only dynamics (bug), the fix sends
-// full tree with statics.
-//
-// Example template:
-// {{if .HasError}}<span class="error-message">{{.Error}}</span>{{else}}<span class="status">Pending</span>{{end}}
-//
-// When HasError changes from false to true:
-// Old: {"s":["<span class=\"status\">","</span>"], "0":"Pending"}
-// New: {"s":["<span class=\"error-message\">","</span>"], "0":"Error message"}
-func TestCompareRangeItemsForChanges_ConditionalBranchChange(t *testing.T) {
-	// Old item: showing status (HasError=false)
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{
-			Statics:  []string{`<span class="status">`, `</span>`},
-			Dynamics: []interface{}{"Pending"},
-		}},
-	}
-
-	// New item: showing error (HasError=true) - DIFFERENT statics AND dynamics
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{
-			Statics:  []string{`<span class="error-message">`, `</span>`},
-			Dynamics: []interface{}{"Permission denied"},
-		}},
-	}
-
-	statics := []string{"<li>", "", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have 1 change for field "1"
-	if len(changes) != 1 {
-		t.Fatalf("Expected 1 change, got %d: %v", len(changes), changes)
-	}
-
-	change1, ok := changes["1"]
-	if !ok {
-		t.Fatal("Expected change for field '1'")
-	}
-
-	// The change should be a TreeNode WITH statics (not stripped)
-	changeTree, isTree := change1.(*TreeNode)
-	if !isTree {
-		t.Fatalf("Expected *TreeNode for conditional branch change, got %T: %v", change1, change1)
-	}
-
-	// Verify statics are included (the new error message wrapper)
-	if len(changeTree.Statics) != 2 {
-		t.Errorf("Expected 2 statics (error-message wrapper), got %d: %v", len(changeTree.Statics), changeTree.Statics)
-	}
-
-	if changeTree.Statics[0] != `<span class="error-message">` {
-		t.Errorf("Expected error-message statics, got %v", changeTree.Statics)
-	}
-
-	// Verify dynamics are also included
-	if changeTree.Dynamics[0] != "Permission denied" {
-		t.Errorf("Expected dynamics with error message, got %v", changeTree.Dynamics)
-	}
-}
-
-// TestCompareRangeItemsForChanges_SameStructureDifferentContent tests that when
-// structure is the same (same statics) but content differs, only dynamics are sent.
-// This is the normal case - no statics needed because client has them cached.
-func TestCompareRangeItemsForChanges_SameStructureDifferentContent(t *testing.T) {
-	// Old item: status showing "Pending"
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{
-			Statics:  []string{`<span class="status">`, `</span>`},
-			Dynamics: []interface{}{"Pending"},
-		}},
-	}
-
-	// New item: status showing "Done" - SAME statics, different dynamics
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"task1", &TreeNode{
-			Statics:  []string{`<span class="status">`, `</span>`},
-			Dynamics: []interface{}{"Done"},
-		}},
-	}
-
-	statics := []string{"<li>", "", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have 1 change for field "1"
-	if len(changes) != 1 {
-		t.Fatalf("Expected 1 change, got %d: %v", len(changes), changes)
-	}
-
-	change1, ok := changes["1"]
-	if !ok {
-		t.Fatal("Expected change for field '1'")
-	}
-
-	// The change should be stripped (dynamics only, no statics)
-	// PrepareTreeForClient with clientHasStatics=true returns map[string]interface{}
-	changeMap, isMap := change1.(map[string]interface{})
-	if !isMap {
-		// Could also be *TreeNode with no statics - check that
-		if changeTree, isTree := change1.(*TreeNode); isTree {
-			if len(changeTree.Statics) > 0 {
-				t.Errorf("Expected NO statics when structure unchanged, got %v", changeTree.Statics)
-			}
-		} else {
-			t.Fatalf("Expected map or TreeNode without statics, got %T: %v", change1, change1)
-		}
-	} else {
-		// Verify it's stripped (no "s" key for statics)
-		if _, hasStatics := changeMap["s"]; hasStatics {
-			t.Errorf("Expected NO statics in change when structure unchanged, got %v", changeMap)
-		}
-		// Verify dynamics are present
-		if changeMap["0"] != "Done" {
-			t.Errorf("Expected dynamics with new content, got %v", changeMap)
-		}
-	}
-}
-
-// TestCompareRangeItemsForChanges_ConditionalBranchChange_LoadingToError tests
-// a more complex scenario: item transitions from loading spinner to error message.
-// This is a realistic async loading pattern.
-func TestCompareRangeItemsForChanges_ConditionalBranchChange_LoadingToError(t *testing.T) {
-	// Old item: showing loading spinner
-	oldItem := &TreeNode{
-		Dynamics: []interface{}{"item-1", &TreeNode{
-			Statics:  []string{`<span class="spinner">`, `</span>`},
-			Dynamics: []interface{}{"⏳"},
-		}, "Item Title"},
-	}
-
-	// New item: showing error (loading finished with error)
-	newItem := &TreeNode{
-		Dynamics: []interface{}{"item-1", &TreeNode{
-			Statics:  []string{`<span class="error">`, `</span>`},
-			Dynamics: []interface{}{"Network timeout"},
-		}, "Item Title"},
-	}
-
-	statics := []string{"<li id=\"", "\">", "", "", "</li>"}
-
-	changes := CompareRangeItemsForChanges(oldItem, newItem, statics)
-
-	// Should have 1 change for field "1" (the conditional part)
-	if len(changes) != 1 {
-		t.Fatalf("Expected 1 change, got %d: %v", len(changes), changes)
-	}
-
-	// Field "0" (key) should not be in changes
-	if _, hasKey := changes["0"]; hasKey {
-		t.Error("Key field should not be in changes")
-	}
-
-	// Field "2" (title) should not be in changes
-	if _, hasTitle := changes["2"]; hasTitle {
-		t.Error("Unchanged field should not be in changes")
-	}
-
-	change1 := changes["1"]
-
-	// The change should be a TreeNode WITH statics
-	changeTree, isTree := change1.(*TreeNode)
-	if !isTree {
-		t.Fatalf("Expected *TreeNode with new statics, got %T: %v", change1, change1)
-	}
-
-	// Verify new statics are included (error wrapper)
-	if len(changeTree.Statics) < 2 || changeTree.Statics[0] != `<span class="error">` {
-		t.Errorf("Expected error statics, got %v", changeTree.Statics)
 	}
 }
 

--- a/internal/diff/range_ops_test.go
+++ b/internal/diff/range_ops_test.go
@@ -188,8 +188,8 @@ func TestGenerateRangeDifferentialOperations_Insertion(t *testing.T) {
 // TestGenerateRangeDifferentialOperations_Mixed verifies that a render combining
 // structural changes (id1/id3 removed, id4 added) with a kept-item content change
 // (id2: "Old Name" → "New Name") signals nil-return so the caller emits a full-tree
-// replacement. Per Phase 4 (proposal §5d), kept-item content changes can no longer
-// be encoded as differential ops.
+// replacement. Kept-item content changes cannot be encoded as differential ops
+// (spec §5d).
 func TestGenerateRangeDifferentialOperations_Mixed(t *testing.T) {
 	item1 := &TreeNode{Dynamics: []interface{}{"id1", "Name 1"}}
 	item2Old := &TreeNode{Dynamics: []interface{}{"id2", "Old Name"}}
@@ -626,9 +626,8 @@ func TestGenerateRangeDifferentialOperations_NilRangeData(t *testing.T) {
 }
 
 // TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack
-// covers a single item present on both renders whose content changed. Phase 4
-// removed the per-item ["u"] producer, so the diff engine must signal nil-return
-// to trigger full-tree replacement.
+// covers a single item present on both renders whose Dynamics changed. The
+// diff engine signals nil-return so the caller emits a full-tree replacement.
 func TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	oldValue := &TreeNode{
@@ -669,7 +668,8 @@ func TestGenerateRangeDifferentialOperations_StructuralAndContent_FallsBack(t *t
 
 // TestGenerateRangeDifferentialOperations_PureStructural_StillEmitsOps locks in
 // the wire-size win for het ranges that change only structurally — pure-add of
-// new items with no kept-item content drift must still emit a compact ['a'] op.
+// new items with no kept-item content drift must still emit a compact ['a']/['i']
+// op carrying the new key.
 func TestGenerateRangeDifferentialOperations_PureStructural_StillEmitsOps(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	oldValue := &TreeNode{
@@ -689,18 +689,67 @@ func TestGenerateRangeDifferentialOperations_PureStructural_StillEmitsOps(t *tes
 		t.Fatal("Expected ops for pure-structural change, got nil-fallback")
 	}
 
-	hasAppend := false
+	foundID2 := false
 	for _, op := range ops {
 		opArr, ok := op.([]interface{})
 		if !ok || len(opArr) < 2 {
 			continue
 		}
-		if opArr[0] == "a" || opArr[0] == "i" || opArr[0] == "p" {
-			hasAppend = true
+		switch opArr[0] {
+		case "a", "p":
+			items, ok := opArr[1].([]interface{})
+			if !ok {
+				continue
+			}
+			for _, item := range items {
+				if node, ok := item.(*TreeNode); ok && len(node.Dynamics) > 0 && node.Dynamics[0] == "id2" {
+					foundID2 = true
+				}
+			}
+		case "i":
+			if len(opArr) >= 3 {
+				if node, ok := opArr[2].(*TreeNode); ok && len(node.Dynamics) > 0 && node.Dynamics[0] == "id2" {
+					foundID2 = true
+				}
+			}
 		}
 	}
-	if !hasAppend {
-		t.Errorf("Expected an append/insert op, got: %v", ops)
+	if !foundID2 {
+		t.Errorf("Expected an append/insert op carrying id2, got: %v", ops)
+	}
+}
+
+// TestGenerateRangeDifferentialOperations_StaticsOnlyChange_FallsBack covers the
+// conditional-branch flip pattern: a kept item's nested TreeNode flips Statics
+// (e.g. {{if .Done}}<s>{{end}}) with no Dynamics change. The hash check alone
+// would miss this (empty Dynamics → identical hash) — the statics fingerprint
+// comparison catches it and forces full-tree fallback.
+func TestGenerateRangeDifferentialOperations_StaticsOnlyChange_FallsBack(t *testing.T) {
+	itemStatics := []string{`<li data-key="`, `">`, "</li>"}
+	rangeStatics := []string{"<ul>", "</ul>"}
+	oldValue := &TreeNode{
+		Statics: rangeStatics,
+		Range: &RangeData{
+			Statics: itemStatics,
+			Items: []interface{}{&TreeNode{
+				Statics:  itemStatics,
+				Dynamics: []interface{}{"task-1", &TreeNode{Statics: []string{"<s>", "</s>"}}},
+			}},
+		},
+	}
+	newValue := &TreeNode{
+		Statics: rangeStatics,
+		Range: &RangeData{
+			Statics: itemStatics,
+			Items: []interface{}{&TreeNode{
+				Statics:  itemStatics,
+				Dynamics: []interface{}{"task-1", &TreeNode{Statics: []string{""}}},
+			}},
+		},
+	}
+
+	if ops := GenerateRangeDifferentialOperations(oldValue, newValue, false); ops != nil {
+		t.Errorf("Expected nil-return for statics-only kept-item change, got: %v", ops)
 	}
 }
 

--- a/internal/diff/range_ops_test.go
+++ b/internal/diff/range_ops_test.go
@@ -625,6 +625,23 @@ func TestGenerateRangeDifferentialOperations_NilRangeData(t *testing.T) {
 	}
 }
 
+// TestHasKeptItemChanged_NonTreeNodeReturnsTrue locks in the safety bias: if a
+// kept-key resolves to a non-*TreeNode on either side, the function returns
+// true (force fallback) rather than silently emit a no-op for unrenderable
+// state. The path is unreachable through GenerateRangeDifferentialOperations
+// today because key extraction itself requires *TreeNode, but the bias remains
+// load-bearing for any future caller that constructs a context manually.
+func TestHasKeptItemChanged_NonTreeNodeReturnsTrue(t *testing.T) {
+	ctx := &rangeContext{
+		newKeys:  []string{"id1"},
+		oldByKey: map[string]interface{}{"id1": "raw-string"},
+		newByKey: map[string]interface{}{"id1": &TreeNode{Dynamics: []interface{}{"id1", "x"}}},
+	}
+	if !hasKeptItemChanged(ctx) {
+		t.Error("Expected true for non-*TreeNode old value (safety bias), got false")
+	}
+}
+
 // TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack
 // covers a single item present on both renders whose Dynamics changed. The
 // diff engine signals nil-return so the caller emits a full-tree replacement.

--- a/internal/diff/transition.go
+++ b/internal/diff/transition.go
@@ -11,7 +11,7 @@ import (
 // "Top-level" covers two cases: the root tree may itself be a Range (when the
 // template is just `{{range}}` with no wrapper element), or a Range may sit
 // directly inside the root tree's Dynamics. Both are at depth ≤ 1 and qualify
-// per proposal §5a — nested ranges deeper than that stay legacy.
+// per spec §5a — nested ranges deeper than that stay legacy.
 //
 // Uses CalculateStaticsFingerprint (not GetStructureFingerprint) for the
 // homogeneity check — the latter over-captures scalar position-presence,
@@ -32,9 +32,10 @@ func TransitionToStreamMode(tree *build.TreeNode) {
 	}
 }
 
-// transitionRangeIfHomogeneous applies the §5a homogeneity check to a single
-// RangeData and, if all items share a statics fingerprint, swaps Items for a
-// RangeStreamState snapshot. No-op for nil/empty/already-transitioned ranges.
+// transitionRangeIfHomogeneous applies the spec §5a homogeneity check to a
+// single RangeData and, if all items share a statics fingerprint, swaps Items
+// for a RangeStreamState snapshot. No-op for nil/empty/already-transitioned
+// ranges.
 func transitionRangeIfHomogeneous(rd *build.RangeData) {
 	if rd == nil || rd.StreamState != nil || len(rd.Items) == 0 {
 		return

--- a/internal/diff/transition.go
+++ b/internal/diff/transition.go
@@ -8,6 +8,11 @@ import (
 // TransitionToStreamMode replaces Range.Items with a RangeStreamState snapshot
 // for top-level homogeneous ranges. Caller must hold the lock that protects tree.
 //
+// "Top-level" covers two cases: the root tree may itself be a Range (when the
+// template is just `{{range}}` with no wrapper element), or a Range may sit
+// directly inside the root tree's Dynamics. Both are at depth ≤ 1 and qualify
+// per proposal §5a — nested ranges deeper than that stay legacy.
+//
 // Uses CalculateStaticsFingerprint (not GetStructureFingerprint) for the
 // homogeneity check — the latter over-captures scalar position-presence,
 // falsely classifying [id, "x"] vs [id, nil] as heterogeneous.
@@ -15,54 +20,54 @@ func TransitionToStreamMode(tree *build.TreeNode) {
 	if tree == nil {
 		return
 	}
+	if tree.HasRange() {
+		transitionRangeIfHomogeneous(tree.Range)
+	}
 	for _, value := range tree.Dynamics {
 		node, ok := value.(*build.TreeNode)
-		if !ok || !node.HasRange() || node.Range == nil {
+		if !ok || !node.HasRange() {
 			continue
 		}
-		rd := node.Range
-		if rd.StreamState != nil {
-			continue
-		}
-		if len(rd.Items) == 0 {
-			continue
-		}
+		transitionRangeIfHomogeneous(node.Range)
+	}
+}
 
-		firstItem, ok := rd.Items[0].(*build.TreeNode)
+// transitionRangeIfHomogeneous applies the §5a homogeneity check to a single
+// RangeData and, if all items share a statics fingerprint, swaps Items for a
+// RangeStreamState snapshot. No-op for nil/empty/already-transitioned ranges.
+func transitionRangeIfHomogeneous(rd *build.RangeData) {
+	if rd == nil || rd.StreamState != nil || len(rd.Items) == 0 {
+		return
+	}
+	firstItem, ok := rd.Items[0].(*build.TreeNode)
+	if !ok {
+		return
+	}
+	ref := build.CalculateStaticsFingerprint(firstItem)
+	for _, item := range rd.Items[1:] {
+		itemNode, ok := item.(*build.TreeNode)
+		if !ok || build.CalculateStaticsFingerprint(itemNode) != ref {
+			return
+		}
+	}
+
+	keyPos := FindKeyPositionFromStatics(rd.Statics)
+	keysList := make([]string, len(rd.Items))
+	hashes := make([]uint64, len(rd.Items))
+	for i, item := range rd.Items {
+		itemNode, ok := item.(*build.TreeNode)
 		if !ok {
 			continue
 		}
-		ref := build.CalculateStaticsFingerprint(firstItem)
-		homogeneous := true
-		for _, item := range rd.Items[1:] {
-			itemNode, ok := item.(*build.TreeNode)
-			if !ok || build.CalculateStaticsFingerprint(itemNode) != ref {
-				homogeneous = false
-				break
-			}
+		if keyStr, ok := getItemKeyWithPos(itemNode, keyPos); ok {
+			keysList[i] = keyStr
 		}
-		if !homogeneous {
-			continue
-		}
-
-		keyPos := FindKeyPositionFromStatics(rd.Statics)
-		keysList := make([]string, len(rd.Items))
-		hashes := make([]uint64, len(rd.Items))
-		for i, item := range rd.Items {
-			itemNode, ok := item.(*build.TreeNode)
-			if !ok {
-				continue
-			}
-			if keyStr, ok := getItemKeyWithPos(itemNode, keyPos); ok {
-				keysList[i] = keyStr
-			}
-			hashes[i] = keys.ItemHashUint64(itemNode.Dynamics)
-		}
-		rd.StreamState = &build.RangeStreamState{
-			Keys:        keysList,
-			Hashes:      hashes,
-			Fingerprint: ref,
-		}
-		rd.Items = nil
+		hashes[i] = keys.ItemHashUint64(itemNode.Dynamics)
 	}
+	rd.StreamState = &build.RangeStreamState{
+		Keys:        keysList,
+		Hashes:      hashes,
+		Fingerprint: ref,
+	}
+	rd.Items = nil
 }

--- a/internal/diff/transition.go
+++ b/internal/diff/transition.go
@@ -6,12 +6,9 @@ import (
 )
 
 // TransitionToStreamMode replaces Range.Items with a RangeStreamState snapshot
-// for top-level homogeneous ranges. Caller must hold the lock that protects tree.
-//
-// "Top-level" covers two cases: the root tree may itself be a Range (when the
-// template is just `{{range}}` with no wrapper element), or a Range may sit
-// directly inside the root tree's Dynamics. Both are at depth ≤ 1 and qualify
-// per spec §5a — nested ranges deeper than that stay legacy.
+// for top-level homogeneous ranges (the root tree's Range and any direct-child
+// Range in Dynamics — depth ≤ 1 per spec §5a). Caller must hold the lock that
+// protects tree.
 //
 // Uses CalculateStaticsFingerprint (not GetStructureFingerprint) for the
 // homogeneity check — the latter over-captures scalar position-presence,

--- a/internal/diff/transition_test.go
+++ b/internal/diff/transition_test.go
@@ -186,9 +186,9 @@ func TestTransitionToStreamMode_NilTreeSafe(t *testing.T) {
 
 // TestTransitionToStreamMode_RootRangeFires covers the case where the root
 // tree itself is a Range (template `{{range .Items}}<x/>{{end}}` with no
-// wrapper element). The root range counts as top-level per §5a and must
-// transition. Phase 3 walked Dynamics only and silently missed this shape;
-// Phase 4 closes the gap so wrapper-less templates also stream-mode.
+// wrapper element). The root range counts as top-level per spec §5a and must
+// transition. Without this case, wrapper-less templates silently fall through
+// to the legacy diff path even when their range is homogeneous.
 func TestTransitionToStreamMode_RootRangeFires(t *testing.T) {
 	itemStatics := []string{`<li data-key="`, `">`, `</li>`}
 	tree := &build.TreeNode{

--- a/internal/diff/transition_test.go
+++ b/internal/diff/transition_test.go
@@ -183,3 +183,35 @@ func TestTransitionToStreamMode_NilTreeSafe(t *testing.T) {
 	// Must not panic on nil input.
 	TransitionToStreamMode(nil)
 }
+
+// TestTransitionToStreamMode_RootRangeFires covers the case where the root
+// tree itself is a Range (template `{{range .Items}}<x/>{{end}}` with no
+// wrapper element). The root range counts as top-level per §5a and must
+// transition. Phase 3 walked Dynamics only and silently missed this shape;
+// Phase 4 closes the gap so wrapper-less templates also stream-mode.
+func TestTransitionToStreamMode_RootRangeFires(t *testing.T) {
+	itemStatics := []string{`<li data-key="`, `">`, `</li>`}
+	tree := &build.TreeNode{
+		Statics: itemStatics,
+		Range: &build.RangeData{
+			Statics: itemStatics,
+			Items: []interface{}{
+				&build.TreeNode{Statics: itemStatics, Dynamics: []interface{}{"a", "alpha"}},
+				&build.TreeNode{Statics: itemStatics, Dynamics: []interface{}{"b", "beta"}},
+			},
+		},
+	}
+
+	TransitionToStreamMode(tree)
+
+	if tree.Range.Items != nil {
+		t.Errorf("Items should be nil after root-range transition, got %v", tree.Range.Items)
+	}
+	if tree.Range.StreamState == nil {
+		t.Fatalf("StreamState should be populated for root-range transition")
+	}
+	ss := tree.Range.StreamState
+	if len(ss.Keys) != 2 || ss.Keys[0] != "a" || ss.Keys[1] != "b" {
+		t.Errorf("Expected keys [a, b], got %v", ss.Keys)
+	}
+}


### PR DESCRIPTION
## Summary

- Delete the partial-delta `["u"]` producer per proposal §314: `CompareRangeItemsForChanges`, `compareRangeItemsWithKeyPos`, `generateUpdateOps`, plus the now-dead `handleNestedTreeNodeChange` and `isMeaningfulValue` helpers.
- Update `docs/specifications/tree-update-specification.md` per §5c (full-snapshot producer contract) + §232 (consumer must replace, not merge).
- Close a Phase 3 coverage gap: `TransitionToStreamMode` now transitions root-level ranges in addition to direct-child ranges. Wrapper-less templates (`{{range .Items}}<x/>{{end}}`) now stream-mode correctly.

## The deletion cascade

`compareRangeItemsWithKeyPos` is the sole producer of partial-delta `["u"]` payloads, called only by `generateUpdateOps`. After Phase 4's spec update, partial-delta `["u"]` is non-compliant on the wire — so `generateUpdateOps` must also go (advisor framing: "compelled, not chosen"). With `generateUpdateOps` gone, kept-item content changes would silently emit no ops; a hash-based content-change detector in `GenerateRangeDifferentialOperations` signals nil-return on any mismatch, which `handleMatchedRanges` already handles by falling through to `*changes = *newTree` (full-tree replacement per §5d).

**Approach A** chosen over Approach B (delete `GenerateRangeDifferentialOperations` entirely): keep `generateRemovalOps`, `generateInsertionOps`, etc. so het ranges with pure-structural changes (add/remove/reorder only) still emit compact ops. The proposal §5d wording compels deleting `["u"]`-emission, not all per-op emission.

## Phase 3 coverage gap surfaced + closed

`TransitionToStreamMode` walked `tree.Dynamics` looking for nested ranges but never checked the root tree itself. For templates whose root tree IS the range (no wrapper element), the transition silently missed it → legacy path → partial-delta `["u"]` ops were emitted. Phase 3 didn't catch this because the legacy path masked it; Phase 4 surfaces it as a panic in `TestAllOperationTypes/Update`. Refactored to extract `transitionRangeIfHomogeneous` and call it on both `tree.Range` and direct-child Dynamics ranges.

## Net change

`8 files changed, 311 insertions(+), 1022 deletions(-)` — net −713 lines.

- 16 tests deleted (asserted deleted partial-delta behavior)
- 3 tests migrated to assert nil-return (`_Mixed`, `_UpdateAndReorder`, `_MultipleUpdatesAndReorder`)
- 4 new tests: `_KeptItemContentChange_FallsBack`, `_StructuralAndContent_FallsBack`, `_PureStructural_StillEmitsOps`, `TestTransitionToStreamMode_RootRangeFires`
- 2 e2e subtests removed (covered by the new internal/diff tests)

## Wire regression accepted

Het ranges with kept-item content changes now emit full-tree replacement instead of partial-delta `["u"]`. Pure-structural changes to het ranges still emit compact ops. Homogeneous ranges are unaffected — they transition to stream mode on render 2 and emit compact `["u"]` with full snapshots per §5c. Acceptable per §5d.

## Test plan

- [x] `GOWORK=off go test ./...` — green (root pkg ~108s, all internal pkgs <1s)
- [x] `GOWORK=off go test -race -count=1 ./internal/diff/... ./internal/keys/... ./internal/build/... ./internal/fuzz/...` — race-clean
- [x] `GOWORK=off go test -race -count=1 ./` — race-clean (root pkg, 526s)
- [x] `grep -rn "CompareRangeItemsForChanges\|compareRangeItemsWithKeyPos\|handleNestedTreeNodeChange\|isMeaningfulValue\|generateUpdateOps" internal/ --include="*.go"` — zero hits
- [x] `examples/test-all.sh` — all 12 packages green with `-race` (chromedp E2E via patterns at 230s, todos, chat, etc.)
- [x] `examples go test ./...` — all 13 packages green (separate run)

Sibling-repo failures unrelated to Phase 4: `lvt` (4 `sqlc not installed`), `tinkerdown` (2 missing local scripts), `livetemplate/e2e/docker` (Dockerfile pins `golang:1.24-alpine` but project requires `go 1.26.0`). All fail on `main` for the same reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)