### PR TITLE
docs: P2 cluster — TreeNode breaking change, lvt-submit deprecation, CSRF note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to LiveTemplate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking changes
+
+- **`TreeNode` public API changed in [#220](https://github.com/livefir/livetemplate/pull/220)** (commit `3fe784ca`, shipped in `v0.8.0` series). The `Dynamics` field type and the helper signatures changed when the internal map was replaced with a slice for ~20% speedup. Since `TreeNode` is re-exported from the top-level `livetemplate` package via `types.go`, external callers that constructed or introspected `TreeNode` directly need to update:
+  - `Dynamics` field: `map[string]interface{}` → `[]interface{}`
+  - `SetDynamic(position string, value interface{})` → `SetDynamic(index int, value interface{})`
+  - `GetDynamic(position string)` → `GetDynamic(index int)`
+  - New `AutoKey string` field replaces the previous `"_k"` map key.
+
+  Most application code does not touch `TreeNode` directly — the breaking surface is limited to library extensions or test fixtures that constructed `TreeNode` literals. The wire format (numeric string keys: `"0"`, `"1"`, ...) is unchanged; only the in-memory Go API moved.
+
 ## [v0.8.23] - 2026-05-02
 
 ### Changes
@@ -801,7 +813,7 @@ Note: Only one pre-existing test failure (TestTemplateGenerateTreeWithFuncMap)
 - **lvt:** add lvt gen auth command - Complete (Phases 1-6) ([#15](https://github.com/livefir/livetemplate/issues/15))
 
 
-[Unreleased]: https://github.com/livefir/livetemplate/compare/v0.8.21...HEAD
+[Unreleased]: https://github.com/livefir/livetemplate/compare/v0.8.23...HEAD
 [v0.8.21]: https://github.com/livefir/livetemplate/compare/v0.8.20...v0.8.21
 [v0.8.20]: https://github.com/livefir/livetemplate/compare/v0.8.19...v0.8.20
 [v0.8.19]: https://github.com/livefir/livetemplate/compare/v0.8.18...v0.8.19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
-- **`TreeNode` public API changed in [#220](https://github.com/livefir/livetemplate/pull/220)** (commit `3fe784ca`, shipped in `v0.8.0` series). The `Dynamics` field type and the helper signatures changed when the internal map was replaced with a slice for ~20% speedup. Since `TreeNode` is re-exported from the top-level `livetemplate` package via `types.go`, external callers that constructed or introspected `TreeNode` directly need to update:
+- **Retroactive breaking-change notice for v0.8.5: `TreeNode` public API changed in [#220](https://github.com/livefir/livetemplate/pull/220)** (commit `3fe784ca`, shipped in `v0.8.5`). The `Dynamics` field type and the helper signatures changed when the internal map was replaced with a slice for ~20% speedup. Since `TreeNode` is re-exported from the top-level `livetemplate` package via `types.go`, external callers that constructed or introspected `TreeNode` directly need to update:
   - `Dynamics` field: `map[string]interface{}` → `[]interface{}`
   - `SetDynamic(position string, value interface{})` → `SetDynamic(index int, value interface{})`
   - `GetDynamic(position string)` → `GetDynamic(index int)`
@@ -814,6 +814,8 @@ Note: Only one pre-existing test failure (TestTemplateGenerateTreeWithFuncMap)
 
 
 [Unreleased]: https://github.com/livefir/livetemplate/compare/v0.8.23...HEAD
+[v0.8.23]: https://github.com/livefir/livetemplate/compare/v0.8.22...v0.8.23
+[v0.8.22]: https://github.com/livefir/livetemplate/compare/v0.8.21...v0.8.22
 [v0.8.21]: https://github.com/livefir/livetemplate/compare/v0.8.20...v0.8.21
 [v0.8.20]: https://github.com/livefir/livetemplate/compare/v0.8.19...v0.8.20
 [v0.8.19]: https://github.com/livefir/livetemplate/compare/v0.8.18...v0.8.19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
-- **Retroactive breaking-change notice for v0.8.5: `TreeNode` public API changed in [#220](https://github.com/livefir/livetemplate/pull/220)** (commit `3fe784ca`, shipped in `v0.8.5`). The `Dynamics` field type and the helper signatures changed when the internal map was replaced with a slice for ~20% speedup. Since `TreeNode` is re-exported from the top-level `livetemplate` package via `types.go`, external callers that constructed or introspected `TreeNode` directly need to update:
+- **Retroactive breaking-change notice for v0.8.5: `TreeNode` internal API changed in [#220](https://github.com/livefir/livetemplate/pull/220)** (commit `3fe784ca`, shipped in `v0.8.5`). The `Dynamics` field type and the helper signatures changed when the internal map was replaced with a slice for ~20% speedup:
   - `Dynamics` field: `map[string]interface{}` → `[]interface{}`
   - `SetDynamic(position string, value interface{})` → `SetDynamic(index int, value interface{})`
   - `GetDynamic(position string)` → `GetDynamic(index int)`
-  - New `AutoKey string` field replaces the previous `"_k"` map key.
+  - New `AutoKey string` Go field replaces the previous `"_k"` map key. The `"_k"` *wire-format* key is unchanged — only the in-memory Go field name moved.
 
-  Most application code does not touch `TreeNode` directly — the breaking surface is limited to library extensions or test fixtures that constructed `TreeNode` literals. The wire format (numeric string keys: `"0"`, `"1"`, ...) is unchanged; only the in-memory Go API moved.
+  `TreeNode` lives in `internal/build` and is not part of the public `livetemplate` API surface; the breaking surface is therefore limited to **library forks and downstream modules that vendor or replace `internal/build`**, plus internal test fixtures. Application code that consumes `livetemplate` through its exported API is unaffected. The on-the-wire tree format (numeric string keys: `"0"`, `"1"`, ...) is unchanged; only the in-memory Go API moved.
 
 ## [v0.8.23] - 2026-05-02
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,9 @@ See `docs/design/ARCHITECTURE.md` for design decisions and `docs/design/CODE_STR
 ```go
 type TreeNode struct {
     Statics     []string                // Static HTML parts (key: "s")
-    Dynamics    map[string]interface{}   // Dynamic content (keys: "0", "1", etc.)
-    Fingerprint string                   // Structure hash (key: "f")
+    Dynamics    []interface{}           // Dynamic content indexed by position (keys: "0", "1", etc.)
+    AutoKey     string                  // Range item key, replaces previous "_k" map key
+    Fingerprint string                  // Structure hash (key: "f")
     Range       *RangeData              // Range operation data (key: "d")
     Metadata    *TreeMetadata           // Additional metadata (key: "m")
 }

--- a/docs/guides/progressive-complexity.md
+++ b/docs/guides/progressive-complexity.md
@@ -369,6 +369,8 @@ When JavaScript is unavailable, forms submit as standard HTML POST requests. The
 
 This is why all Tier 1 examples use `<form method="POST">` — they work without JavaScript by design.
 
+> **Security note:** When using no-JS POST mode, implement CSRF protection (e.g., [`gorilla/csrf`](https://github.com/gorilla/csrf) middleware). The JS transport modes benefit from same-origin WebSocket/fetch, but plain HTML form POST does not.
+
 ### JavaScript + HTTP (fetch)
 
 When JavaScript is available but WebSocket is not connected, the JS client intercepts form submissions and sends them via `fetch()`. The server responds with a JSON tree update, and the client patches the DOM. No page reload occurs.

--- a/docs/guides/progressive-complexity.md
+++ b/docs/guides/progressive-complexity.md
@@ -369,7 +369,7 @@ When JavaScript is unavailable, forms submit as standard HTML POST requests. The
 
 This is why all Tier 1 examples use `<form method="POST">` — they work without JavaScript by design.
 
-> **Security note:** When using no-JS POST mode, implement CSRF protection (e.g., [`gorilla/csrf`](https://github.com/gorilla/csrf) middleware). The JS transport modes benefit from same-origin WebSocket/fetch, but plain HTML form POST does not.
+> **Security note:** When using no-JS POST mode, implement CSRF protection (e.g., [`gorilla/csrf`](https://github.com/gorilla/csrf) or equivalent CSRF middleware). The JS transport modes send the `Origin` header that the server validates on WebSocket upgrade and fetch; plain HTML form POST does not carry the same protection.
 
 ### JavaScript + HTTP (fetch)
 

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -96,10 +96,12 @@ Data can be passed via hidden inputs, button `value`, or `data-*` attributes:
 The client resolves the action name in this order (first match wins):
 
 1. `lvt-form:action="X"` on the form → action is `X` (explicit routing, highest precedence)
-2. `lvt-submit="X"` on the form → action is `X` (backward compatible)
+2. `lvt-submit="X"` on the form → action is `X` (**legacy** — see note below)
 3. Clicked button's `name` attribute → action is the button name
 4. `form name="X"` → action is `X`
 5. None of the above → defaults to `"submit"` → routes to `Submit()`
+
+> **Legacy attribute:** `lvt-submit` is kept for backward compatibility but should be avoided in new code. Prefer button `name` (e.g., `<button name="save">`) or form `name` (e.g., `<form name="search">`) — these work natively without JavaScript. See [Progressive Complexity Reference — Action Resolution Order](progressive-complexity-reference.md#action-resolution-order-tier-1) for the Tier 1 (standard HTML) routing rules.
 
 > **Note:** The form field name `action` is **not** reserved. A form field `<input name="action" value="approve">` flows through to `ActionData` as normal data. Use `lvt-form:action` on the `<form>` element for routing.
 

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -97,7 +97,7 @@ During form submission, the framework automatically manages loading indicators:
 | `lvt-*` attributes | N/A | Works | Works |
 | Server push (broadcast) | N/A | N/A | Works |
 
-> **Security note:** When using no-JS POST mode, implement CSRF protection (e.g., [`gorilla/csrf`](https://github.com/gorilla/csrf) middleware). The JS transport modes benefit from same-origin WebSocket/fetch, but plain HTML form POST does not.
+> **Security note:** When using no-JS POST mode, implement CSRF protection (e.g., [`gorilla/csrf`](https://github.com/gorilla/csrf) or equivalent CSRF middleware). The JS transport modes send the `Origin` header that the server validates on WebSocket upgrade and fetch; plain HTML form POST does not carry the same protection.
 
 ## Tier 2: `lvt-*` Attributes
 

--- a/docs/references/progressive-complexity-reference.md
+++ b/docs/references/progressive-complexity-reference.md
@@ -97,6 +97,8 @@ During form submission, the framework automatically manages loading indicators:
 | `lvt-*` attributes | N/A | Works | Works |
 | Server push (broadcast) | N/A | N/A | Works |
 
+> **Security note:** When using no-JS POST mode, implement CSRF protection (e.g., [`gorilla/csrf`](https://github.com/gorilla/csrf) middleware). The JS transport modes benefit from same-origin WebSocket/fetch, but plain HTML form POST does not.
+
 ## Tier 2: `lvt-*` Attributes
 
 For behaviors that standard HTML cannot express — timing control, reactive DOM, keyboard shortcuts, scroll management — use `lvt-*` attributes. The attribute prefixes are:


### PR DESCRIPTION
## Summary

Three doc-only fixes for P2 cluster:

- **#222** — Document the TreeNode internal-API change from PR #220 in CHANGELOG (retroactive breaking-change notice for v0.8.5; affects forks/vendors of internal/build, not external `livetemplate` API consumers)
- **#260** — Mark `lvt-submit` as legacy in client-attributes.md with cross-link to progressive-complexity-reference.md's resolution-order section
- **#238** — Add CSRF protection note for no-JS POST mode in both progressive-complexity.md (guide) and progressive-complexity-reference.md (reference)

## Test plan

- [x] Cross-link `progressive-complexity-reference.md#action-resolution-order-tier-1` resolves to existing heading
- [x] CSRF note appears in exactly two files (guide + reference)
- [x] `lvt-submit` usage example preserved (only the label/callout changes)
- [x] CHANGELOG `[Unreleased]` link bumped to v0.8.23 + missing v0.8.22 / v0.8.23 link defs added
- [x] CLAUDE.md `Key Data Structures` TreeNode block synced to slice-based API
- [x] CHANGELOG TreeNode notice scopes correctly: internal/build (forks + vendors), not external API consumers

Closes #222
Closes #260
Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)