### PR TITLE
feat(capabilities): advertise validate, upload, progressive_enhancement (#252)

### DIFF
--- a/dispatch.go
+++ b/dispatch.go
@@ -13,8 +13,26 @@ import (
 // ErrMethodNotFound is returned when Dispatch cannot find a method matching the action.
 var ErrMethodNotFound = errors.New("method not found for action")
 
-// CapabilityChange is the capability name for controllers with a Change() method.
-const CapabilityChange = "change"
+// Capability names advertised in ResponseMetadata.Capabilities so the client
+// can adapt its behavior to features the server supports.
+//
+// A capability should only be in the list if the client changes its behavior
+// based on it. Detection happens once at Handle() time.
+const (
+	// CapabilityChange is set when the controller has a Change() method,
+	// detected via reflection (see HasActionMethod).
+	CapabilityChange = "change"
+	// CapabilityValidate is set when the controller has a Validate() method,
+	// detected via reflection (see HasActionMethod).
+	CapabilityValidate = "validate"
+	// CapabilityUpload is set when the template has at least one upload
+	// configuration registered via WithUpload.
+	CapabilityUpload = "upload"
+	// CapabilityProgressiveEnhancement is set when non-JS form fallback is
+	// enabled (default: enabled). Clients can use it to know the server
+	// handles plain POSTs end-to-end.
+	CapabilityProgressiveEnhancement = "progressive_enhancement"
+)
 
 // DispatchError provides context about a failed dispatch.
 type DispatchError struct {
@@ -132,6 +150,32 @@ func HasActionMethod(controller interface{}, state interface{}, action string) b
 		stateType = stateType.Elem()
 	}
 	return getMethodIndexNewSignature(controllerType, stateType, action) >= 0
+}
+
+// detectCapabilities builds the capability list advertised to the client.
+// Order is fixed (change, validate, upload, progressive_enhancement) so wire
+// output is deterministic.
+//
+// Returns nil when no capabilities apply so JSON marshaling can omit the
+// field via `omitempty`.
+func detectCapabilities(controller interface{}, state interface{}, cfg *mountConfig) []string {
+	caps := make([]string, 0, 4)
+	if HasActionMethod(controller, state, CapabilityChange) {
+		caps = append(caps, CapabilityChange)
+	}
+	if HasActionMethod(controller, state, CapabilityValidate) {
+		caps = append(caps, CapabilityValidate)
+	}
+	if len(cfg.UploadConfigs) > 0 {
+		caps = append(caps, CapabilityUpload)
+	}
+	if cfg.ProgressiveEnhancement {
+		caps = append(caps, CapabilityProgressiveEnhancement)
+	}
+	if len(caps) == 0 {
+		return nil
+	}
+	return caps
 }
 
 // methodCacheNewSignature caches method lookups for new signature

--- a/handle_test.go
+++ b/handle_test.go
@@ -1746,8 +1746,60 @@ func (c *capControllerWithoutChange) Submit(state capState, ctx *Context) (capSt
 	return state, nil
 }
 
+type capControllerWithValidate struct{}
+
+func (c *capControllerWithValidate) Validate(state capState, ctx *Context) (capState, error) {
+	return state, nil
+}
+
+type capControllerWithChangeAndValidate struct{}
+
+func (c *capControllerWithChangeAndValidate) Change(state capState, ctx *Context) (capState, error) {
+	return state, nil
+}
+
+func (c *capControllerWithChangeAndValidate) Validate(state capState, ctx *Context) (capState, error) {
+	return state, nil
+}
+
+// readCapabilities issues an Accept: application/json request to the handler
+// and returns the capabilities slice from the initial render meta. Any nil
+// return signals that capabilities was omitted.
+func readCapabilities(t *testing.T, handler http.Handler) []interface{} {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", rec.Code)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response JSON: %v", err)
+	}
+	meta, ok := resp["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected meta field in response")
+	}
+	caps, ok := meta["capabilities"].([]interface{})
+	if !ok {
+		return nil
+	}
+	return caps
+}
+
+func capsContain(caps []interface{}, name string) bool {
+	for _, c := range caps {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
 func TestHandle_CapabilitiesInInitialRender(t *testing.T) {
-	tmpl, err := New("test")
+	tmpl, err := New("test", WithProgressiveEnhancement(false))
 	if err != nil {
 		t.Fatalf("New failed: %v", err)
 	}
@@ -1756,43 +1808,19 @@ func TestHandle_CapabilitiesInInitialRender(t *testing.T) {
 		t.Fatalf("Parse failed: %v", err)
 	}
 
-	ctrl := &capControllerWithChange{}
-	state := AsState(&capState{Name: "test"})
+	handler := tmpl.Handle(&capControllerWithChange{}, AsState(&capState{Name: "test"}))
 
-	handler := tmpl.Handle(ctrl, state)
-
-	req := httptest.NewRequest("GET", "/", nil)
-	req.Header.Set("Accept", "application/json")
-	rec := httptest.NewRecorder()
-
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("Expected status 200, got %d", rec.Code)
-	}
-
-	var resp map[string]interface{}
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("Failed to parse response JSON: %v", err)
-	}
-
-	meta, ok := resp["meta"].(map[string]interface{})
-	if !ok {
-		t.Fatal("Expected meta field in response")
-	}
-
-	caps, ok := meta["capabilities"].([]interface{})
-	if !ok {
-		t.Fatal("Expected capabilities array in meta")
-	}
-
+	caps := readCapabilities(t, handler)
 	if len(caps) != 1 || caps[0] != "change" {
 		t.Errorf("Expected capabilities=[\"change\"], got %v", caps)
 	}
 }
 
 func TestHandle_NoCapabilitiesWithoutChangeMethod(t *testing.T) {
-	tmpl, err := New("test")
+	// Disable progressive enhancement so the only candidate capability is
+	// "change". With it disabled and no Change() method, no capabilities
+	// should be advertised.
+	tmpl, err := New("test", WithProgressiveEnhancement(false))
 	if err != nil {
 		t.Fatalf("New failed: %v", err)
 	}
@@ -1801,38 +1829,16 @@ func TestHandle_NoCapabilitiesWithoutChangeMethod(t *testing.T) {
 		t.Fatalf("Parse failed: %v", err)
 	}
 
-	ctrl := &capControllerWithoutChange{}
-	state := AsState(&capState{Name: "test"})
+	handler := tmpl.Handle(&capControllerWithoutChange{}, AsState(&capState{Name: "test"}))
 
-	handler := tmpl.Handle(ctrl, state)
-
-	req := httptest.NewRequest("GET", "/", nil)
-	req.Header.Set("Accept", "application/json")
-	rec := httptest.NewRecorder()
-
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("Expected status 200, got %d", rec.Code)
-	}
-
-	var resp map[string]interface{}
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("Failed to parse response JSON: %v", err)
-	}
-
-	meta, ok := resp["meta"].(map[string]interface{})
-	if !ok {
-		t.Fatal("Expected meta field in response")
-	}
-
-	if _, exists := meta["capabilities"]; exists {
-		t.Error("Expected capabilities to be omitted when controller has no Change() method")
+	caps := readCapabilities(t, handler)
+	if caps != nil {
+		t.Errorf("Expected capabilities to be omitted, got %v", caps)
 	}
 }
 
 func TestHandle_CapabilitiesInWebSocketInitialRender(t *testing.T) {
-	tmpl, err := New("test")
+	tmpl, err := New("test", WithProgressiveEnhancement(false))
 	if err != nil {
 		t.Fatalf("New failed: %v", err)
 	}
@@ -1882,6 +1888,140 @@ func TestHandle_CapabilitiesInWebSocketInitialRender(t *testing.T) {
 
 	if len(caps) != 1 || caps[0] != "change" {
 		t.Errorf("Expected capabilities=[\"change\"], got %v", caps)
+	}
+}
+
+func TestHandle_CapabilitiesValidateDetected(t *testing.T) {
+	tmpl, err := New("test", WithProgressiveEnhancement(false))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Name}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&capControllerWithValidate{}, AsState(&capState{Name: "test"}))
+
+	caps := readCapabilities(t, handler)
+	if !capsContain(caps, "validate") {
+		t.Errorf("Expected capabilities to include \"validate\", got %v", caps)
+	}
+	if capsContain(caps, "change") {
+		t.Errorf("Did not expect \"change\" without Change() method, got %v", caps)
+	}
+}
+
+func TestHandle_CapabilitiesValidateAndChange(t *testing.T) {
+	tmpl, err := New("test", WithProgressiveEnhancement(false))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Name}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&capControllerWithChangeAndValidate{}, AsState(&capState{Name: "test"}))
+
+	caps := readCapabilities(t, handler)
+	if !capsContain(caps, "change") || !capsContain(caps, "validate") {
+		t.Errorf("Expected both \"change\" and \"validate\", got %v", caps)
+	}
+}
+
+func TestHandle_CapabilitiesValidateOmittedWithoutMethod(t *testing.T) {
+	tmpl, err := New("test", WithProgressiveEnhancement(false))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Name}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&capControllerWithChange{}, AsState(&capState{Name: "test"}))
+
+	caps := readCapabilities(t, handler)
+	if capsContain(caps, "validate") {
+		t.Errorf("Did not expect \"validate\" without Validate() method, got %v", caps)
+	}
+}
+
+func TestHandle_CapabilitiesUploadDetected(t *testing.T) {
+	tmpl, err := New("test",
+		WithProgressiveEnhancement(false),
+		WithUpload("attachment", UploadConfig{}),
+	)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Name}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&capControllerWithoutChange{}, AsState(&capState{Name: "test"}))
+
+	caps := readCapabilities(t, handler)
+	if !capsContain(caps, "upload") {
+		t.Errorf("Expected capabilities to include \"upload\", got %v", caps)
+	}
+}
+
+func TestHandle_CapabilitiesUploadOmittedWithoutConfig(t *testing.T) {
+	tmpl, err := New("test", WithProgressiveEnhancement(false))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Name}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&capControllerWithChange{}, AsState(&capState{Name: "test"}))
+
+	caps := readCapabilities(t, handler)
+	if capsContain(caps, "upload") {
+		t.Errorf("Did not expect \"upload\" without UploadConfigs, got %v", caps)
+	}
+}
+
+func TestHandle_CapabilitiesProgressiveEnhancementDefault(t *testing.T) {
+	// ProgressiveEnhancement defaults to true and is advertised whenever the
+	// option is enabled.
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Name}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&capControllerWithoutChange{}, AsState(&capState{Name: "test"}))
+
+	caps := readCapabilities(t, handler)
+	if !capsContain(caps, "progressive_enhancement") {
+		t.Errorf("Expected capabilities to include \"progressive_enhancement\" by default, got %v", caps)
+	}
+}
+
+func TestHandle_CapabilitiesProgressiveEnhancementDisabled(t *testing.T) {
+	tmpl, err := New("test", WithProgressiveEnhancement(false))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Name}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&capControllerWithoutChange{}, AsState(&capState{Name: "test"}))
+
+	caps := readCapabilities(t, handler)
+	if capsContain(caps, "progressive_enhancement") {
+		t.Errorf("Did not expect \"progressive_enhancement\" when disabled, got %v", caps)
 	}
 }
 
