### PR TITLE
chore: Phase 1A cleanup — extract button-name helper, migrate goldens (#327, #323)

### DIFF
--- a/internal/send/message.go
+++ b/internal/send/message.go
@@ -50,6 +50,31 @@ func ParseActionFromHTTP(r *http.Request) (ActionMessage, error) {
 	return msg, nil
 }
 
+// detectSubmitButtonName scans form values for a single field with one empty
+// string value and returns its name. This is how a standard HTML submit button
+// with name="X" surfaces (the browser sends "X=" with no value). Returns "" if
+// zero or multiple such candidates exist (ambiguous).
+//
+// "action" is excluded because it's a common HTML form attribute (<form
+// action="/path">) that browsers don't submit; an empty action= field on the
+// wire would be ambiguous between "name='action' button" and accidental data.
+// Names already in actionFields (e.g. "lvt-action", "data") are also skipped.
+func detectSubmitButtonName(values map[string][]string, actionFields map[string]bool) string {
+	var candidate string
+	for key, vs := range values {
+		if key == "" || key == "action" || actionFields[key] {
+			continue
+		}
+		if len(vs) == 1 && vs[0] == "" {
+			if candidate != "" {
+				return ""
+			}
+			candidate = key
+		}
+	}
+	return candidate
+}
+
 // parseMultipartForm parses action from multipart/form-data (file uploads).
 // Supports two data formats:
 //  1. JSON-encoded "data" form field (client library sends this)
@@ -87,27 +112,10 @@ func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 	if !jsonDataParsed {
 		actionFields := map[string]bool{"lvt-action": true, "data": true}
 
-		// Button-name-as-action detection (same logic as parseURLEncodedForm)
 		if msg.Action == "" && r.MultipartForm != nil {
-			var candidate string
-			ambiguous := false
-			for key, values := range r.MultipartForm.Value {
-				// Skip "action" — it's a common HTML attribute (<form action="/path">)
-				// that browsers don't submit, but could cause false-positive routing.
-				if key == "" || key == "action" || actionFields[key] {
-					continue
-				}
-				if len(values) == 1 && values[0] == "" {
-					if candidate != "" {
-						ambiguous = true
-						break
-					}
-					candidate = key
-				}
-			}
-			if candidate != "" && !ambiguous {
-				msg.Action = candidate
-				actionFields[candidate] = true
+			if name := detectSubmitButtonName(r.MultipartForm.Value, actionFields); name != "" {
+				msg.Action = name
+				actionFields[name] = true
 			}
 		}
 
@@ -158,31 +166,10 @@ func parseURLEncodedForm(r *http.Request) (ActionMessage, error) {
 	// Action routing fields to exclude from data
 	actionFields := map[string]bool{"lvt-action": true}
 
-	// If no explicit action, detect button-name-as-action:
-	// A submit button with name="X" and no value submits "X=" in form data.
-	// We detect this as the unique single-value field with an empty string.
-	// If multiple empty-value fields exist, we skip (ambiguous — can't determine which button).
-	// Note: "action" is explicitly excluded from this scan. While it's a normal
-	// data field, an empty action= would be ambiguous with the common HTML pattern
-	// <form action="/path"> which browsers don't submit, but could confuse routing.
 	if msg.Action == "" {
-		var candidate string
-		ambiguous := false
-		for key, values := range r.Form {
-			if key == "" || key == "action" || actionFields[key] {
-				continue
-			}
-			if len(values) == 1 && values[0] == "" {
-				if candidate != "" {
-					ambiguous = true
-					break
-				}
-				candidate = key
-			}
-		}
-		if candidate != "" && !ambiguous {
-			msg.Action = candidate
-			actionFields[candidate] = true
+		if name := detectSubmitButtonName(r.Form, actionFields); name != "" {
+			msg.Action = name
+			actionFields[name] = true
 		}
 	}
 

--- a/testdata/golden/resource_template.tmpl.golden
+++ b/testdata/golden/resource_template.tmpl.golden
@@ -70,7 +70,7 @@
       {{end}}
     </div>
     <div class="mb-4">
-      <button class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50" style="margin-right: 8px; padding: 0.5rem 1rem; font-size: 1rem; min-width: 100px;" type="submit" lvt-disable-with="Adding...">Add Post</button>
+      <button class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50" style="margin-right: 8px; padding: 0.5rem 1rem; font-size: 1rem; min-width: 100px;" type="submit" lvt-form:disable-with="Adding...">Add Post</button>
       <button class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50" style="padding: 0.5rem 1rem; font-size: 1rem; min-width: 100px;" type="button" lvt-modal-close="add-modal">Cancel</button>
     </div>
   </form>
@@ -107,7 +107,7 @@
       {{end}}
     </div>
     <div class="mb-4" style="display: flex; gap: 8px; margin-top: 1.5rem;">
-      <button class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50" type="submit" lvt-disable-with="Updating...">Save</button>
+      <button class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50" type="submit" lvt-form:disable-with="Updating...">Save</button>
       <a href="/post/{{.EditingID}}" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50" style="text-decoration: none; display: inline-flex; align-items: center; justify-content: center;">Cancel</a>
       <button class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50" type="button" lvt-click="delete" lvt-data-id="{{.EditingID}}" lvt-confirm="Are you sure you want to delete this post?" style="margin-left: auto;">Delete</button>
     </div>


### PR DESCRIPTION
## Summary

Two small Phase 1A follow-ups bundled into one PR:

- **#327** — Extract `detectSubmitButtonName()` helper to deduplicate the byte-identical button-name-as-action detection blocks in `parseMultipartForm` and `parseURLEncodedForm` (`internal/send/message.go`). The duplication was introduced as a copy-paste in PR #326. No behavior change.
- **#323** — Migrate the two `lvt-disable-with` occurrences in `testdata/golden/resource_template.tmpl.golden` to `lvt-form:disable-with` per Phase 1A. Other old-form `lvt-*` attributes in this fixture (`lvt-modal-close`, `lvt-submit`, `lvt-click`, `lvt-confirm`) are out of scope for Phase 1A and tracked separately.

## Test plan

- [x] `go test ./internal/send/...` passes (covers `TestParseActionFromHTTP_*` button-name cases including ambiguity)
- [x] `go test -race ./internal/send/...` passes
- [x] `go test ./...` (full suite, ~135s) passes
- [x] `golangci-lint run --enable-only=errcheck,govet,ineffassign,staticcheck,unparam,unused` — 0 issues
- [x] `go vet ./...` clean
- [x] `TestRangeDynamicDoesNotAppendContent` (uses the migrated golden) passes

Closes #323. Closes #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)