### PR TITLE
fix(pubsub): gate handler registrations on Subscribe() success (#357)

### DIFF
--- a/handle_test.go
+++ b/handle_test.go
@@ -2820,8 +2820,6 @@ func TestEphemeral_SyncStillWorks(t *testing.T) {
 	}
 }
 
-// fakeBroadcaster is a minimal pubsub.Broadcaster + GroupActionBroadcaster used
-// to verify that handler registrations are gated on Subscribe() success (#357).
 type fakeBroadcaster struct {
 	subscribeErr      error
 	subscribeCalls    int
@@ -2855,11 +2853,6 @@ func (f *fakeBroadcaster) SubscribeGroupActions(_ pubsub.GroupActionHandler) err
 	return nil
 }
 
-// TestHandle_PubSubSubscribeFailureSkipsRegistrations verifies that when
-// PubSubBroadcaster.Subscribe() returns an error (e.g. Redis unreachable),
-// SubscribeServerActions and SubscribeGroupActions are NOT called. Otherwise
-// per-WS trySubscribe calls would log "not subscribed" errors on every connection.
-// See https://github.com/livetemplate/livetemplate/issues/357.
 func TestHandle_PubSubSubscribeFailureSkipsRegistrations(t *testing.T) {
 	fb := &fakeBroadcaster{subscribeErr: errors.New("redis unreachable")}
 
@@ -2885,8 +2878,6 @@ func TestHandle_PubSubSubscribeFailureSkipsRegistrations(t *testing.T) {
 	}
 }
 
-// TestHandle_PubSubSubscribeSuccessRegistersAll verifies that when Subscribe
-// succeeds, both SubscribeServerActions and SubscribeGroupActions are called.
 func TestHandle_PubSubSubscribeSuccessRegistersAll(t *testing.T) {
 	fb := &fakeBroadcaster{}
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -2819,3 +2819,95 @@ func TestEphemeral_SyncStillWorks(t *testing.T) {
 		}
 	}
 }
+
+// fakeBroadcaster is a minimal pubsub.Broadcaster + GroupActionBroadcaster used
+// to verify that handler registrations are gated on Subscribe() success (#357).
+type fakeBroadcaster struct {
+	subscribeErr      error
+	subscribeCalls    int
+	serverActionCalls int
+	groupActionCalls  int
+}
+
+func (f *fakeBroadcaster) PublishGlobal(_ []byte) error            { return nil }
+func (f *fakeBroadcaster) PublishToGroup(_ string, _ []byte) error { return nil }
+func (f *fakeBroadcaster) PublishToUser(_ string, _ []byte) error  { return nil }
+func (f *fakeBroadcaster) PublishServerAction(_ string, _ string, _ map[string]interface{}) error {
+	return nil
+}
+func (f *fakeBroadcaster) PublishGroupAction(_ string, _ string, _ map[string]interface{}) error {
+	return nil
+}
+func (f *fakeBroadcaster) Close() error { return nil }
+
+func (f *fakeBroadcaster) Subscribe(_ pubsub.MessageHandler) error {
+	f.subscribeCalls++
+	return f.subscribeErr
+}
+
+func (f *fakeBroadcaster) SubscribeServerActions(_ pubsub.ServerActionHandler) error {
+	f.serverActionCalls++
+	return nil
+}
+
+func (f *fakeBroadcaster) SubscribeGroupActions(_ pubsub.GroupActionHandler) error {
+	f.groupActionCalls++
+	return nil
+}
+
+// TestHandle_PubSubSubscribeFailureSkipsRegistrations verifies that when
+// PubSubBroadcaster.Subscribe() returns an error (e.g. Redis unreachable),
+// SubscribeServerActions and SubscribeGroupActions are NOT called. Otherwise
+// per-WS trySubscribe calls would log "not subscribed" errors on every connection.
+// See https://github.com/livetemplate/livetemplate/issues/357.
+func TestHandle_PubSubSubscribeFailureSkipsRegistrations(t *testing.T) {
+	fb := &fakeBroadcaster{subscribeErr: errors.New("redis unreachable")}
+
+	tmpl, err := New("test", WithPubSubBroadcaster(fb))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Count}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	_ = tmpl.Handle(&testHandleController{}, AsState(&testHandleState{}))
+
+	if fb.subscribeCalls != 1 {
+		t.Errorf("Subscribe should be called once, got %d", fb.subscribeCalls)
+	}
+	if fb.serverActionCalls != 0 {
+		t.Errorf("SubscribeServerActions must NOT be called when Subscribe fails, got %d", fb.serverActionCalls)
+	}
+	if fb.groupActionCalls != 0 {
+		t.Errorf("SubscribeGroupActions must NOT be called when Subscribe fails, got %d", fb.groupActionCalls)
+	}
+}
+
+// TestHandle_PubSubSubscribeSuccessRegistersAll verifies that when Subscribe
+// succeeds, both SubscribeServerActions and SubscribeGroupActions are called.
+func TestHandle_PubSubSubscribeSuccessRegistersAll(t *testing.T) {
+	fb := &fakeBroadcaster{}
+
+	tmpl, err := New("test", WithPubSubBroadcaster(fb))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Count}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	_ = tmpl.Handle(&testHandleController{}, AsState(&testHandleState{}))
+
+	if fb.subscribeCalls != 1 {
+		t.Errorf("Subscribe should be called once, got %d", fb.subscribeCalls)
+	}
+	if fb.serverActionCalls != 1 {
+		t.Errorf("SubscribeServerActions should be called once, got %d", fb.serverActionCalls)
+	}
+	if fb.groupActionCalls != 1 {
+		t.Errorf("SubscribeGroupActions should be called once, got %d", fb.groupActionCalls)
+	}
+}