@@ -1966,7 +2106,10 @@ func TestFaviconDoesNotResetState(t *testing.T) {
 }
 
 func TestHandle_NoCapabilitiesInWebSocketWithoutChangeMethod(t *testing.T) {
-	tmpl, err := New("test")
+	// Disable progressive enhancement so the only candidate capability is
+	// "change". With it disabled and no Change() method, no capabilities
+	// should be advertised.
+	tmpl, err := New("test", WithProgressiveEnhancement(false))
 	if err != nil {
 		t.Fatalf("New failed: %v", err)
 	}

--- a/template.go
+++ b/template.go
@@ -1512,9 +1512,7 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 		HasSync:                HasActionMethod(controller, state.Inner(), syncMethodName),
 	}
 
-	if HasActionMethod(controller, state.Inner(), CapabilityChange) {
-		mountCfg.Capabilities = []string{CapabilityChange}
-	}
+	mountCfg.Capabilities = detectCapabilities(controller, state.Inner(), &mountCfg)
 
 	limits := session.NewConnectionLimits(mountCfg.MaxConnections, mountCfg.MaxConnectionsPerGroup)
 	metrics := observe.NewMetrics(slog.Default())


### PR DESCRIPTION
## Summary

`ResponseMetadata.Capabilities` was set up by #251 to advertise server features the client can adapt to. Currently only `"change"` is advertised. Extend with three more (also from #252):

