### PR TITLE
feat(session): observability log on chained TriggerAction (#337 Option A)

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -1525,9 +1525,8 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 	// allowed — each hop runs through a connection event loop, so the
 	// only unbounded failure mode is a handler that recursively
 	// re-triggers itself, which is a caller bug rather than framework
-	// amplification. The "from dispatched" constructor variant flags the
-	// session so chained TriggerAction calls log a debug line, making
-	// such recursion visible in logs (#337).
+	// amplification. The dispatched-flagged session emits an
+	// observability log on chained TriggerAction (#337).
 	ctx = ctx.WithSession(newLocalSessionFromDispatched(h, connSt.groupID))
 	if schema := h.config.Template.formSchema; schema != nil {
 		ctx = ctx.WithFormSchema(schema)
@@ -1874,9 +1873,8 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 		// caller intent and each hop still runs through the per-connection
 		// event loop (no unbounded recursion on a single goroutine), but
 		// handlers that recursively trigger themselves will loop until the
-		// session disconnects. The "from dispatched" constructor variant
-		// flags the session so chained TriggerAction calls log a debug
-		// line, making such recursion visible in logs (#337).
+		// session disconnects. The dispatched-flagged session emits an
+		// observability log on chained TriggerAction (#337).
 		actionCtx := NewContext(ctx, msg.Action, msg.Data)
 		actionCtx = actionCtx.WithUserID(msg.UserID)
 		actionCtx = actionCtx.WithFlashSetter(state)

--- a/mount.go
+++ b/mount.go
@@ -1525,8 +1525,10 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 	// allowed — each hop runs through a connection event loop, so the
 	// only unbounded failure mode is a handler that recursively
 	// re-triggers itself, which is a caller bug rather than framework
-	// amplification.
-	ctx = ctx.WithSession(newLocalSession(h, connSt.groupID))
+	// amplification. The "from dispatched" constructor variant flags the
+	// session so chained TriggerAction calls log a debug line, making
+	// such recursion visible in logs (#337).
+	ctx = ctx.WithSession(newLocalSessionFromDispatched(h, connSt.groupID))
 	if schema := h.config.Template.formSchema; schema != nil {
 		ctx = ctx.WithFormSchema(schema)
 	}
@@ -1872,11 +1874,13 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 		// caller intent and each hop still runs through the per-connection
 		// event loop (no unbounded recursion on a single goroutine), but
 		// handlers that recursively trigger themselves will loop until the
-		// session disconnects.
+		// session disconnects. The "from dispatched" constructor variant
+		// flags the session so chained TriggerAction calls log a debug
+		// line, making such recursion visible in logs (#337).
 		actionCtx := NewContext(ctx, msg.Action, msg.Data)
 		actionCtx = actionCtx.WithUserID(msg.UserID)
 		actionCtx = actionCtx.WithFlashSetter(state)
-		actionCtx = actionCtx.WithSession(newLocalSession(h, conn.GroupID))
+		actionCtx = actionCtx.WithSession(newLocalSessionFromDispatched(h, conn.GroupID))
 
 		// Dispatch action using Controller+State pattern
 		newState, actionErr := DispatchWithState(h.config.Controller, state.state, actionCtx)

--- a/session_impl.go
+++ b/session_impl.go
@@ -37,10 +37,7 @@ func newLocalSession(handler *liveHandler, groupID string) *localSession {
 	return &localSession{handler: handler, groupID: groupID}
 }
 
-// newLocalSessionFromDispatched constructs a localSession that knows it
-// was created inside a dispatched-action handler. TriggerAction calls on
-// the returned value emit an observability log line so that recursive or
-// runaway chained dispatches are detectable (#337 Option A).
+// newLocalSessionFromDispatched constructs a localSession with fromDispatched=true.
 func newLocalSessionFromDispatched(handler *liveHandler, groupID string) *localSession {
 	return &localSession{handler: handler, groupID: groupID, fromDispatched: true}
 }

--- a/session_impl.go
+++ b/session_impl.go
@@ -20,14 +20,9 @@ import (
 // and authenticated flows both work, because every connection has a
 // groupID assigned at mount time regardless of auth state.
 type localSession struct {
-	handler *liveHandler
-	groupID string
-	// fromDispatched is true when this localSession was constructed inside
-	// a dispatched-action handler (i.e. the action context originated from
-	// EnqueueDispatch, not from an HTTP request or initial WS connect).
-	// When set, TriggerAction emits a slog.Debug line on each invocation so
-	// that infinite chained-dispatch loops are visible in logs (#337).
-	fromDispatched bool
+	handler        *liveHandler
+	groupID        string
+	fromDispatched bool // set by newLocalSessionFromDispatched; enables #337 observability log
 }
 
 // newLocalSession constructs a localSession scoped to a specific session
@@ -37,7 +32,6 @@ func newLocalSession(handler *liveHandler, groupID string) *localSession {
 	return &localSession{handler: handler, groupID: groupID}
 }
 
-// newLocalSessionFromDispatched constructs a localSession with fromDispatched=true.
 func newLocalSessionFromDispatched(handler *liveHandler, groupID string) *localSession {
 	return &localSession{handler: handler, groupID: groupID, fromDispatched: true}
 }
@@ -115,11 +109,8 @@ func (s *localSession) TriggerAction(action string, data map[string]interface{})
 		return fmt.Errorf("livetemplate: session has no groupID")
 	}
 
-	// Observability log for chained TriggerAction calls (#337 Option A).
-	// Emitted before EnqueueDispatch so that an unbounded recursion (a
-	// handler that re-triggers its own action) shows up in logs even if
-	// the WebSocket disconnects before the loop terminates.
 	if s.fromDispatched {
+		// #337: log before EnqueueDispatch so recursion shows up even if the WS drops mid-loop.
 		slog.Debug("Session.TriggerAction called from within a dispatched action",
 			slog.String("component", "local_session"),
 			slog.String("group_id", s.groupID),

--- a/session_impl.go
+++ b/session_impl.go
@@ -22,6 +22,12 @@ import (
 type localSession struct {
 	handler *liveHandler
 	groupID string
+	// fromDispatched is true when this localSession was constructed inside
+	// a dispatched-action handler (i.e. the action context originated from
+	// EnqueueDispatch, not from an HTTP request or initial WS connect).
+	// When set, TriggerAction emits a slog.Debug line on each invocation so
+	// that infinite chained-dispatch loops are visible in logs (#337).
+	fromDispatched bool
 }
 
 // newLocalSession constructs a localSession scoped to a specific session
@@ -29,6 +35,14 @@ type localSession struct {
 // to store in a controller across goroutines.
 func newLocalSession(handler *liveHandler, groupID string) *localSession {
 	return &localSession{handler: handler, groupID: groupID}
+}
+
+// newLocalSessionFromDispatched constructs a localSession that knows it
+// was created inside a dispatched-action handler. TriggerAction calls on
+// the returned value emit an observability log line so that recursive or
+// runaway chained dispatches are detectable (#337 Option A).
+func newLocalSessionFromDispatched(handler *liveHandler, groupID string) *localSession {
+	return &localSession{handler: handler, groupID: groupID, fromDispatched: true}
 }
 
 // TriggerAction dispatches a server-initiated action to every connection
@@ -102,6 +116,18 @@ func (s *localSession) TriggerAction(action string, data map[string]interface{})
 	}
 	if s.groupID == "" {
 		return fmt.Errorf("livetemplate: session has no groupID")
+	}
+
+	// Observability log for chained TriggerAction calls (#337 Option A).
+	// Emitted before EnqueueDispatch so that an unbounded recursion (a
+	// handler that re-triggers its own action) shows up in logs even if
+	// the WebSocket disconnects before the loop terminates.
+	if s.fromDispatched {
+		slog.Debug("Session.TriggerAction called from within a dispatched action",
+			slog.String("component", "local_session"),
+			slog.String("group_id", s.groupID),
+			slog.String("action", action),
+		)
 	}
 
 	connections := s.handler.registry.GetByGroup(s.groupID)

--- a/session_impl_test.go
+++ b/session_impl_test.go
@@ -225,6 +225,7 @@ type chainedTriggerController struct {
 	secondRan bool
 	chainErr  error
 	done      chan struct{}
+	doneOnce  sync.Once
 	cancelCtx context.Context
 }
 
@@ -263,11 +264,8 @@ func (c *chainedTriggerController) Second(state chainedTriggerState, ctx *Contex
 	state.Second = ctx.GetString("data")
 	c.mu.Lock()
 	c.secondRan = true
-	if c.done != nil {
-		close(c.done)
-		c.done = nil
-	}
 	c.mu.Unlock()
+	c.doneOnce.Do(func() { close(c.done) })
 	return state, nil
 }
 
@@ -276,11 +274,35 @@ func (c *chainedTriggerController) Second(state chainedTriggerState, ctx *Contex
 // ctx.Session().TriggerAction, a slog.Debug line is emitted so that
 // runaway recursive chains are detectable in logs. Calls originating
 // from OnConnect (not dispatched) must NOT log.
+// syncBuf is a thread-safe bytes.Buffer wrapper for capturing slog output
+// from a goroutine the test does not control. bytes.Buffer is not safe
+// for concurrent Write/String, so the slog handler's writes race with the
+// test's assertions under `go test -race`.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
 func TestLocalSession_TriggerActionFromDispatchedLogsDebug(t *testing.T) {
-	// Capture slog output. Replace the default logger for the test, then
-	// restore it via t.Cleanup. Debug level is required because slog.Debug
-	// is filtered out by the default handler level.
-	var buf bytes.Buffer
+	// Capture slog output via a thread-safe wrapper — the slog handler
+	// writes from the dispatch goroutine while assertions read from the
+	// test goroutine, so a plain bytes.Buffer would race under -race.
+	// Replace the default logger for the test, then restore it via
+	// t.Cleanup. Debug level is required because slog.Debug is filtered
+	// out by the default handler level.
+	var buf syncBuf
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	t.Cleanup(func() { slog.SetDefault(prev) })

--- a/session_impl_test.go
+++ b/session_impl_test.go
@@ -269,11 +269,6 @@ func (c *chainedTriggerController) Second(state chainedTriggerState, ctx *Contex
 	return state, nil
 }
 
-// TestLocalSession_TriggerActionFromDispatchedLogsDebug verifies the
-// #337 Option A fix: when a dispatched-action handler calls
-// ctx.Session().TriggerAction, a slog.Debug line is emitted so that
-// runaway recursive chains are detectable in logs. Calls originating
-// from OnConnect (not dispatched) must NOT log.
 // syncBuf is a thread-safe bytes.Buffer wrapper for capturing slog output
 // from a goroutine the test does not control. bytes.Buffer is not safe
 // for concurrent Write/String, so the slog handler's writes race with the
@@ -295,13 +290,21 @@ func (s *syncBuf) String() string {
 	return s.buf.String()
 }
 
+// TestLocalSession_TriggerActionFromDispatchedLogsDebug verifies the
+// #337 Option A fix: when a dispatched-action handler calls
+// ctx.Session().TriggerAction, a slog.Debug line is emitted so that
+// runaway recursive chains are detectable in logs. Calls originating
+// from OnConnect (not dispatched) must NOT log.
+//
+// Note: this test mutates the global slog.Default() via SetDefault. Do
+// not add t.Parallel() here — concurrent tests would race on the global
+// logger. Cleanup restores the previous default.
 func TestLocalSession_TriggerActionFromDispatchedLogsDebug(t *testing.T) {
 	// Capture slog output via a thread-safe wrapper — the slog handler
 	// writes from the dispatch goroutine while assertions read from the
 	// test goroutine, so a plain bytes.Buffer would race under -race.
-	// Replace the default logger for the test, then restore it via
-	// t.Cleanup. Debug level is required because slog.Debug is filtered
-	// out by the default handler level.
+	// Debug level is required because slog.Debug is filtered out by the
+	// default handler level.
 	var buf syncBuf
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))

--- a/session_impl_test.go
+++ b/session_impl_test.go
@@ -1,8 +1,10 @@
 package livetemplate
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -201,5 +203,210 @@ func TestLocalSession_TriggerActionDisconnectedReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no connected sessions") {
 		t.Errorf("Expected 'no connected sessions' in error, got: %v", err)
+	}
+}
+
+// chainedTriggerState exercises the dispatched->TriggerAction->dispatched
+// re-entry path covered by #337. It records both that the dispatched
+// action ran and that the chained call returned without error.
+type chainedTriggerState struct {
+	First  string
+	Second string
+}
+
+// chainedTriggerController spawns an OnConnect goroutine that calls
+// TriggerAction("first", ...). The First handler — invoked through the
+// dispatch queue — chains TriggerAction("second", ...). The flag on the
+// localSession built for the dispatched context should make the second
+// call emit a debug log line; the first call (from OnConnect) should not.
+type chainedTriggerController struct {
+	mu        sync.Mutex
+	firstRan  bool
+	secondRan bool
+	chainErr  error
+	done      chan struct{}
+	cancelCtx context.Context
+}
+
+func (c *chainedTriggerController) OnConnect(state chainedTriggerState, ctx *Context) (chainedTriggerState, error) {
+	sess := ctx.Session()
+	if sess == nil {
+		return state, nil
+	}
+	go func() {
+		select {
+		case <-time.After(50 * time.Millisecond):
+		case <-c.cancelCtx.Done():
+			return
+		}
+		_ = sess.TriggerAction("first", map[string]interface{}{"data": "from-onconnect"})
+	}()
+	return state, nil
+}
+
+func (c *chainedTriggerController) First(state chainedTriggerState, ctx *Context) (chainedTriggerState, error) {
+	state.First = ctx.GetString("data")
+	c.mu.Lock()
+	c.firstRan = true
+	c.mu.Unlock()
+	// Chained TriggerAction from inside a dispatched handler — this is the
+	// invocation that should emit the #337 observability log line.
+	if sess := ctx.Session(); sess != nil {
+		c.mu.Lock()
+		c.chainErr = sess.TriggerAction("second", map[string]interface{}{"data": "chained"})
+		c.mu.Unlock()
+	}
+	return state, nil
+}
+
+func (c *chainedTriggerController) Second(state chainedTriggerState, ctx *Context) (chainedTriggerState, error) {
+	state.Second = ctx.GetString("data")
+	c.mu.Lock()
+	c.secondRan = true
+	if c.done != nil {
+		close(c.done)
+		c.done = nil
+	}
+	c.mu.Unlock()
+	return state, nil
+}
+
+// TestLocalSession_TriggerActionFromDispatchedLogsDebug verifies the
+// #337 Option A fix: when a dispatched-action handler calls
+// ctx.Session().TriggerAction, a slog.Debug line is emitted so that
+// runaway recursive chains are detectable in logs. Calls originating
+// from OnConnect (not dispatched) must NOT log.
+func TestLocalSession_TriggerActionFromDispatchedLogsDebug(t *testing.T) {
+	// Capture slog output. Replace the default logger for the test, then
+	// restore it via t.Cleanup. Debug level is required because slog.Debug
+	// is filtered out by the default handler level.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	auth := &fixedUserAuth{groupID: "chained-trigger-group", userID: "chained-user"}
+
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.First}}|{{.Second}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ctrl := &chainedTriggerController{
+		done:      make(chan struct{}),
+		cancelCtx: cancelCtx,
+	}
+	handler := tmpl.Handle(ctrl, AsState(&chainedTriggerState{}))
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	ws, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Drain server-push frames in the background. We don't care about
+	// their content; we only need the WebSocket reader to keep up with
+	// the dispatcher so EnqueueDispatch isn't backpressured. The reader
+	// exits on socket close (deferred above) or read timeout.
+	go func() {
+		for {
+			if err := ws.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+				return
+			}
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ctrl.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("chained TriggerAction did not run within timeout")
+	}
+
+	ctrl.mu.Lock()
+	firstRan := ctrl.firstRan
+	secondRan := ctrl.secondRan
+	chainErr := ctrl.chainErr
+	ctrl.mu.Unlock()
+
+	if !firstRan {
+		t.Fatal("first action handler did not run")
+	}
+	if !secondRan {
+		t.Fatal("second (chained) action handler did not run")
+	}
+	if chainErr != nil {
+		t.Fatalf("chained TriggerAction returned error: %v", chainErr)
+	}
+
+	// Assert: the chained TriggerAction inside First emitted the debug log.
+	logged := buf.String()
+	if !strings.Contains(logged, "Session.TriggerAction called from within a dispatched action") {
+		t.Errorf("expected #337 Option A debug log, not found. Captured:\n%s", logged)
+	}
+	// Confirm the action name in the log is "second" (the chained call).
+	// The OnConnect-originated "first" call must NOT log, so a "action=first"
+	// debug line should be absent.
+	if !strings.Contains(logged, "action=second") {
+		t.Errorf("expected log to reference action=second, got:\n%s", logged)
+	}
+	if strings.Contains(logged, "action=first") &&
+		strings.Contains(logged, "Session.TriggerAction called from within a dispatched action") {
+		// Both could appear if the message text matched independently; check
+		// the more specific case: same line containing both.
+		for _, line := range strings.Split(logged, "\n") {
+			if strings.Contains(line, "Session.TriggerAction called from within a dispatched action") &&
+				strings.Contains(line, "action=first") {
+				t.Errorf("OnConnect-originated TriggerAction(first) must NOT log; got line: %s", line)
+			}
+		}
+	}
+}
+
+// TestLocalSession_FromDispatchedFlag is a structural fallback: it
+// verifies the constructor variant sets the fromDispatched flag,
+// independent of slog capture. If the integration test above is brittle,
+// this still validates the wiring change.
+func TestLocalSession_FromDispatchedFlag(t *testing.T) {
+	auth := &fixedUserAuth{groupID: "g", userID: "u"}
+	tmpl, err := New("t", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div></div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	handler := tmpl.Handle(
+		&triggerActionTestController{done: make(chan struct{}), cancelCtx: context.Background()},
+		AsState(&triggerActionTestState{}),
+	)
+	h, ok := handler.(*liveHandler)
+	if !ok {
+		t.Fatalf("Handle() returned unexpected concrete type %T", handler)
+	}
+
+	plain := newLocalSession(h, "g")
+	if plain.fromDispatched {
+		t.Error("newLocalSession should produce fromDispatched=false")
+	}
+
+	dispatched := newLocalSessionFromDispatched(h, "g")
+	if !dispatched.fromDispatched {
+		t.Error("newLocalSessionFromDispatched should produce fromDispatched=true")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a `slog.Debug` line each time `Session.TriggerAction` is called from a context that was itself built from a dispatched action — making infinite-loop chained TriggerAction patterns (e.g., `ctx.Session().TriggerAction("self", nil)`) detectable **when debug logging is enabled** (default handler level is `Info`, so operators must lower their level to surface this).
- Implementation: new unexported `localSession.fromDispatched` flag + `newLocalSessionFromDispatched` constructor; wired into `handleDispatchedAction` (mount.go ~1531) and `handleServerActionMessage` (mount.go ~1883). Initial WS connect, HTTP POST action, and upload completion paths use `newLocalSession` and remain silent.
- Options B (depth counter) and C (rate limiter) are explicitly out of scope per the issue's design-tradeoff caveats and tracked separately.

## Test plan

- [x] `go test ./... -timeout=300s` passes
- [x] `go test -race -count=10` confirms no data races on the slog capture or controller state
- [x] Pre-commit hook passes (no `--no-verify`)
- [x] `session_impl_test.go` exercises both the dispatched-context (logs) and non-dispatched (silent) paths

Addresses #337 (Option A); Options B (depth counter) / C (rate limiter) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)