### PR TITLE
refactor: remove deprecated generateTreeInternalWithErrors wrapper (#373)

### DIFF
--- a/e2e_update_spec_test.go
+++ b/e2e_update_spec_test.go
@@ -642,7 +642,7 @@ func TestUserJourney_TodoApp(t *testing.T) {
 	// Execute journey steps
 	for _, step := range steps {
 		t.Run(step.name, func(t *testing.T) {
-			tree, err := tmpl.generateTreeInternalWithErrors(step.state)
+			tree, err := tmpl.buildTree(step.state, nil)
 			if err != nil {
 				t.Fatalf("Failed to generate tree: %v", err)
 			}
@@ -824,7 +824,7 @@ func BenchmarkSpecificationCompliance(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		data := struct{ Count int }{Count: i}
-		_, _ = tmpl.generateTreeInternalWithErrors(data)
+		_, _ = tmpl.buildTree(data, nil)
 	}
 }
 

--- a/template.go
+++ b/template.go
@@ -1288,13 +1288,6 @@ func (t *Template) ExecuteUpdates(wr io.Writer, data interface{}, messages ...ma
 // Internal Helper Methods (Phase 2: Build)
 // =============================================================================
 
-// generateTreeInternalWithErrors delegates to buildTree() for backward compatibility.
-// DEPRECATED: Tests should use buildTree() directly. This wrapper exists only for
-// existing test code and will be removed in a future version.
-func (t *Template) generateTreeInternalWithErrors(data interface{}) (*treeNode, error) {
-	return t.buildTree(data, nil)
-}
-
 // getOrComputeBodyContent returns the cached body content from t.templateStr (the template
 // source with {{}} action syntax), NOT from rendered HTML. The parser needs template actions
 // to identify dynamic slots, so this intentionally uses the source text.

--- a/template_test.go
+++ b/template_test.go
@@ -2110,7 +2110,7 @@ func TestTemplateGenerateTreeWithFuncMap(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	// After Execute(), check the cached lastTree instead of calling generateTreeInternalWithErrors
+	// After Execute(), check the cached lastTree instead of calling buildTree
 	// (calling it again with same data would generate an empty diff)
 	if tmpl.lastTree == nil {
 		t.Fatalf("expected last tree to be cached")
@@ -2266,9 +2266,9 @@ func TestTemplateGenerateInitialTreeFallsBackForBlockWithDynamicTemplate(t *test
 		t.Fatalf("expected AST parser to error for block with dynamic template invocation")
 	}
 
-	tree, err := tmpl.generateTreeInternalWithErrors(data)
+	tree, err := tmpl.buildTree(data, nil)
 	if err != nil {
-		t.Fatalf("generateTreeInternalWithErrors failed: %v", err)
+		t.Fatalf("buildTree failed: %v", err)
 	}
 
 	if tree == nil {
@@ -2308,9 +2308,9 @@ func TestTemplateGenerateInitialTreeFallsBackForChannelRange(t *testing.T) {
 		t.Fatalf("expected AST parser to error for channel range")
 	}
 
-	tree, err := tmpl.generateTreeInternalWithErrors(data)
+	tree, err := tmpl.buildTree(data, nil)
 	if err != nil {
-		t.Fatalf("generateTreeInternalWithErrors failed: %v", err)
+		t.Fatalf("buildTree failed: %v", err)
 	}
 
 	if tree == nil {
@@ -2350,9 +2350,9 @@ func TestTemplateGenerateInitialTreeFallsBackForChannelRangeWithDecls(t *testing
 		t.Fatalf("expected AST parser to error for channel range with declarations")
 	}
 
-	tree, err := tmpl.generateTreeInternalWithErrors(data)
+	tree, err := tmpl.buildTree(data, nil)
 	if err != nil {
-		t.Fatalf("generateTreeInternalWithErrors failed: %v", err)
+		t.Fatalf("buildTree failed: %v", err)
 	}
 
 	if tree == nil {
@@ -2386,9 +2386,9 @@ func TestTemplateGenerateInitialTreeFallsBackForIntegerRange(t *testing.T) {
 		t.Fatalf("expected AST parser to error for integer range")
 	}
 
-	tree, err := tmpl.generateTreeInternalWithErrors(nil)
+	tree, err := tmpl.buildTree(nil, nil)
 	if err != nil {
-		t.Fatalf("generateTreeInternalWithErrors failed: %v", err)
+		t.Fatalf("buildTree failed: %v", err)
 	}
 
 	if tree == nil {
@@ -2463,9 +2463,9 @@ func TestTemplateGenerateInitialTreeFallsBackForRangeBreak(t *testing.T) {
 		t.Fatalf("expected AST parser to error for range with break")
 	}
 
-	tree, err := tmpl.generateTreeInternalWithErrors(data)
+	tree, err := tmpl.buildTree(data, nil)
 	if err != nil {
-		t.Fatalf("generateTreeInternalWithErrors failed: %v", err)
+		t.Fatalf("buildTree failed: %v", err)
 	}
 
 	if tree == nil {
@@ -2501,9 +2501,9 @@ func TestTemplateGenerateInitialTreeFallsBackForRangeContinue(t *testing.T) {
 		t.Fatalf("expected AST parser to error for range with continue")
 	}
 
-	tree, err := tmpl.generateTreeInternalWithErrors(data)
+	tree, err := tmpl.buildTree(data, nil)
 	if err != nil {
-		t.Fatalf("generateTreeInternalWithErrors failed: %v", err)
+		t.Fatalf("buildTree failed: %v", err)
 	}
 
 	if tree == nil {
@@ -2550,9 +2550,9 @@ func TestTemplateGenerateInitialTreeFallsBackForDynamicTemplateInvocation(t *tes
 		t.Fatalf("expected AST parser to error for dynamic template invocation")
 	}
 
-	tree, err := tmpl.generateTreeInternalWithErrors(data)
+	tree, err := tmpl.buildTree(data, nil)
 	if err != nil {
-		t.Fatalf("generateTreeInternalWithErrors failed: %v", err)
+		t.Fatalf("buildTree failed: %v", err)
 	}
 
 	if tree == nil {
@@ -2599,9 +2599,9 @@ func TestTemplateGenerateInitialTreeFallsBackForWithIterSeq(t *testing.T) {
 		t.Fatalf("expected AST parser to error for with pipeline returning iter.Seq")
 	}
 
-	tree, err := tmpl.generateTreeInternalWithErrors(nil)
+	tree, err := tmpl.buildTree(nil, nil)
 	if err != nil {
-		t.Fatalf("generateTreeInternalWithErrors failed: %v", err)
+		t.Fatalf("buildTree failed: %v", err)
 	}
 
 	if tree == nil {


### PR DESCRIPTION
## Summary

Closes the deprecation that never landed: `generateTreeInternalWithErrors` at `template.go:1291-1296` was marked `DEPRECATED` with a comment saying "will be removed in a future version" — but it stayed for ~11 test callsites that never migrated. The wrapper was a thin pass-through to `buildTree(data, nil)`, so the migration is mechanical.

## Changes

- Remove the wrapper in `template.go`.
- Migrate 11 callers in `template_test.go` (9) and `e2e_update_spec_test.go` (2) from `tmpl.generateTreeInternalWithErrors(data)` to `tmpl.buildTree(data, nil)`.
- Update `t.Fatalf` messages from `"generateTreeInternalWithErrors failed: %v"` to `"buildTree failed: %v"` so test failure messages point at the actual function being called.
- Update one in-test comment that referenced the removed name.

No behavior change.

## Test plan

- [x] `go test ./...` passes (full suite, ~135s)
- [x] `golangci-lint run --enable-only=errcheck,govet,ineffassign,staticcheck,unparam,unused` — 0 issues (confirms no new dead code)
- [x] Pre-commit hook ran the full gate before commit
- [x] `grep -rn 'generateTreeInternalWithErrors' --include='*.go'` — 0 hits in the worktree (confirms full removal)

Closes #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)