### PR TITLE
docs: rewrite README + new standard-HTML guide and navigate reference (#268, #349)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,40 @@
 # LiveTemplate
 
-Build interactive web applications in Go using a simplified programming model. Write server-side code, get reactive UIs automatically.
+Reactive web UIs in standard HTML and Go. No custom template language. No client-side framework. No persistent connection required.
 
-**[Quick Start](#quick-start)** • **[API Docs](https://pkg.go.dev/github.com/livetemplate/livetemplate)** • **[CLI Tool](https://github.com/livetemplate/lvt)** • **[Examples](https://github.com/livetemplate/examples)**
+**[Quick Start](#quick-start)** | **[Docs](docs/)** | **[Examples](https://github.com/livetemplate/examples)** | **[API Reference](https://pkg.go.dev/github.com/livetemplate/livetemplate)**
+
+> **Alpha** — Core features work and are tested, but the API may change before v1.0.
 
 <p align="center">
   <img src="assets/demo.svg" alt="LiveTemplate reactive update flow — click a button, server updates state, only changed value sent to browser" width="720">
 </p>
 
----
+The HTML and Go behind a reactive todo list:
 
-> **ALPHA SOFTWARE**
->
-> LiveTemplate is currently in **alpha stage**. Core features work and are tested, but the API may change before v1.0. Use in production at your own risk.
+```html
+<form method="POST">
+    <input type="text" name="title" required placeholder="What needs to be done?">
+    <button name="add">Add Todo</button>
+</form>
+<ul>
+{{range .Items}}<li>{{.Title}}</li>{{end}}
+</ul>
+```
 
----
+```go
+func (c *TodoController) Add(state TodoState, ctx *livetemplate.Context) (TodoState, error) {
+    state.Items = append(state.Items, Todo{Title: ctx.GetString("title")})
+    ctx.BroadcastAction("Refresh", nil) // pushes update to other WS-connected tabs
+    return state, nil
+}
+```
 
-## A Better Way to Build Interactive Apps
+The button's `name` IS the action — `<button name="add">` routes to `Add()`. No custom attributes, no JavaScript wiring. Without JS, the form POSTs normally. With the JS client, the DOM patches in place. Add a WebSocket and other tabs sync automatically. See [Standard HTML Reactivity](docs/guides/standard-html-reactivity.md) for how this compares to htmx, Livewire, and LiveView.
 
-Every interactive feature in a traditional web app requires the same ceremony: design a REST endpoint, write a serializer, manage client-side state, update the DOM, and wire it all together. That overhead discourages interactivity — teams leave things static not because they should be, but because the plumbing isn't worth it. As Chris McCord [put it](https://fly.io/blog/how-we-got-to-liveview/) when explaining why he built Phoenix LiveView: conventional frameworks make you "fetch the world, munge it into some format, and shoot it over the wire... then throw all that state away" on every request.
+> The full [todos example](https://github.com/livetemplate/examples/tree/main/todos) uses SQLite, form validation, and toasts. The snippet above is the minimal in-memory shape.
 
-LiveView's answer was to keep all state on the server and push rendered updates over a persistent connection — no REST layer, no client-side framework. LiveTemplate brings that approach to Go, but with one major difference: it doesn't require a persistent connection and works equally well over standard HTTP. When a user clicks a button, LiveTemplate calls a method on your Go struct, you update your state, and only what changed is sent back to the browser. No endpoints to design, no JSON to serialize, no client-side state to synchronize.
+## How It Works
 
 ```mermaid
 sequenceDiagram
@@ -34,163 +48,7 @@ sequenceDiagram
     Note over Browser: DOM updated<br/>Counter: 6
 ```
 
-## Why LiveTemplate?
-
-### 1. Reactive UIs in Pure Go
-
-All user-initiated interactions work over plain HTTP — no WebSocket required. The JS client sends actions as standard HTTP requests and patches the DOM with the response. WebSocket is only needed when the *server* needs to push updates unprompted (e.g., notifying other users in a chat room). Unlike Phoenix LiveView, which requires a persistent connection for all interactions, LiveTemplate treats WebSocket as an optional upgrade for broadcast scenarios only.
-
-This extends to progressive enhancement at the HTML level too. LiveTemplate follows a **progressive complexity** model — start with standard HTML, add custom attributes only when you need behaviors HTML can't express:
-
-| Tier | What you write | When to use |
-|------|---------------|-------------|
-| **Tier 1: Standard HTML** | `<form>`, `<button name="add">`, `<dialog>`, `<a href>` | Forms, actions, modals, navigation |
-| **Tier 2: `lvt-*` attributes** | `lvt-debounce`, `lvt-key`, `lvt-addClass-on:pending` | Timing, keyboard shortcuts, reactive DOM |
-
-A form that works at all transport levels — no JS, fetch, and WebSocket — with zero custom attributes:
-
-```html
-<form method="POST">
-    <input type="text" name="title" required placeholder="What needs to be done?">
-    <button name="add">Add Todo</button>
-</form>
-```
-
-The button's `name` IS the action — `<button name="add">` routes to the `Add()` method. Without JS, the form POSTs normally. With the JS client, the submission is intercepted and the DOM is patched in place. One declaration, three transport modes.
-
-```go
-func (c *TodoController) Add(state TodoState, ctx *livetemplate.Context) (TodoState, error) {
-    if err := ctx.ValidateForm(); err != nil {  // Inferred from HTML required attr
-        return state, err
-    }
-    state.Items = append(state.Items, Todo{Title: ctx.GetString("title")})
-    return state, nil
-}
-```
-
-Forms without a named button auto-route to a conventional `Submit()` method — no attributes needed at all for the simplest case. See the [Progressive Complexity Guide](docs/guides/progressive-complexity.md) for the full walkthrough and the [todos-progressive](https://github.com/livetemplate/examples/tree/main/todos-progressive) and [profile-progressive](https://github.com/livetemplate/examples/tree/main/profile-progressive) examples.
-
-For behaviors that HTML can't express — timing control, reactive DOM, keyboard shortcuts — use `lvt-*` attributes:
-
-```html
-<!-- Debounced search: waits 300ms after typing stops before querying -->
-<input name="Query" value="{{.Query}}"
-    lvt-input="search" lvt-debounce="300"
-    placeholder="Search...">
-```
-
-```go
-func (c *AppController) Search(state AppState, ctx *livetemplate.Context) (AppState, error) {
-    state.Query = ctx.GetString("Query")
-    state.Results = c.DB.Search(state.Query)
-    return state, nil
-}
-```
-
-Your existing Go toolchain, testing infrastructure, and deployment pipeline all work as-is. See the [examples](https://github.com/livetemplate/examples) repository.
-
-### 2. Safe State Management
-
-LiveTemplate separates **controllers** (singleton, holds dependencies) from **state** (pure data, cloned per session). This prevents a class of bugs where session-specific data like OAuth tokens or caches accidentally leaks between users:
-
-```go
-// Controller: Singleton, holds shared dependencies — never cloned
-type TodoController struct {
-    DB     *sql.DB
-    Logger *slog.Logger
-}
-
-// State: Pure data, cloned per session — must be serializable
-type TodoState struct {
-    Items  []Todo
-    Filter string
-}
-
-func (c *TodoController) Add(state TodoState, ctx *livetemplate.Context) (TodoState, error) {
-    todo := Todo{Title: ctx.GetString("title")}
-    // c.DB is a dependency on the controller, not in cloned state
-    c.DB.Create(&todo)
-    state.Items = append(state.Items, todo)
-    return state, nil
-}
-```
-
-The separation is enforced at the API level: `tmpl.Handle(controller, livetemplate.AsState(state))`. Convention and the `AssertPureState[T]()` test helper catch accidental dependency leakage. See the [chat example](https://github.com/livetemplate/examples/tree/main/chat) for a multi-user app using this pattern with broadcasting.
-
-### 3. Efficient by Design
-
-LiveTemplate separates your template into static HTML (the parts that never change) and dynamic values (the parts that do). On first render, the client receives and caches the full structure:
-
-```json
-{"s": ["<div>Counter: ", "</div>"], "0": "5"}
-```
-
-When the counter changes from 5 to 6, only the new value is sent:
-
-```json
-{"0": "6"}
-```
-
-No re-rendered HTML, no string diffing — just the single value that changed. For typical pages with lots of markup and few changing values, this means **50-90% less data** than sending full HTML. This optimization works over both plain HTTP and WebSocket — the server tracks tree state per session, so subsequent actions always send minimal diffs regardless of transport. This is the same static/dynamic split that [Phoenix LiveView uses](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html) — a proven approach to minimizing wire traffic.
-
-### 4. Idiomatic Go Error Handling
-
-Errors flow naturally using Go's familiar patterns. Return an error and LiveTemplate automatically displays it in your template:
-
-```go
-func (c *AuthController) Signup(state AuthState, ctx *livetemplate.Context) (AuthState, error) {
-    var input SignupInput
-    if err := ctx.BindAndValidate(&input, validate); err != nil {
-        return state, err  // Validation errors automatically sent to client
-    }
-
-    if c.usernameExists(input.Username) {
-        return state, livetemplate.NewFieldError("username",
-            errors.New("username already taken"))
-    }
-
-    return state, nil
-}
-```
-
-```html
-<input name="username" {{if .lvt.HasError "username"}}aria-invalid="true"{{end}}>
-{{if .lvt.HasError "username"}}
-    <small>{{.lvt.Error "username"}}</small>
-{{end}}
-```
-
-No error serialization code. No client-side error state management. Actions return `(State, error)` — the standard Go signature.
-
-### 5. Generate Complete Apps Instantly
-
-The `lvt` CLI generates complete CRUD applications — forms, tables, validation, database integration — all reactive by default:
-
-```bash
-lvt new myapp
-cd myapp
-lvt gen products name price:float stock:int
-lvt serve
-```
-
-Code generation works reliably because templates have a predictable static/dynamic structure. Generated code inherits the reactive programming model. No glue code, no manual wiring. Pluggable CSS kits (Tailwind, Bulma, Pico, or plain HTML) let you match your team's preferred styling approach.
-
-## Current Limitations
-
-LiveTemplate is inspired by [Phoenix LiveView](https://hexdocs.pm/phoenix_live_view) but doesn't yet cover its full feature set. Here's what's missing:
-
-| Feature | LiveView | LiveTemplate | Notes |
-|---------|----------|--------------|-------|
-| **Live Navigation** | `push_navigate`, `push_patch` | Not yet | LiveView updates the URL and swaps page sections without a full reload. LiveTemplate requires full page navigation. |
-| **Stateful Components** | `LiveComponent` with own lifecycle | Stateless templates only | LiveView components have isolated state, events, and lifecycle hooks. LiveTemplate has `{{template}}` invocations but no component-level state or event handling. |
-| **Streams** | `stream/3` for large lists | Not yet | LiveView streams handle large/infinite lists without keeping all items in server memory. LiveTemplate keeps all state in memory. |
-| **JS Commands** | `JS.push`, `JS.toggle`, `JS.show` | Partial | LiveView has composable server-defined JS command chains. LiveTemplate's [reactive attributes](docs/references/client-attributes.md) cover common cases (disable, add/remove class, set attribute) but aren't as flexible. |
-| **Client Hooks** | `phx-hook` lifecycle callbacks | Not yet | LiveView hooks let you integrate third-party JS libraries (charts, maps, editors) with mounted/updated/destroyed callbacks. |
-| **Presence** | `Phoenix.Presence` | Not built-in | LiveView has built-in distributed presence tracking ("who's online"). Can be built on LiveTemplate's session stores but requires manual implementation. |
-| **Testing Helpers** | `live/2`, `render_click/3` | Minimal | LiveView provides a full test DSL for simulating user interactions without a browser. LiveTemplate has `AssertPureState` but no view-level test helpers yet. |
-| **Form Recovery** | Automatic on reconnect | Not yet | LiveView restores form inputs automatically after a WebSocket reconnection. |
-
-Some of these are on the roadmap. If a missing feature is blocking your project, [open an issue](https://github.com/livetemplate/livetemplate/issues) — it helps us prioritize.
+When a user clicks a button, LiveTemplate calls a method on your Go struct, diffs the template output, and sends only what changed.
 
 ## Quick Start
 
@@ -198,24 +56,20 @@ Some of these are on the roadmap. If a missing feature is blocking your project,
 go get github.com/livetemplate/livetemplate
 ```
 
-**1. Create your controller and state** ([main.go](https://github.com/livetemplate/examples/blob/main/counter/main.go))
+**1. Define controller and state** ([full example](https://github.com/livetemplate/examples/blob/main/counter/main.go))
 
 ```go
-// State: Pure data, cloned per session
 type CounterState struct {
     Counter int
 }
 
-// Controller: Holds dependencies, singleton
 type CounterController struct{}
 
-// Action "increment" maps to method Increment()
 func (c *CounterController) Increment(state CounterState, ctx *livetemplate.Context) (CounterState, error) {
     state.Counter++
     return state, nil
 }
 
-// Action "decrement" maps to method Decrement()
 func (c *CounterController) Decrement(state CounterState, ctx *livetemplate.Context) (CounterState, error) {
     state.Counter--
     return state, nil
@@ -224,23 +78,25 @@ func (c *CounterController) Decrement(state CounterState, ctx *livetemplate.Cont
 func main() {
     controller := &CounterController{}
     state := &CounterState{Counter: 0}
-    tmpl := livetemplate.New("counter")
+    tmpl := livetemplate.Must(livetemplate.New("counter"))
     http.Handle("/", tmpl.Handle(controller, livetemplate.AsState(state)))
     http.ListenAndServe(":8080", nil)
 }
 ```
 
-**2. Create your template** ([counter.tmpl](https://github.com/livetemplate/examples/blob/main/counter/counter.tmpl))
+`New` auto-discovers `*.tmpl` files in the current directory — `counter.tmpl` is picked up automatically.
+
+**2. Write the template** ([counter.tmpl](https://github.com/livetemplate/examples/blob/main/counter/counter.tmpl))
 
 ```html
-<!-- counter.tmpl -->
 <h1>Counter: {{.Counter}}</h1>
 <form method="POST" style="display:inline">
     <button name="increment">+</button>
     <button name="decrement">-</button>
 </form>
 
-<script src="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/dist/livetemplate-client.browser.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/livetemplate.css">
+<script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/dist/livetemplate-client.browser.js"></script>
 ```
 
 **3. Run it**
@@ -249,105 +105,48 @@ func main() {
 go run main.go  # Open http://localhost:8080
 ```
 
-That's it! Click buttons and watch the counter update automatically.
+## Features
 
-## How It Works
+**Standard HTML first** — Forms, buttons, dialogs, and links work reactively without custom attributes. `lvt-*` attributes are available for behaviors HTML can't express (debounce, keyboard shortcuts, reactive DOM). [Guide →](docs/guides/progressive-complexity.md)
 
-```
-User clicks button → Server updates state → Template re-renders →
-Only changed values sent → Client patches the DOM
-```
+**Safe state management** — Controllers (singleton, hold dependencies) are separated from state (pure data, cloned per session). No accidental data leakage between users. [Reference →](docs/references/controller-pattern.md)
 
-1. Define your **State** as a Go struct (pure data, cloned per session)
-2. Define your **Controller** with dependencies (singleton)
-3. Handle actions as methods on the Controller (action name → method name)
-4. Use standard Go templates (add `lvt-*` attributes only when needed)
-5. LiveTemplate automatically syncs state to UI
+**Efficient updates** — Templates split into static structure (cached) and dynamic values. Updates send only changed values — typically 85%+ bandwidth savings. [Details →](docs/performance/performance-characteristics.md)
 
-State is persisted to SessionStore after every action. Cross-tab sync is automatic when the controller implements a `Sync()` method — the framework dispatches it to peer connections after each action. Use `ctx.BroadcastAction()` for custom cross-connection updates.
+**Idiomatic Go errors** — Actions return `(State, error)`. Validation errors flow to templates automatically. No error serialization code. [Error handling →](docs/references/error-handling.md)
 
-All interactive features — including efficient tree-based diffs — work over plain HTTP. WebSocket is optional, required only for server-initiated broadcasts (e.g., multi-user chat notifications).
-
-## Performance
-
-LiveTemplate is designed for high-performance reactive updates with minimal bandwidth usage.
-
-### Key Metrics
-
-| Operation | Latency | Bandwidth Savings |
-|-----------|---------|-------------------|
-| Initial Render | ~20-65µs | - |
-| Small Update (1-2 fields) | ~18-20µs | 85% vs full render |
-| Large Update (5+ fields) | ~65µs | 65% vs full render |
-| Range Operations | ~30-65µs | 80% vs full render |
-
-*Actual benchmarks from baseline (Go 1.26, Apple M1). See [baseline.txt](testdata/benchmarks/baseline.txt) for complete results.*
-
-### How It Works
-
-1. **First Render:** Full HTML sent; client caches the static parts
-2. **Subsequent Updates:** Only changed values sent (static HTML already cached)
-3. **Result:** 85%+ bandwidth savings, sub-millisecond latency
-
-### Running Benchmarks
-
-```bash
-# Run all benchmarks
-make bench
-
-# Compare against baseline
-make bench-compare
-
-# Generate performance profiles
-make profile-cpu
-make profile-mem
-```
-
-See the full [performance documentation](docs/performance/) for comprehensive analysis.
+**Code generation** — `lvt new myapp && lvt gen resource products name price:float` scaffolds full CRUD apps with reactive UIs. [CLI →](https://github.com/livetemplate/lvt)
 
 ## Learn More
 
-**Core Documentation:**
+**Guides:**
 
-- [Go API Reference](https://pkg.go.dev/github.com/livetemplate/livetemplate) - Server-side API
-- [Progressive Complexity Guide](docs/guides/progressive-complexity.md) - Standard HTML first, `lvt-*` only when needed
-- [Progressive Complexity Reference](docs/references/progressive-complexity-reference.md) - Quick-lookup for HTML → framework behavior
-- [Controller+State Pattern](docs/references/controller-pattern.md) - Core architecture pattern
-- [Client Attributes](docs/references/client-attributes.md) - `lvt-*` event bindings
-- [Error Handling](docs/references/error-handling.md) - Validation and errors
-- [Configuration](docs/references/CONFIGURATION.md) - Template and server options
+- [Standard HTML Reactivity](docs/guides/standard-html-reactivity.md) — How LiveTemplate compares to htmx, Livewire, LiveView
+- [Progressive Complexity](docs/guides/progressive-complexity.md) — Standard HTML → `lvt-*` attributes
+- [Scaling](docs/guides/SCALING.md) — Redis-backed sessions, horizontal scaling
 
-**Feature Guides:**
+**References:**
 
-- [File Uploads](docs/references/uploads.md) - Phoenix LiveView-inspired upload system
-- [Server Actions](docs/references/server-actions.md) - Push updates from server-side code
-- [Session Management](docs/references/session.md) - Session stores and scaling
-- [Horizontal Scaling](docs/guides/SCALING.md) - Redis-backed session stores
-- [Authentication](docs/references/authentication.md) - User identification and custom authenticators
-- [Observability](docs/guides/OBSERVABILITY.md) - Logging and metrics
-
-**Architecture:**
-
-- [Architecture Overview](docs/design/ARCHITECTURE.md) - System design
-- [Performance Characteristics](docs/performance/performance-characteristics.md) - Phase analysis
-- [Benchmarking Guide](docs/performance/benchmarking-guide.md) - How to benchmark
+- [Controller+State Pattern](docs/references/controller-pattern.md) — Core architecture
+- [Client Attributes](docs/references/client-attributes.md) — `lvt-*` reference
+- [Navigate Action](docs/references/navigate.md) — `__navigate__` reserved action invariants
+- [Error Handling](docs/references/error-handling.md) — Validation and errors
+- [Configuration](docs/references/CONFIGURATION.md) — Options and environment variables
+- [Current Limitations](docs/references/current-limitations.md) — Known gaps and workarounds
 
 **Related Projects:**
 
-- [CLI Tool (lvt)](https://github.com/livetemplate/lvt) - Code generator and dev server
-- [Client Library](https://github.com/livetemplate/client) - TypeScript client (npm: `@livetemplate/client`)
-- [Examples](https://github.com/livetemplate/examples) - Counter, Todos, Chat, and more
+- [CLI Tool (lvt)](https://github.com/livetemplate/lvt) — Code generator and dev server
+- [Client Library](https://github.com/livetemplate/client) — TypeScript client (npm: `@livetemplate/client`)
+- [Examples](https://github.com/livetemplate/examples) — Counter, Todos, Chat, and more
+- [Tinkerdown](https://github.com/livetemplate/tinkerdown) — Build data-driven apps from a single markdown file (built on LiveTemplate)
 
 ## Contributing
 
-**New to the codebase?** Start with the [Contributor Walkthrough](docs/guides/new-contributor-walkthrough.md) - a comprehensive guide to the 5-phase architecture with links to code and tests.
+**New to the codebase?** Start with the [Contributor Walkthrough](docs/guides/new-contributor-walkthrough.md).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
-
----
-
-**Built with LiveTemplate?** Share your project in [GitHub Discussions](https://github.com/livetemplate/livetemplate/discussions).
+MIT License — see [LICENSE](LICENSE) file for details.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # LiveTemplate Roadmap
 
-**Current version:** v0.8.17
+**Current version:** v0.8.23
 
 This roadmap shows what's actively being worked on, what's coming next, and what's on the horizon. For known limitations and workarounds, see [Current Limitations](docs/references/current-limitations.md). For detailed feature proposals, see `docs/proposals/`. For completed historical plans, see `docs/archive/implementation-plans/`.
 
@@ -87,6 +87,8 @@ See [docs/roadmap/html-fallback-coverage.md](docs/roadmap/html-fallback-coverage
 
 ## Completed
 
+- **Streaming Range Rendering** — Phases 5-8.5 shipped in v0.8.21–v0.8.23: benchmark gate with measured numbers (#366), recursive transition + LargeTable demo (#368), type-direct hash + parallel build (#369), dead `keyGen` plumbing removed (#370). Proposal: [streaming-range-rendering-proposal.md](docs/proposals/streaming-range-rendering-proposal.md).
+- **Navigate action + flash persistence (PR #344)** — `__navigate__` reserved WS action for same-handler SPA nav; flash messages persist until `ClearFlash` or `FlashExpiry`. Reference: [navigate.md](docs/references/navigate.md).
 - **M1: Production Foundation** — Health checks, connection limits, graceful shutdown, Prometheus metrics, env-based configuration, production examples (28/35 tasks, remaining are docs listed above)
 - **M2: Horizontal Scaling** — Redis session store, distributed pub/sub, client reconnection with exponential backoff and jitter (18/21 tasks, remaining listed above)
 - **Architecture Improvements Phases 1-5** — Stateful structure bug fix (82% payload reduction), server-side ID metadata, unified range operations, type-safe TreeNode, optimized fingerprinting

--- a/assets/demo.svg
+++ b/assets/demo.svg
@@ -238,8 +238,8 @@
   <!-- Template code in browser (always visible) -->
   <text style="fill: #484f58; font-family: ui-monospace, monospace; font-size: 9.5px;" x="44" y="168">// counter.tmpl</text>
   <text style="fill: #8b949e; font-family: ui-monospace, monospace; font-size: 9.5px;" x="44" y="182">&lt;h1&gt;Counter: <tspan fill="#58a6ff">{{.Counter}}</tspan>&lt;/h1&gt;</text>
-  <text style="fill: #8b949e; font-family: ui-monospace, monospace; font-size: 9.5px;" x="44" y="196">&lt;button <tspan fill="#d2a8ff">lvt-click="increment"</tspan>&gt;+&lt;/button&gt;</text>
-  <text style="fill: #8b949e; font-family: ui-monospace, monospace; font-size: 9.5px;" x="44" y="210">&lt;button <tspan fill="#d2a8ff">lvt-click="decrement"</tspan>&gt;−&lt;/button&gt;</text>
+  <text style="fill: #8b949e; font-family: ui-monospace, monospace; font-size: 9.5px;" x="44" y="196">&lt;button <tspan fill="#d2a8ff">name="increment"</tspan>&gt;+&lt;/button&gt;</text>
+  <text style="fill: #8b949e; font-family: ui-monospace, monospace; font-size: 9.5px;" x="44" y="210">&lt;button <tspan fill="#d2a8ff">name="decrement"</tspan>&gt;−&lt;/button&gt;</text>
 
   <!-- ==================== SERVER (right) ==================== -->
   <rect class="server-box" x="410" y="20" width="280" height="200" />
@@ -289,7 +289,7 @@
       <tspan class="payload-dim">: [</tspan>
       <tspan class="payload-static">"&lt;h1&gt;Counter: "</tspan>
       <tspan class="payload-dim">, </tspan>
-      <tspan class="payload-static">"&lt;/h1&gt;&lt;button lvt-click=..."</tspan>
+      <tspan class="payload-static">"&lt;/h1&gt;&lt;button name=..."</tspan>
       <tspan class="payload-dim">], </tspan>
       <tspan class="payload-key">"0"</tspan>
       <tspan class="payload-dim">: </tspan>

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Complete API references, configuration, and specifications:
 - **[Error Handling](references/error-handling.md)** - Validation errors, field errors, and error display
 - **[Authentication](references/authentication.md)** - Authentication system and custom authenticators
 - **[Server Actions](references/server-actions.md)** - Server-initiated actions (TriggerAction API)
+- **[Navigate Action](references/navigate.md)** - `__navigate__` reserved action invariants and Mount semantics
 - **[Session Management](references/session.md)** - State safety, session stores, and connection management
 - **[PubSub](references/pubsub.md)** - Distributed broadcasting, Redis channel schema, subscription lifecycle
 - **[Template Support Matrix](references/template-support-matrix.md)** - Supported Go template features
@@ -30,6 +31,7 @@ Complete API references, configuration, and specifications:
 
 Step-by-step guides and tutorials:
 
+- **[Standard HTML Reactivity](guides/standard-html-reactivity.md)** - Why standard HTML is LiveTemplate's key differentiator vs htmx, Livewire, LiveView
 - **[Progressive Complexity Guide](guides/progressive-complexity.md)** - Standard HTML first, `lvt-*` only when needed
 - **[Ephemeral Components Guide](guides/ephemeral-components.md)** - Client-side toasts, banners, alerts
 - **[New Contributor Walkthrough](guides/new-contributor-walkthrough.md)** - 5-phase architecture walkthrough

--- a/docs/guides/standard-html-reactivity.md
+++ b/docs/guides/standard-html-reactivity.md
@@ -1,0 +1,182 @@
+# Standard HTML Reactivity
+
+LiveTemplate makes standard HTML reactive by default. A plain `<form method="POST">` with `<button name="add">` is interactive at every transport level — no framework-specific attributes required. This guide explains how it works, how it compares to other frameworks, and the tradeoffs involved.
+
+> **Recent reinforcement:** As of client v0.8.38, the TypeScript client and the generated templates went through a deliberate "attribute reduction" pass that removed `lvt-*` attributes from anything HTML can already express. Tier 1 standard HTML is now the default everywhere; Tier 2 attributes are reserved for behaviors HTML genuinely cannot express (timing, keyboard shortcuts, reactive DOM).
+
+---
+
+## Why Standard HTML?
+
+Every interactive feature in a traditional web app requires the same ceremony: design a REST endpoint, write a serializer, manage client-side state, update the DOM, and wire it all together. That overhead discourages interactivity — teams leave things static not because they should be, but because the plumbing isn't worth it. As Chris McCord [put it](https://fly.io/blog/how-we-got-to-liveview/) when explaining why he built Phoenix LiveView: conventional frameworks make you "fetch the world, munge it into some format, and shoot it over the wire... then throw all that state away" on every request.
+
+LiveView's answer was to keep all state on the server and push rendered updates over a persistent connection. LiveTemplate brings that approach to Go, with one major difference: it works equally well over standard HTTP. And it goes a step further — the HTML itself needs no framework-specific attributes for core interactions.
+
+## How It Works
+
+### Button Name = Action Routing
+
+The `name` attribute on a button routes to a Go method:
+
+```html
+<button name="add">Add</button>       <!-- routes to Add() -->
+<button name="delete">Delete</button>  <!-- routes to Delete() -->
+```
+
+This uses standard HTML semantics — the button `name` is included in form data on submit. LiveTemplate reads it and dispatches to the matching method. No custom attributes needed.
+
+### Form Auto-Interception
+
+All `<form>` elements inside a LiveTemplate handler are automatically intercepted:
+
+- **Without JavaScript**: The form submits as a standard POST. The server uses Post-Redirect-Get (PRG) — redirects on success, re-renders with errors on validation failure.
+- **With JavaScript (fetch)**: The JS client intercepts the submit, sends via `fetch()`, and patches the DOM with the response. No page reload.
+- **With JavaScript (WebSocket)**: Actions are sent over the WebSocket connection for real-time updates.
+
+The same HTML works identically across all three modes.
+
+### Validation
+
+For production form validation, use `ctx.BindAndValidate()` with Go struct tags:
+
+```go
+// validate is a *validator.Validate from github.com/go-playground/validator/v10,
+// typically initialized once and stored on the controller.
+var input struct {
+    Email string `validate:"required,email,min=5"`
+}
+if err := ctx.BindAndValidate(&input, c.validate); err != nil {
+    return state, err // field errors sent to template automatically
+}
+```
+
+For HTML-attribute-based validation (`required`, `pattern`, `min`, `max`), see the [Error Handling reference](../references/error-handling.md) for the `ValidateForm` + `WithFormSchema` pattern.
+
+---
+
+## Multi-User Broadcast
+
+When one user's action should be visible to other WebSocket-connected tabs, use `BroadcastAction`. Note: `BroadcastAction` must be called AFTER all state mutations and `ctx.With*()` calls, because `With*()` creates shallow copies and broadcasts queued before the copy won't propagate.
+
+```go
+func (c *TodoController) Add(state TodoState, ctx *livetemplate.Context) (TodoState, error) {
+    state.Items = append(state.Items, Todo{Title: ctx.GetString("title")})
+    // BroadcastAction after all state changes — pushes to other WS-connected tabs
+    ctx.BroadcastAction("Refresh", nil)
+    return state, nil
+}
+
+func (c *TodoController) Refresh(state TodoState, ctx *livetemplate.Context) (TodoState, error) {
+    state.Items = c.loadItems()
+    return state, nil
+}
+```
+
+Broadcast is scoped to the session group. For multi-instance deployments, add Redis pub/sub:
+
+```go
+tmpl, _ := livetemplate.New("app",
+    livetemplate.WithPubSubBroadcaster(redisBroadcaster),
+)
+```
+
+See [PubSub Reference](../references/pubsub.md) for details.
+
+---
+
+## Comparison with Other Frameworks
+
+Every major reactive framework requires custom attributes on HTML elements. LiveTemplate is unique in making standard HTML reactive without modification.
+
+| Framework | Form markup required | Custom attributes |
+|-----------|---------------------|-------------------|
+| **htmx** | `<form hx-post="/todos" hx-target="#list">` | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
+| **Laravel Livewire** | `<form wire:submit="add">` | `wire:submit`, `wire:model`, `wire:click` |
+| **Phoenix LiveView** | `<form phx-submit="add">` | `phx-submit`, `phx-click`, `phx-change` |
+| **LiveTemplate** | `<form method="POST">` | None for standard interactions |
+
+### htmx
+
+htmx extends HTML with `hx-*` attributes for AJAX interactions. A form without `hx-post` submits normally (full page reload). Every interactive element needs explicit `hx-*` attributes.
+
+### Laravel Livewire
+
+Livewire uses `wire:*` directives in PHP/Blade templates. `wire:submit` captures form submissions, `wire:model` enables two-way binding. State is serialized into HTML attributes.
+
+### Phoenix LiveView
+
+LiveView uses `phx-*` attributes and requires a persistent WebSocket connection. Forms need `phx-submit` to route actions. The initial page renders as static HTML, then upgrades to WebSocket.
+
+### LiveTemplate
+
+Standard HTML forms work reactively without any framework attributes. The button `name` routes to a Go method, form data is available via `ctx.GetString()`, and the response is a minimal tree diff. WebSocket is optional — only needed for server-initiated broadcasts.
+
+---
+
+## Feature Gap vs Phoenix LiveView
+
+LiveTemplate is inspired by Phoenix LiveView but does not yet cover its full feature set. Tracked gaps as of v0.8.23:
+
+| Feature | LiveView | LiveTemplate | Notes |
+|---------|----------|-------------|-------|
+| **Live Navigation** | `push_navigate`, `push_patch` | Partial — `__navigate__` action covers same-handler query-string navigation (no reconnect). Different-handler nav still falls back to fetch or full page load. | See [Navigate Action](../references/navigate.md). |
+| **Stateful Components** | `LiveComponent` with own lifecycle | Stateless templates only | `{{template}}` invocations work but have no component-level state or event handling. |
+| **Streams** | `stream/3` for large lists | Not yet | LiveView streams handle large/infinite lists without keeping all items in server memory. Streaming-range rendering (PRs #366/#368/#369/#370) is the latest step toward this. |
+| **JS Commands** | `JS.push`, `JS.toggle`, `JS.show` | Partial | [`lvt-*` reactive attributes](../references/client-attributes.md) cover common cases (disable, add/remove class, set attribute) but aren't as composable as LiveView's server-defined JS chains. |
+| **Client Hooks** | `phx-hook` lifecycle callbacks | Proposed | [`lvt-hook` proposal](../proposals/lifecycle-hooks-proposal.md) covers third-party JS library integration; not yet shipped. |
+| **Presence** | `Phoenix.Presence` | Not built-in | Can be built on LiveTemplate's session stores; requires manual implementation. |
+| **Testing Helpers** | `live/2`, `render_click/3` | Minimal | `AssertPureState` exists; no view-level test DSL. Browser tests use chromedp. |
+| **Form Recovery** | Automatic on reconnect | Partial — `lvt-form:preserve` retains specific fields across re-renders | Full automatic recovery on WS reconnection is not yet built in. |
+
+For day-to-day workarounds, see [Current Limitations](../references/current-limitations.md).
+
+---
+
+## Progressive Complexity
+
+LiveTemplate follows a two-tier model:
+
+| Tier | What you write | When to use |
+|------|---------------|-------------|
+| **Tier 1: Standard HTML** | `<form>`, `<button name="add">`, `<dialog>`, `<a href>` | Forms, actions, modals, navigation |
+| **Tier 2: `lvt-*` attributes** | `lvt-on:`, `lvt-mod:debounce`, `lvt-el:`, `lvt-fx:` | Timing, keyboard shortcuts, reactive DOM |
+
+Tier 2 is only for behaviors standard HTML cannot express. For example, debounced search requires `lvt-mod:debounce` because HTML has no timing mechanism:
+
+```html
+<input name="Query" value="{{.Query}}"
+    lvt-on:input="search" lvt-mod:debounce="300"
+    placeholder="Search...">
+```
+
+See the [Progressive Complexity Guide](progressive-complexity.md) for the complete walkthrough.
+
+---
+
+## Tradeoffs
+
+| Approach | Philosophy | Clarity | Flexibility |
+|----------|-----------|---------|-------------|
+| **Custom attributes** (htmx, Livewire, LiveView) | Explicit is better than implicit | High — clear what's reactive | High — opt-in reactivity |
+| **Standard HTML** (LiveTemplate) | Make the common case simple | Lower — everything is reactive | Lower — opt-out via `lvt-form:no-intercept` / `lvt-nav:no-intercept` |
+
+**Advantages of LiveTemplate's approach:**
+- Standard HTML works at all transport levels (no-JS, fetch, WebSocket)
+- No framework vocabulary to learn for common interactions
+- Progressive enhancement works out of the box
+- Less markup to write
+
+**Disadvantages:**
+- Less visual distinction between reactive and static elements
+- Harder to tell at a glance which elements trigger server actions
+- Action routing via button `name` is less explicit than URL-based routing
+
+---
+
+## See Also
+
+- [Progressive Complexity Guide](progressive-complexity.md) — Full walkthrough from standard HTML to `lvt-*` attributes
+- [Progressive Complexity Reference](../references/progressive-complexity-reference.md) — Quick-lookup table
+- [Controller+State Pattern](../references/controller-pattern.md) — Core architecture pattern
+- [Client Attributes](../references/client-attributes.md) — Complete `lvt-*` reference
+- [Examples](https://github.com/livetemplate/examples) — Counter, Todos, Chat, and more

--- a/docs/performance/performance-characteristics.md
+++ b/docs/performance/performance-characteristics.md
@@ -1,5 +1,36 @@
 # LiveTemplate Performance Characteristics
 
+## Summary
+
+| Operation | Latency | Bandwidth Savings |
+|-----------|---------|-------------------|
+| Initial Render | ~20-65µs | — |
+| Small Update (1-2 fields) | ~18-20µs | 85% vs full render |
+| Large Update (5+ fields) | ~65µs | 65% vs full render |
+| Range Operations | ~30-65µs | 80% vs full render |
+
+Numbers from baseline (Go 1.26, Apple M1/M2). Full results in [`testdata/benchmarks/baseline.txt`](../../testdata/benchmarks/baseline.txt).
+
+**How updates stay small:** The first render ships full HTML and the client caches the static parts. Subsequent renders ship only the changed dynamic values — the statics never travel again until the template structure itself changes (detected by an FNV-1a fingerprint).
+
+### Running Benchmarks
+
+```bash
+# Run all benchmarks
+make bench
+
+# Compare against baseline
+make bench-compare
+
+# Generate performance profiles
+make profile-cpu
+make profile-mem
+```
+
+For statistically confident timing comparisons, use `make bench-10x` with `benchstat` — single-run timings can swing 2-4x due to thermal and GC noise.
+
+---
+
 > **Benchmark Environment:** Go 1.26.0, arm64 (Apple M2). Numbers updated 2026-03-22.
 > These are single-run results (`make bench-save`); ns/op timings can vary significantly
 > between runs (2-4x swings observed) due to system load, thermal throttling, and GC timing.

--- a/docs/references/navigate.md
+++ b/docs/references/navigate.md
@@ -1,0 +1,110 @@
+# Navigate Action Reference
+
+The `__navigate__` action is a reserved WebSocket-only message that re-runs `Mount` with new query parameters on the **same** WebSocket connection — no reconnect, no full-page reload. It powers in-handler SPA-style navigation (search filters, tab switches, faceted browse) without giving up the LiveTemplate session, the cached statics, or the open WS pipe.
+
+This page is the invariant catalogue (issue #349). It documents what `__navigate__` does, when the client emits it, and the rules a controller must satisfy to behave correctly under it.
+
+---
+
+## What `__navigate__` Does
+
+When the server receives `{action: "__navigate__", data: {<query params>}}` over a session's WebSocket:
+
+1. The event loop bypasses `DispatchWithState` (the normal action router).
+2. It treats `msg.Data` as the new query string and re-invokes `Mount` with that data.
+3. The render that follows is a tree **update**, not a full render — the client already has statics cached, so only the changed dynamic slots travel over the wire.
+4. Flash messages set with `SetFlash` survive the navigate by default; only `ClearFlash(key)` or `ClearAllFlash()` removes them. (See "Flash interaction" below.)
+
+The reserved constant lives at `livetemplate/action.go` — grep `actionNavigate = "__navigate__"`. There is **no controller method named `__navigate__`**, and adding one is not how you customize navigation behavior. Mount is the customization point.
+
+---
+
+## When the Client Emits It
+
+The TypeScript client emits `__navigate__` from `client/dom/link-interceptor.ts`. The cases:
+
+| Trigger | Condition | What gets sent |
+|---|---|---|
+| `<a href>` click | Same pathname, only query string differs | `{action: "__navigate__", data: <new query params>}` over the open WS |
+| `popstate` (back/forward) | Same pathname as before, only query string changed | Same as above |
+| Different pathname | New path | Falls back to a fetch-based navigation (or full page load if WS is HTTP-only) |
+| External link, `target="_blank"`, `download`, or `lvt-nav:no-intercept` | Any | Not intercepted — browser handles the link normally |
+
+The popstate path matters: when a user hits Back, the browser updates `window.location` first and then fires the event. The link interceptor stores the previous URL on each push so the popstate handler can compare against the right "before" URL.
+
+If the WebSocket is not OPEN, the client falls through to fetch-based navigation. `__navigate__` is strictly the fast path; the slow path stays correct.
+
+---
+
+## What the Controller Must Do
+
+### Mount must be safe to re-run
+
+Mount runs on every HTTP request, every WS connect, AND every `__navigate__`. Crucially, **inside Mount, a `__navigate__` re-run is indistinguishable from a connect-time Mount** — the dispatch loop deliberately rebinds `ctx.Action()` to `""` for navigate so handlers don't have to special-case it. (Grep `mount.go` for `WithAction("") // ctx.Action()=="" matches connect-time Mount`.)
+
+That means the standard `if ctx.Action() == "" { ... }` guard from the controller-pattern docs filters out form POSTs but does **not** filter out navigate re-mounts. If you have side effects that must fire exactly once per session (analytics page-view, audit log, expensive bootstrap), gate them on per-session state, not on `ctx.Action()`:
+
+```go
+func (c *Controller) Mount(state State, ctx *livetemplate.Context) (State, error) {
+    if ctx.Action() == "" && !state.PageViewTracked {
+        c.analytics.TrackPageView(ctx.UserID())
+        state.PageViewTracked = true
+    }
+    state.Filter = ctx.GetString("filter")
+    return state, nil
+}
+```
+
+State persists across navigate re-mounts within the same session, so the `PageViewTracked` flag survives. This pattern is the recommended workaround until a first-class "is this the initial mount" signal lands; see issue [#346](https://github.com/livetemplate/livetemplate/issues/346) for the related discussion on `BroadcastAction` semantics inside navigate Mount.
+
+### Read query params from `ctx`
+
+Inside Mount, `ctx.GetString("filter")` and friends return whatever was in `msg.Data` for a `__navigate__`, or the URL query for the initial GET. Same call site, same data shape — your Mount code does not need to branch on "am I initial vs. navigate."
+
+### Don't touch the URL yourself
+
+The client owns `pushState`. Mount must not redirect or rewrite paths in response to a `__navigate__` — doing so will desynchronize the browser URL from the server-side state. If you need to deny a navigation, return an error from Mount; the client surfaces it without committing the URL change.
+
+---
+
+## Flash Interaction
+
+PR #344 paired `__navigate__` with a "persist-until-cleared" flash lifecycle. The rules:
+
+- `ctx.SetFlash(key, msg)` — flash persists across renders, including across `__navigate__` re-mounts, until explicitly cleared.
+- `ctx.SetFlash(key, msg, livetemplate.FlashExpiry(5*time.Second))` — flash auto-expires after the duration even if not cleared.
+- `ctx.ClearFlash(key)` — removes a single keyed flash.
+- A bulk `ClearAllFlash()` API is proposed in [issue #345](https://github.com/livetemplate/livetemplate/issues/345) but has not landed — until then, clear keys individually.
+
+The "cleared after one render" semantics from older versions are gone. If you want one-shot flash-after-action, call `ClearFlash` at the top of the handler that consumes it (typically in Mount when the relevant query param disappears).
+
+---
+
+## What Travels Over the Wire
+
+Because the client has the statics cached from the initial render, a `__navigate__` response is a tree **update** — only the changed dynamic slots ship. The shape is identical to any other action's update payload. No special framing, no per-page bundle.
+
+For a counter-template-sized handler (two slots: `Selected`, `MountCount`), the navigate update is on the order of 10-20 bytes. For a search-results handler (item list), it's roughly the bytes of the item list, with the surrounding chrome (header, filter UI, footer) shipped only once at first connect.
+
+---
+
+## Verification
+
+The load-bearing test is `TestNavigateActionReMountsWithNewQueryData` in `navigate_test.go`. It:
+
+1. Connects a WebSocket with `?s=alpha`.
+2. Confirms the rendered tree shows `state.Selected == "alpha"` and `MountCount == 1`.
+3. Sends `{action: "__navigate__", data: {s: "beta"}}` over the same WS.
+4. Confirms the next render flips `Selected` to `"beta"` and bumps `MountCount` to `2` — proving Mount re-ran without any reconnect.
+
+Browser-level chromedp tests live in the lvt repo at `e2e/livetemplate_core_test.go` per the [test strategy](../../CLAUDE.md). Both layers must stay green.
+
+---
+
+## See Also
+
+- [Controller+State Pattern](controller-pattern.md) — Mount-time conventions
+- [Client Attributes](client-attributes.md) — `lvt-nav:no-intercept` opt-out
+- [Standard HTML Reactivity](../guides/standard-html-reactivity.md) — Why navigation is a Tier 1 concern
+- [PR #344](https://github.com/livetemplate/livetemplate/pull/344) — Original implementation
+- Follow-up issues: [#345](https://github.com/livetemplate/livetemplate/issues/345) (`ClearAllFlash`), [#346](https://github.com/livetemplate/livetemplate/issues/346) (`BroadcastAction` inside Mount on navigate), [#347](https://github.com/livetemplate/livetemplate/issues/347), [#348](https://github.com/livetemplate/livetemplate/issues/348)


### PR DESCRIPTION
## Summary

- Rewrites the README per the [proposal](https://github.com/livetemplate/livetemplate/blob/main/docs/proposals/readme-rewrite-proposal.md) (issue #268), updated to reflect state through v0.8.23. README goes from 353 → 152 lines; lead with the demo SVG and a plain HTML form / Go method hero; CDN pinned to `@latest` (matches the examples repo).
- Adds **`docs/guides/standard-html-reactivity.md`** — the new standard-HTML pitch + framework comparisons + Phoenix LiveView feature-gap table updated for `__navigate__`, `lvt-form:preserve`, streaming-range, and the `lvt-hook` proposal. Includes a sidebar noting the client v0.8.38 attribute-reduction release that strengthens the Tier 1 thesis.
- Adds **`docs/references/navigate.md`** — closes #349 (PR #344 follow-up). Documents that `mount.go` rebinds `ctx.Action()` to `""` for navigate, so controllers cannot distinguish initial Mount from navigate re-Mount; recommends gating one-shot side effects on per-session state instead.
- **`assets/demo.svg`**: `lvt-click="..."` → `name="..."` so the hero visual matches the standard-HTML pitch (3 text edits, no layout change).
- **`ROADMAP.md`**: bumps to v0.8.23, marks streaming range (#366/#368/#369/#370) and PR #344 as shipped.
- **`docs/performance/performance-characteristics.md`**: adds Summary block at top with the metrics table and `make bench` commands moved out of the README.
- **`docs/README.md`**: surfaces both new docs.

## Test plan

- [x] All 30+ internal markdown links resolve (verified via perl link-sweep)
- [x] `go test ./... -timeout=300s` passes (matches `scripts/pre-commit.sh` budget)
- [x] `examples/counter` chromedp E2E suite passes (TestCounterE2E, TestWebSocketBasic)
- [x] README quick-start code compiles against this branch
- [x] `https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/livetemplate.css` returns 200
- [x] `https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/dist/livetemplate-client.browser.js` returns 200
- [x] Manual UX test on iPhone over Tailscale (signoff received before push)

## Companion PR

- examples: [chore/readme-cdn-align](https://github.com/livetemplate/examples/tree/chore/readme-cdn-align) — aligns the examples README CDN string to `@latest` to match this README

🤖 Generated with [Claude Code](https://claude.com/claude-code)