### PR TITLE
fix(mount): auto-wire FormSchema into Context (#236)

### DIFF
--- a/formvalidation.go
+++ b/formvalidation.go
@@ -33,10 +33,9 @@ type FormSchema struct {
 // inputAttrRegex matches HTML input/textarea/select elements and captures their attributes.
 var inputAttrRegex = regexp.MustCompile(`<(?:input|textarea|select)\b([^>]*)>`)
 
-// Strips Go template actions before HTML attribute extraction.
 var templateDirectiveRegex = regexp.MustCompile(`(?s)\{\{.*?\}\}`)
 
-// Pre-blanks partially-dynamic names like name="user_{{.ID}}" so they don't collapse to misleading literals after the directive strip.
+// name attrs containing any directive are blanked so partial-dynamic forms don't collapse to spurious literal rules.
 var dynamicNameAttrRegex = regexp.MustCompile(`(?s)(\bname\s*=\s*")[^"]*\{\{.*?\}\}[^"]*"`)
 
 func extractFormSchemaFromTemplateStr(templateStr string) *FormSchema {

--- a/formvalidation.go
+++ b/formvalidation.go
@@ -33,30 +33,13 @@ type FormSchema struct {
 // inputAttrRegex matches HTML input/textarea/select elements and captures their attributes.
 var inputAttrRegex = regexp.MustCompile(`<(?:input|textarea|select)\b([^>]*)>`)
 
-// templateDirectiveRegex matches Go template actions like {{...}} so we can strip
-// them from the raw template source before form-attribute extraction. Dynamic
-// attribute values (e.g. name="{{.Field}}") collapse to name="" and are then
-// discarded by ExtractFormSchema, matching the documented limitation that
-// dynamic field names are not auto-detected.
+// Strips Go template actions before HTML attribute extraction.
 var templateDirectiveRegex = regexp.MustCompile(`(?s)\{\{.*?\}\}`)
 
-// dynamicNameAttrRegex matches a name attribute whose double-quoted value
-// contains a {{...}} template directive (fully or partially dynamic). We blank
-// the value before stripping directives so partially-dynamic names like
-// name="user_{{.ID}}" do not collapse to a misleading literal (name="user_")
-// and produce a wrong-field rule. Blanking forces ExtractFormSchema to skip
-// the input entirely, matching the documented limitation that dynamic field
-// names are not auto-detected.
+// Pre-blanks partially-dynamic names like name="user_{{.ID}}" so they don't collapse to misleading literals after the directive strip.
 var dynamicNameAttrRegex = regexp.MustCompile(`(?s)(\bname\s*=\s*")[^"]*\{\{.*?\}\}[^"]*"`)
 
-// extractFormSchemaFromTemplateStr derives a FormSchema from the raw template
-// source by stripping {{...}} directives and scanning the literal HTML for
-// validation attributes. Returns nil if the template has no rules so callers
-// can skip wiring entirely.
 func extractFormSchemaFromTemplateStr(templateStr string) *FormSchema {
-	// Pre-pass: blank any name attribute that contains a template directive
-	// so partially-dynamic names are skipped instead of misdetected after the
-	// global directive strip.
 	blanked := dynamicNameAttrRegex.ReplaceAllString(templateStr, `${1}"`)
 	stripped := templateDirectiveRegex.ReplaceAllString(blanked, "")
 	schema := ExtractFormSchema([]string{stripped})

--- a/formvalidation.go
+++ b/formvalidation.go
@@ -33,6 +33,26 @@ type FormSchema struct {
 // inputAttrRegex matches HTML input/textarea/select elements and captures their attributes.
 var inputAttrRegex = regexp.MustCompile(`<(?:input|textarea|select)\b([^>]*)>`)
 
+// templateDirectiveRegex matches Go template actions like {{...}} so we can strip
+// them from the raw template source before form-attribute extraction. Dynamic
+// attribute values (e.g. name="{{.Field}}") collapse to name="" and are then
+// discarded by ExtractFormSchema, matching the documented limitation that
+// dynamic field names are not auto-detected.
+var templateDirectiveRegex = regexp.MustCompile(`(?s)\{\{.*?\}\}`)
+
+// extractFormSchemaFromTemplateStr derives a FormSchema from the raw template
+// source by stripping {{...}} directives and scanning the literal HTML for
+// validation attributes. Returns nil if the template has no rules so callers
+// can skip wiring entirely.
+func extractFormSchemaFromTemplateStr(templateStr string) *FormSchema {
+	stripped := templateDirectiveRegex.ReplaceAllString(templateStr, "")
+	schema := ExtractFormSchema([]string{stripped})
+	if schema == nil || len(schema.Rules) == 0 {
+		return nil
+	}
+	return schema
+}
+
 // attrRegex matches individual HTML attributes.
 // Handles double-quoted values only. This is sufficient because Go's html/template
 // always renders attributes with double quotes in statics.

--- a/formvalidation.go
+++ b/formvalidation.go
@@ -40,12 +40,25 @@ var inputAttrRegex = regexp.MustCompile(`<(?:input|textarea|select)\b([^>]*)>`)
 // dynamic field names are not auto-detected.
 var templateDirectiveRegex = regexp.MustCompile(`(?s)\{\{.*?\}\}`)
 
+// dynamicNameAttrRegex matches a name attribute whose double-quoted value
+// contains a {{...}} template directive (fully or partially dynamic). We blank
+// the value before stripping directives so partially-dynamic names like
+// name="user_{{.ID}}" do not collapse to a misleading literal (name="user_")
+// and produce a wrong-field rule. Blanking forces ExtractFormSchema to skip
+// the input entirely, matching the documented limitation that dynamic field
+// names are not auto-detected.
+var dynamicNameAttrRegex = regexp.MustCompile(`(?s)(\bname\s*=\s*")[^"]*\{\{.*?\}\}[^"]*"`)
+
 // extractFormSchemaFromTemplateStr derives a FormSchema from the raw template
 // source by stripping {{...}} directives and scanning the literal HTML for
 // validation attributes. Returns nil if the template has no rules so callers
 // can skip wiring entirely.
 func extractFormSchemaFromTemplateStr(templateStr string) *FormSchema {
-	stripped := templateDirectiveRegex.ReplaceAllString(templateStr, "")
+	// Pre-pass: blank any name attribute that contains a template directive
+	// so partially-dynamic names are skipped instead of misdetected after the
+	// global directive strip.
+	blanked := dynamicNameAttrRegex.ReplaceAllString(templateStr, `${1}"`)
+	stripped := templateDirectiveRegex.ReplaceAllString(blanked, "")
 	schema := ExtractFormSchema([]string{stripped})
 	if schema == nil || len(schema.Rules) == 0 {
 		return nil

--- a/formvalidation_test.go
+++ b/formvalidation_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExtractFormSchema_BasicAttributes(t *testing.T) {
@@ -362,6 +363,64 @@ func TestMount_AutoWiresFormSchema_HTTP(t *testing.T) {
 	}
 	if !strings.Contains(body, "at least 3 characters") {
 		t.Errorf("Expected minlength validation error in response, got: %s", body)
+	}
+}
+
+func TestMount_AutoWiresFormSchema_WS(t *testing.T) {
+	tmpl, err := New("autowire-ws")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>
+		<form method="POST">
+			<input type="email" name="email" required>
+			<input type="text" name="name" required minlength="3">
+		</form>
+	</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if tmpl.formSchema == nil {
+		t.Fatal("Template.formSchema should be populated after Parse")
+	}
+
+	handler := tmpl.Handle(&validateFormController{}, AsState(&validateFormState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	ws := connectWS(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	sendWSAction(t, ws, "Submit", map[string]interface{}{
+		"email": "not-an-email",
+		"name":  "ab",
+	})
+	resp := readWSUpdate(t, ws, 3*time.Second)
+
+	meta, ok := resp["meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("Submit response has no meta: %#v", resp)
+	}
+	if success, _ := meta["success"].(bool); success {
+		t.Errorf("meta.success = true, want false (validation should have failed)")
+	}
+	errs, ok := meta["errors"].(map[string]any)
+	if !ok {
+		t.Fatalf("meta.errors missing or wrong type: %#v", meta)
+	}
+	emailMsg, _ := errs["email"].(string)
+	if !strings.Contains(emailMsg, "valid email") {
+		t.Errorf("meta.errors[email] = %q, want substring 'valid email'", emailMsg)
+	}
+	nameMsg, _ := errs["name"].(string)
+	if !strings.Contains(nameMsg, "at least 3 characters") {
+		t.Errorf("meta.errors[name] = %q, want substring 'at least 3 characters'", nameMsg)
 	}
 }
 

--- a/formvalidation_test.go
+++ b/formvalidation_test.go
@@ -3,7 +3,11 @@ package livetemplate
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -227,5 +231,120 @@ func TestContext_ValidateForm(t *testing.T) {
 	err := ctx.ValidateForm()
 	if err == nil {
 		t.Fatal("Expected validation error for short title")
+	}
+}
+
+func TestExtractFormSchemaFromTemplateStr_StripsDirectives(t *testing.T) {
+	// Mixed static + dynamic attributes: name="title" is literal, value
+	// is dynamic. The directive must be stripped so the literal name is found.
+	src := `<form><input type="email" name="title" value="{{.Title}}" required minlength="5"></form>`
+	schema := extractFormSchemaFromTemplateStr(src)
+	if schema == nil {
+		t.Fatal("Expected schema, got nil")
+	}
+	if len(schema.Rules) != 1 {
+		t.Fatalf("Expected 1 rule, got %d", len(schema.Rules))
+	}
+	if schema.Rules[0].Field != "title" || !schema.Rules[0].Required {
+		t.Errorf("unexpected rule: %+v", schema.Rules[0])
+	}
+
+	// Template with no validation attributes returns nil so callers can skip.
+	none := extractFormSchemaFromTemplateStr(`<div>{{.Body}}</div>`)
+	if none != nil {
+		t.Errorf("Expected nil for template with no input rules, got %+v", none)
+	}
+}
+
+// validateFormController exercises ctx.ValidateForm() inside an action method
+// without ever calling WithFormSchema manually — this regression-tests
+// issue #236 ("ValidateForm silently a no-op for real users").
+type validateFormController struct{}
+
+type validateFormState struct {
+	Errors map[string]string
+}
+
+func (c *validateFormController) Mount(s validateFormState, ctx *Context) (validateFormState, error) {
+	return s, nil
+}
+
+func (c *validateFormController) Submit(s validateFormState, ctx *Context) (validateFormState, error) {
+	if err := ctx.ValidateForm(); err != nil {
+		var multi MultiError
+		if errors.As(err, &multi) {
+			out := make(map[string]string, len(multi))
+			for _, fe := range multi {
+				out[fe.Field] = fe.Message
+			}
+			s.Errors = out
+		}
+		return s, err
+	}
+	s.Errors = nil
+	return s, nil
+}
+
+func TestMount_AutoWiresFormSchema_HTTP(t *testing.T) {
+	tmpl, err := New("autowire-http")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>
+		<form method="POST">
+			<input type="email" name="email" required>
+			<input type="text" name="name" required minlength="3">
+		</form>
+	</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if tmpl.formSchema == nil {
+		t.Fatal("Template.formSchema should be populated after Parse")
+	}
+	if len(tmpl.formSchema.Rules) != 2 {
+		t.Fatalf("Expected 2 rules cached on template, got %d", len(tmpl.formSchema.Rules))
+	}
+
+	handler := tmpl.Handle(&validateFormController{}, AsState(&validateFormState{}))
+
+	form := url.Values{}
+	form.Set("lvt-action", "Submit")
+	form.Set("email", "not-an-email")
+	form.Set("name", "ab") // too short
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	// JSON response should carry both per-field validation errors emitted by
+	// ValidateForm — proving the schema was auto-wired without the controller
+	// ever calling WithFormSchema.
+	if !strings.Contains(body, "valid email") {
+		t.Errorf("Expected email validation error in response, got: %s", body)
+	}
+	if !strings.Contains(body, "at least 3 characters") {
+		t.Errorf("Expected minlength validation error in response, got: %s", body)
+	}
+}
+
+func TestMount_AutoWiresFormSchema_NoFormFields(t *testing.T) {
+	// Templates without input/textarea/select rules should leave formSchema
+	// nil so the auto-wire branch in mount.go is a no-op (preserves existing
+	// behavior for non-form templates).
+	tmpl, err := New("autowire-noform")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	if _, err := tmpl.Parse(`<div>{{.Title}}</div>`); err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if tmpl.formSchema != nil {
+		t.Errorf("Expected formSchema=nil for template without inputs, got %+v", tmpl.formSchema)
 	}
 }

--- a/formvalidation_test.go
+++ b/formvalidation_test.go
@@ -256,6 +256,38 @@ func TestExtractFormSchemaFromTemplateStr_StripsDirectives(t *testing.T) {
 	}
 }
 
+func TestExtractFormSchemaFromTemplateStr_SkipsDynamicNames(t *testing.T) {
+	// Names that contain a template directive are dynamic — even partially —
+	// and must produce no rule. Without the dynamic-name pre-pass, a partial
+	// directive like name="user_{{.ID}}" would collapse to name="user_" after
+	// the global strip and yield a rule for a field that never exists, causing
+	// ValidateForm to emit spurious required/format errors.
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"fully dynamic", `<input type="email" name="{{.Field}}" required>`},
+		{"prefix + directive", `<input type="email" name="user_{{.ID}}" required>`},
+		{"directive + suffix", `<input type="email" name="{{.Prefix}}_field" required>`},
+		{"directive in middle", `<input type="text" name="a{{.Mid}}b" required minlength="3">`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := extractFormSchemaFromTemplateStr(tc.src)
+			if schema != nil {
+				t.Errorf("Expected nil schema for dynamic name (%s), got rules: %+v", tc.src, schema.Rules)
+			}
+		})
+	}
+
+	// Sanity: a fully literal name alongside a dynamic value still yields a rule.
+	mixed := `<form><input type="email" name="literal" value="{{.X}}" required></form>`
+	schema := extractFormSchemaFromTemplateStr(mixed)
+	if schema == nil || len(schema.Rules) != 1 || schema.Rules[0].Field != "literal" {
+		t.Fatalf("Expected single rule for literal name, got %+v", schema)
+	}
+}
+
 // validateFormController exercises ctx.ValidateForm() inside an action method
 // without ever calling WithFormSchema manually — this regression-tests
 // issue #236 ("ValidateForm silently a no-op for real users").

--- a/mount.go
+++ b/mount.go
@@ -1517,9 +1517,6 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 	ctx := NewContext(context.Background(), req.Action, req.Data)
 	ctx = ctx.WithUserID(userID)
 	ctx = ctx.WithFlashSetter(connSt)
-	if schema := h.config.Template.formSchema; schema != nil {
-		ctx = ctx.WithFormSchema(schema)
-	}
 	// Wire Session so dispatched actions (from BroadcastAction or
 	// Session.TriggerAction) can also call ctx.Session().TriggerAction
 	// for follow-on server pushes. pendingBroadcasts from ctx is still
@@ -1530,6 +1527,9 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 	// re-triggers itself, which is a caller bug rather than framework
 	// amplification.
 	ctx = ctx.WithSession(newLocalSession(h, connSt.groupID))
+	if schema := h.config.Template.formSchema; schema != nil {
+		ctx = ctx.WithFormSchema(schema)
+	}
 
 	newState, err := DispatchWithState(h.config.Controller, connSt.state, ctx)
 	if err != nil {
@@ -1877,6 +1877,9 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 		actionCtx = actionCtx.WithUserID(msg.UserID)
 		actionCtx = actionCtx.WithFlashSetter(state)
 		actionCtx = actionCtx.WithSession(newLocalSession(h, conn.GroupID))
+		if schema := h.config.Template.formSchema; schema != nil {
+			actionCtx = actionCtx.WithFormSchema(schema)
+		}
 
 		// Dispatch action using Controller+State pattern
 		newState, actionErr := DispatchWithState(h.config.Controller, state.state, actionCtx)

--- a/mount.go
+++ b/mount.go
@@ -1877,9 +1877,6 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 		actionCtx = actionCtx.WithUserID(msg.UserID)
 		actionCtx = actionCtx.WithFlashSetter(state)
 		actionCtx = actionCtx.WithSession(newLocalSession(h, conn.GroupID))
-		if schema := h.config.Template.formSchema; schema != nil {
-			actionCtx = actionCtx.WithFormSchema(schema)
-		}
 
 		// Dispatch action using Controller+State pattern
 		newState, actionErr := DispatchWithState(h.config.Controller, state.state, actionCtx)

--- a/mount.go
+++ b/mount.go
@@ -729,6 +729,9 @@ eventLoop:
 			actionCtx = actionCtx.WithUploads(uploadRegistry)
 			actionCtx = actionCtx.WithFlashSetter(connSt)
 			actionCtx = actionCtx.WithSession(newLocalSession(h, groupID))
+			if schema := connTmpl.formSchema; schema != nil {
+				actionCtx = actionCtx.WithFormSchema(schema)
+			}
 
 			// actionNavigate re-runs Mount with msg.Data as query params. Rebind
 			// actionCtx itself (not a discarded copy) so BroadcastAction calls
@@ -1218,6 +1221,9 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	actionCtx = actionCtx.WithUploads(uploadRegistry)
 	actionCtx = actionCtx.WithFlashSetter(connSt)
 	actionCtx = actionCtx.WithSession(newLocalSession(h, groupID))
+	if schema := h.config.Template.formSchema; schema != nil {
+		actionCtx = actionCtx.WithFormSchema(schema)
+	}
 
 	// Dispatch action using Controller+State pattern
 	newState, actionErr := DispatchWithState(h.config.Controller, connSt.state, actionCtx)
@@ -1511,6 +1517,9 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 	ctx := NewContext(context.Background(), req.Action, req.Data)
 	ctx = ctx.WithUserID(userID)
 	ctx = ctx.WithFlashSetter(connSt)
+	if schema := h.config.Template.formSchema; schema != nil {
+		ctx = ctx.WithFormSchema(schema)
+	}
 	// Wire Session so dispatched actions (from BroadcastAction or
 	// Session.TriggerAction) can also call ctx.Session().TriggerAction
 	// for follow-on server pushes. pendingBroadcasts from ctx is still

--- a/template.go
+++ b/template.go
@@ -230,6 +230,7 @@ type Template struct {
 	cachedParseTemplate    *parse.Template // Cached AST to avoid re-parsing on every render
 	cachedBodyContent      string          // Cached result of ExtractTemplateBodyContent(t.templateStr)
 	cachedBodyContentValid bool            // Whether cachedBodyContent has been computed (empty string is valid)
+	formSchema             *FormSchema     // Cached schema extracted from templateStr; nil if no rules
 }
 
 // Funcs registers a template.FuncMap that will be applied to all template parsing and execution.
@@ -911,6 +912,7 @@ func (t *Template) Clone() (*Template, error) {
 	cachedParse := t.cachedParseTemplate
 	bodyContent := t.cachedBodyContent
 	bodyContentValid := t.cachedBodyContentValid
+	formSchema := t.formSchema
 	t.mu.RUnlock()
 
 	// Share immutable data from master instead of re-creating per clone.
@@ -927,6 +929,7 @@ func (t *Template) Clone() (*Template, error) {
 		cachedParseTemplate:    cachedParse, // Share parsed AST + builtins
 		cachedBodyContent:      bodyContent, // Share extracted body content
 		cachedBodyContentValid: bodyContentValid,
+		formSchema:             formSchema, // Share extracted form schema (immutable)
 		// Don't copy lastData, lastHTML, lastTree, etc. - start fresh per session
 	}
 
@@ -1035,6 +1038,7 @@ func (t *Template) parseInternal(text string, baseTemplate *template.Template, i
 	t.cachedParseTemplate = nil // Invalidate cached AST when template source changes
 	t.cachedBodyContent = ""    // Invalidate cached body content
 	t.cachedBodyContentValid = false
+	t.formSchema = extractFormSchemaFromTemplateStr(text)
 
 	// Validate that tree generation works with this template
 	// This ensures templates with {{define}}/{{block}} are caught during initialization


### PR DESCRIPTION
## Summary

- `ctx.ValidateForm()` was silently a no-op for real users — it gated on `c.formSchema`, but nothing in the framework populated that field, and the public API offered no path from a handler to the template statics needed for `ExtractFormSchema`. Most code that called `ValidateForm` got `nil` back regardless of input.
- Cache the `FormSchema` once on `Template` at parse time, derived from `templateStr` with `{{...}}` directives stripped. Dynamic name attributes collapse and are discarded, matching the documented `ExtractFormSchema` limitation. `Clone()` shares the pointer like the other immutable parse-time caches (`cachedParseTemplate`, `cachedBodyContent`).
- Attach the cached schema to `actionCtx` in `mount.go` before action dispatch on the three dispatch paths that carry user form input: WS event loop, HTTP path, and the dispatched-action path. Handlers that call `WithFormSchema` explicitly still win because the chained `With*` returns a fresh context.

## Test plan

- [x] `TestMount_AutoWiresFormSchema_HTTP` posts a malformed form to a controller that calls `ctx.ValidateForm()` without manual `WithFormSchema` setup and asserts both per-field errors round-trip in the response (proves the auto-wire fires on the HTTP path).
- [x] `TestMount_AutoWiresFormSchema_WS` opens a WebSocket, dispatches a `Submit` action with malformed data, and asserts `meta.success=false` plus per-field errors come back over the wire (proves the auto-wire fires on the WS event-loop path — the more common real-world path).
- [x] `TestMount_AutoWiresFormSchema_NoFormFields` confirms `formSchema` stays `nil` for templates without inputs (auto-wire branch is a no-op for non-form templates).
- [x] `TestExtractFormSchemaFromTemplateStr_StripsDirectives` covers the `{{...}}` stripping helper.
- [x] Full suite: `GOWORK=off go test ./... -timeout=300s` — passes.
- [x] Pre-commit hook (`go fmt` + `golangci-lint` + full tests) — passes.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)