### PR TITLE
fix(mount): use r.Context() for WS lifecycleCtx (#303)

### DIFF
--- a/lifecycle_integration_test.go
+++ b/lifecycle_integration_test.go
@@ -1,6 +1,7 @@
 package livetemplate
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
@@ -263,4 +264,84 @@ func treeContainsString(node map[string]interface{}, want string) bool {
 		}
 	}
 	return false
+}
+
+// =============================================================================
+// WebSocket Lifecycle Context Cancellation (issue #303)
+// =============================================================================
+//
+// Mount runs on every WebSocket connect/reconnect (PR #301). The lifecycleCtx
+// passed to Mount must inherit cancellation from the upgraded HTTP request so
+// that DB work or other context-aware operations cancel when the client
+// disconnects, rather than orphaning until they complete on their own.
+
+type wsCtxCancelState struct {
+	Count int
+}
+
+type wsCtxCancelController struct {
+	captured chan context.Context
+}
+
+func (c *wsCtxCancelController) Mount(state wsCtxCancelState, ctx *Context) (wsCtxCancelState, error) {
+	// Non-blocking send — if multiple Mounts run (reconnect), keep the first.
+	select {
+	case c.captured <- ctx.Context:
+	default:
+	}
+	return state, nil
+}
+
+func TestWebSocketLifecycleCtx_CancelsOnDisconnect(t *testing.T) {
+	ctrl := &wsCtxCancelController{captured: make(chan context.Context, 1)}
+
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Count}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(ctrl, AsState(&wsCtxCancelState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	// connectWSRaw blocks until the initial render frame arrives, which
+	// means Mount has run and the server is in its event loop.
+	ws, _ := connectWSRaw(t, wsURL)
+
+	var mountCtx context.Context
+	select {
+	case mountCtx = <-ctrl.captured:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Mount was not called within 2s of WebSocket connect")
+	}
+
+	if mountCtx == nil {
+		t.Fatal("Mount captured a nil context")
+	}
+	if err := mountCtx.Err(); err != nil {
+		t.Fatalf("ctx already canceled before disconnect: %v", err)
+	}
+
+	// Close the WebSocket. r.Context() should be canceled when the HTTP
+	// handler returns, which propagates to the captured Mount ctx.
+	if err := ws.Close(); err != nil {
+		t.Fatalf("WebSocket close failed: %v", err)
+	}
+
+	select {
+	case <-mountCtx.Done():
+		// Success — lifecycle ctx canceled with the request.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Mount ctx was not canceled within 2s after WebSocket close — lifecycleCtx is detached from r.Context() (issue #303)")
+	}
+
+	if err := mountCtx.Err(); err == nil {
+		t.Errorf("expected mountCtx.Err() to be non-nil after Done(), got nil")
+	}
 }

--- a/lifecycle_integration_test.go
+++ b/lifecycle_integration_test.go
@@ -266,15 +266,6 @@ func treeContainsString(node map[string]interface{}, want string) bool {
 	return false
 }
 
-// =============================================================================
-// WebSocket Lifecycle Context Cancellation (issue #303)
-// =============================================================================
-//
-// Mount runs on every WebSocket connect/reconnect (PR #301). The lifecycleCtx
-// passed to Mount must inherit cancellation from the upgraded HTTP request so
-// that DB work or other context-aware operations cancel when the client
-// disconnects, rather than orphaning until they complete on their own.
-
 type wsCtxCancelState struct {
 	Count int
 }
@@ -310,8 +301,6 @@ func TestWebSocketLifecycleCtx_CancelsOnDisconnect(t *testing.T) {
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
 
-	// connectWSRaw blocks until the initial render frame arrives, which
-	// means Mount has run and the server is in its event loop.
 	ws, _ := connectWSRaw(t, wsURL)
 
 	var mountCtx context.Context

--- a/mount.go
+++ b/mount.go
@@ -547,9 +547,12 @@ func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		groupID:  groupID,
 	}
 
-	// Create context for lifecycle methods with query params from initial connection
+	// Create context for lifecycle methods with query params from initial connection.
+	// Use r.Context() so Mount/OnConnect inherit cancellation from the WS request
+	// lifetime — when the client disconnects, in-flight DB work cancels rather than
+	// orphaning queries (issue #303).
 	wsQueryData := send.QueryParamsToData(r)
-	lifecycleCtx := NewContext(context.Background(), "", wsQueryData)
+	lifecycleCtx := NewContext(ctx, "", wsQueryData)
 	lifecycleCtx = lifecycleCtx.WithUserID(userID)
 	lifecycleCtx = lifecycleCtx.WithFlashSetter(connSt)
 	lifecycleCtx = lifecycleCtx.WithSession(newLocalSession(h, groupID))

--- a/mount.go
+++ b/mount.go
@@ -547,10 +547,7 @@ func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		groupID:  groupID,
 	}
 
-	// Create context for lifecycle methods with query params from initial connection.
-	// Use r.Context() so Mount/OnConnect inherit cancellation from the WS request
-	// lifetime — when the client disconnects, in-flight DB work cancels rather than
-	// orphaning queries (issue #303).
+	// Use r.Context() (not context.Background()) so Mount/OnConnect cancel on disconnect (#303).
 	wsQueryData := send.QueryParamsToData(r)
 	lifecycleCtx := NewContext(ctx, "", wsQueryData)
 	lifecycleCtx = lifecycleCtx.WithUserID(userID)


### PR DESCRIPTION
## Summary

- `handleWebSocket` was building the lifecycle context with `context.Background()`, so Mount/OnConnect never observed client disconnects.
- Now that `Mount()` runs on every WS connect/reconnect (PR #301), DB queries or other context-aware work started by Mount could orphan and pile up when clients disconnected.
- Switch the WS lifecycle context to inherit from `r.Context()` (the upgraded request's context), which is canceled when the WS connection closes.

The HTTP path (`handleHTTP`, mount.go:1003) was already correct — it already used the request-derived `ctx`. Only the WS site needed fixing.

Closes #303

## Test plan

- [x] New `TestWebSocketLifecycleCtx_CancelsOnDisconnect` in `lifecycle_integration_test.go`: opens a WS, captures `ctx.Context` from inside Mount, closes the WS, asserts the captured context's `Done()` fires within 2s and `Err()` is non-nil.
- [x] Verified the test FAILS on `context.Background()` (the bug) and PASSES on `r.Context()` (the fix).
- [x] `go test ./... -timeout=120s` — all packages green.
- [x] Pre-commit hook (go fmt + golangci-lint with errcheck/govet/ineffassign/staticcheck/unparam/unused + tests) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)