- **`"validate"`** — detected via reflection; controller has a `Validate()` method
- **`"upload"`** — detected from `mountCfg.UploadConfigs` (any `WithUpload` registered)
- **`"progressive_enhancement"`** — from `mountCfg.ProgressiveEnhancement` (default: `true`)

Detection is centralized in `dispatch.go`'s new `detectCapabilities()` helper so wire order is deterministic. Returns nil when empty so `omitempty` drops the field.

### Behavior change to call out

**`progressive_enhancement` is now advertised by default** because `mountCfg.ProgressiveEnhancement` defaults to `true`. Any existing application that previously got an empty capabilities list when no `Change()` method exists will now receive `["progressive_enhancement"]`. The pre-existing `TestHandle_NoCapabilitiesInWebSocketWithoutChangeMethod` test was updated to use `WithProgressiveEnhancement(false)` to keep its "no capabilities" assertion valid — the same fix any downstream test asserting an empty capabilities list will need to apply. (See companion PR [examples#98](https://github.com/livetemplate/examples/pull/98) which made the live-preview test tolerant.)

## Test plan

- [x] `TestHandle_CapabilitiesValidateDetected` / `_ValidateOmittedWithoutMethod`
- [x] `TestHandle_CapabilitiesUploadDetected` / `_UploadOmittedWithoutConfig`
- [x] `TestHandle_CapabilitiesProgressiveEnhancementDefault`
- [x] Pre-existing `TestHandle_NoCapabilitiesInWebSocketWithoutChangeMethod` updated to use `WithProgressiveEnhancement(false)` to keep the "no capabilities" assertion valid
- [x] `go test ./... -timeout=300s` passes
- [x] Pre-commit hook passes (no `--no-verify`)
- [x] Cross-repo CI passes (after companion examples-repo PR #98 merged)

Closes #252 (extends #251)

🤖 Generated with [Claude Code](https://claude.com/claude-code)