--- a/template.go
+++ b/template.go
@@ -1566,7 +1566,6 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 	// If the backing store (e.g. Redis) is unreachable, this blocks until
 	// the client's configured dial timeout fires.
 	if mountCfg.PubSubBroadcaster != nil {
-		slog.Info("Starting pub/sub subscriber")
 		if err := mountCfg.PubSubBroadcaster.Subscribe(handler.handlePubSubMessage); err != nil {
 			slog.Warn("Pub/sub subscriber failed - cross-instance dispatch disabled",
 				slog.Any("error", err))

--- a/template.go
+++ b/template.go
@@ -1568,19 +1568,19 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 	if mountCfg.PubSubBroadcaster != nil {
 		slog.Info("Starting pub/sub subscriber")
 		if err := mountCfg.PubSubBroadcaster.Subscribe(handler.handlePubSubMessage); err != nil {
-			slog.Error("Pub/sub subscriber error",
+			slog.Warn("Pub/sub subscriber failed - cross-instance dispatch disabled",
 				slog.Any("error", err))
-		}
-
-		if err := mountCfg.PubSubBroadcaster.SubscribeServerActions(handler.handleServerActionMessage); err != nil {
-			slog.Error("Failed to subscribe to server actions",
-				slog.Any("error", err))
-		}
-
-		if gab, ok := mountCfg.PubSubBroadcaster.(pubsub.GroupActionBroadcaster); ok {
-			if err := gab.SubscribeGroupActions(handler.handleGroupActionMessage); err != nil {
-				slog.Error("Failed to subscribe to group actions",
+		} else {
+			if err := mountCfg.PubSubBroadcaster.SubscribeServerActions(handler.handleServerActionMessage); err != nil {
+				slog.Error("Failed to subscribe to server actions",
 					slog.Any("error", err))
+			}
+
+			if gab, ok := mountCfg.PubSubBroadcaster.(pubsub.GroupActionBroadcaster); ok {
+				if err := gab.SubscribeGroupActions(handler.handleGroupActionMessage); err != nil {
+					slog.Error("Failed to subscribe to group actions",
+						slog.Any("error", err))
+				}
 			}
 		}
 	}

--- a/template.go
+++ b/template.go
@@ -1570,6 +1570,7 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 			slog.Warn("Pub/sub subscriber failed - cross-instance dispatch disabled",
 				slog.Any("error", err))
 		} else {
+			slog.Info("Pub/sub subscriber started")
 			if err := mountCfg.PubSubBroadcaster.SubscribeServerActions(handler.handleServerActionMessage); err != nil {
 				slog.Error("Failed to subscribe to server actions",
 					slog.Any("error", err))


### PR DESCRIPTION
## Summary

- Gate `SubscribeServerActions` and `SubscribeGroupActions` registrations on the initial `PubSubBroadcaster.Subscribe()` succeeding. Previously, when `Subscribe()` failed (e.g. Redis unreachable at startup), the downstream calls still ran and silently registered handlers in local maps even though `processMessages()` never started.
- Downgrade the failure log from `Error` to a single `Warn` ("cross-instance dispatch disabled") to make the degraded-mode signal clear without the per-connection `Error` spam from per-WS `trySubscribe` retries.
- Adds two unit tests in `handle_test.go` using a fake `Broadcaster + GroupActionBroadcaster` with call counters: one asserts the downstream `Subscribe*` calls are skipped on failure; one asserts they all run on success.

Closes #357

## Test plan

- [x] `GOWORK=off go test ./... -timeout=180s` passes (full suite, including new gate tests)
- [x] `golangci-lint run --enable-only=errcheck,govet,ineffassign,staticcheck,unparam,unused` clean
- [x] Pre-commit hook (gofmt + lint + tests) passes without `--no-verify`
- [x] New tests `TestHandle_PubSubSubscribeFailureSkipsRegistrations` and `TestHandle_PubSubSubscribeSuccessRegistersAll` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)