### PR TITLE
feat(send): explicit submitter field on the wire (#237 Phase 1)

### DIFF
--- a/internal/send/message.go
+++ b/internal/send/message.go
@@ -12,6 +12,9 @@ import (
 const wsTextMessage = 1 // RFC 6455 text message type (mirrors WSTextMessage in root package)
 
 // ActionMessage represents an action message from the client (internal protocol).
+// Wire-format note: HTTP form paths use the form key "lvt-submitter"; JSON
+// (HTTP and WS) paths use the top-level key "submitter". Different conventions
+// for different envelopes — form fields take the lvt- prefix, JSON keys do not.
 type ActionMessage struct {
 	Action    string                 `json:"action"`              // Action name, may include store prefix (e.g., "counter.increment")
 	Submitter string                 `json:"submitter,omitempty"` // Optional explicit submitter name (e.g. SubmitEvent.submitter.name); used as Action when Action is empty.
@@ -118,7 +121,7 @@ func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 	// Get action from lvt-action field (explicit routing for progressive enhancement)
 	msg.Action = r.FormValue("lvt-action")
 	// Capture explicit submitter (client-emitted SubmitEvent.submitter.name);
-	// resolveSubmitterFallback below promotes this to msg.Action only when
+	// resolveSubmitterFallback (called immediately after) promotes this to msg.Action only when
 	// msg.Action is empty, so lvt-action always wins. Read here (before the
 	// jsonDataParsed branch) so submitter routing applies whether or not a
 	// JSON "data" envelope is present.
@@ -194,7 +197,7 @@ func parseURLEncodedForm(r *http.Request) (ActionMessage, error) {
 	// Get action from lvt-action field (explicit routing for progressive enhancement)
 	msg.Action = r.FormValue("lvt-action")
 	// Capture explicit submitter (client-emitted SubmitEvent.submitter.name);
-	// resolveSubmitterFallback below promotes this to msg.Action only when
+	// resolveSubmitterFallback (called immediately after) promotes this to msg.Action only when
 	// msg.Action is empty, so lvt-action always wins.
 	msg.Submitter = r.FormValue("lvt-submitter")
 	resolveSubmitterFallback(&msg)

--- a/internal/send/message.go
+++ b/internal/send/message.go
@@ -13,8 +13,18 @@ const wsTextMessage = 1 // RFC 6455 text message type (mirrors WSTextMessage in 
 
 // ActionMessage represents an action message from the client (internal protocol).
 type ActionMessage struct {
-	Action string                 `json:"action"` // Action name, may include store prefix (e.g., "counter.increment")
-	Data   map[string]interface{} `json:"data"`   // All values from forms, inputs, data attributes, etc.
+	Action    string                 `json:"action"`              // Action name, may include store prefix (e.g., "counter.increment")
+	Submitter string                 `json:"submitter,omitempty"` // Optional explicit submitter name (e.g. SubmitEvent.submitter.name); used as Action when Action is empty.
+	Data      map[string]interface{} `json:"data"`                // All values from forms, inputs, data attributes, etc.
+}
+
+// resolveSubmitterFallback fills msg.Action from msg.Submitter when Action
+// is empty, so an explicit `submitter` field on the wire is treated as the
+// action of last resort. Idempotent; safe to call from any parser.
+func resolveSubmitterFallback(msg *ActionMessage) {
+	if msg.Action == "" && msg.Submitter != "" {
+		msg.Action = msg.Submitter
+	}
 }
 
 // ParseActionFromHTTP parses an action message from HTTP POST request body (internal protocol).
@@ -41,6 +51,8 @@ func ParseActionFromHTTP(r *http.Request) (ActionMessage, error) {
 	if err := jsonutil.API.NewDecoder(r.Body).Decode(&msg); err != nil {
 		return ActionMessage{}, fmt.Errorf("failed to parse action: %w", err)
 	}
+
+	resolveSubmitterFallback(&msg)
 
 	// Ensure data map is initialized
 	if msg.Data == nil {
@@ -82,6 +94,17 @@ func detectSubmitButtonName(values map[string][]string, actionFields map[string]
 //
 // When a JSON "data" blob is present, it takes precedence. Otherwise,
 // individual form fields are read, matching parseURLEncodedForm behavior.
+//
+// Action resolution order (first match wins):
+//  1. "lvt-action" form field (legacy explicit routing for progressive enhancement)
+//  2. "lvt-submitter" form field (explicit client-emitted SubmitEvent.submitter.name)
+//  3. Button name routing: a form field with an empty string value is treated as a
+//     submit button whose name is the action (standard HTML: <button name="increment">)
+//  4. Empty string (server defaults to "submit" via applyDefaultAction)
+//
+// Both lvt-action and lvt-submitter are read BEFORE the JSON "data" branch so
+// they take precedence over the heuristic regardless of whether a JSON "data"
+// envelope is present.
 func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 	var msg ActionMessage
 
@@ -94,6 +117,13 @@ func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 
 	// Get action from lvt-action field (explicit routing for progressive enhancement)
 	msg.Action = r.FormValue("lvt-action")
+	// Capture explicit submitter (client-emitted SubmitEvent.submitter.name);
+	// resolveSubmitterFallback below promotes this to msg.Action only when
+	// msg.Action is empty, so lvt-action always wins. Read here (before the
+	// jsonDataParsed branch) so submitter routing applies whether or not a
+	// JSON "data" envelope is present.
+	msg.Submitter = r.FormValue("lvt-submitter")
+	resolveSubmitterFallback(&msg)
 
 	// Try to get data from JSON-encoded form field (client library format).
 	// When present, JSON data takes precedence over individual form fields.
@@ -110,7 +140,7 @@ func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 	// This handles browser-native multipart submissions where text fields are
 	// sent as separate form fields alongside file uploads.
 	if !jsonDataParsed {
-		actionFields := map[string]bool{"lvt-action": true, "data": true}
+		actionFields := map[string]bool{"lvt-action": true, "lvt-submitter": true, "data": true}
 
 		if msg.Action == "" && r.MultipartForm != nil {
 			if name := detectSubmitButtonName(r.MultipartForm.Value, actionFields); name != "" {
@@ -146,9 +176,10 @@ func parseMultipartForm(r *http.Request) (ActionMessage, error) {
 //
 // Action resolution order (first match wins):
 //  1. "lvt-action" form field (legacy explicit routing for progressive enhancement)
-//  2. Button name routing: a form field with an empty string value is treated as a
+//  2. "lvt-submitter" form field (explicit client-emitted SubmitEvent.submitter.name)
+//  3. Button name routing: a form field with an empty string value is treated as a
 //     submit button whose name is the action (standard HTML: <button name="increment">)
-//  3. Empty string (server defaults to "submit" via applyDefaultAction)
+//  4. Empty string (server defaults to "submit" via applyDefaultAction)
 //
 // Note: "action" is NOT reserved — it flows through as normal form data.
 // For explicit routing, use lvt-form:action attribute (client-side) or
@@ -162,9 +193,14 @@ func parseURLEncodedForm(r *http.Request) (ActionMessage, error) {
 
 	// Get action from lvt-action field (explicit routing for progressive enhancement)
 	msg.Action = r.FormValue("lvt-action")
+	// Capture explicit submitter (client-emitted SubmitEvent.submitter.name);
+	// resolveSubmitterFallback below promotes this to msg.Action only when
+	// msg.Action is empty, so lvt-action always wins.
+	msg.Submitter = r.FormValue("lvt-submitter")
+	resolveSubmitterFallback(&msg)
 
 	// Action routing fields to exclude from data
-	actionFields := map[string]bool{"lvt-action": true}
+	actionFields := map[string]bool{"lvt-action": true, "lvt-submitter": true}
 
 	if msg.Action == "" {
 		if name := detectSubmitButtonName(r.Form, actionFields); name != "" {
@@ -199,6 +235,8 @@ func ParseActionFromWebSocket(data []byte) (ActionMessage, error) {
 	if err := jsonutil.API.Unmarshal(data, &msg); err != nil {
 		return ActionMessage{}, fmt.Errorf("failed to parse action: %w", err)
 	}
+
+	resolveSubmitterFallback(&msg)
 
 	// Ensure data map is initialized
 	if msg.Data == nil {

--- a/internal/send/message_test.go
+++ b/internal/send/message_test.go
@@ -1056,6 +1056,33 @@ func TestParseActionFromHTTP_Multipart_ExplicitSubmitter(t *testing.T) {
 		}
 	})
 
+	// Empty lvt-submitter must not bypass the heuristic. Documents the contract:
+	// resolveSubmitterFallback's predicate is `Submitter != ""`, not just `Submitter`,
+	// so an empty string never short-circuits the heuristic tiebreaker.
+	t.Run("empty lvt-submitter is no-op; heuristic still tiebreaks", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		multipartField(t, writer, "lvt-submitter", "")
+		multipartField(t, writer, "save", "") // empty-value button
+		multipartField(t, writer, "title", "hello")
+		closeMultipart(t, writer)
+
+		req := httptest.NewRequest("POST", "/", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+
+		msg, err := ParseActionFromHTTP(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if msg.Action != "save" {
+			t.Errorf("Action = %q, want %q (heuristic should resolve when lvt-submitter is empty)", msg.Action, "save")
+		}
+		if msg.Submitter != "" {
+			t.Errorf("Submitter = %q, want empty", msg.Submitter)
+		}
+	})
+
 	// Proposal Out of Scope #6: routing-layer fields live at the envelope level;
 	// a "submitter" key inside the JSON data blob is user data, not routing.
 	t.Run("form lvt-submitter wins over submitter inside JSON data blob", func(t *testing.T) {

--- a/internal/send/message_test.go
+++ b/internal/send/message_test.go
@@ -804,6 +804,357 @@ func TestQueryParamsToData(t *testing.T) {
 	}
 }
 
+// TestParseActionFromHTTP_URLEncoded_ExplicitSubmitter covers Phase 1 of the
+// explicit-submitter proposal (docs/proposals/explicit-submitter.md): the
+// "lvt-submitter" form field is the explicit, client-emitted SubmitEvent.
+// submitter.name. It populates msg.Action when no lvt-action is provided,
+// is preserved on msg.Submitter for diagnostics, is stripped from msg.Data,
+// and takes precedence over the empty-value heuristic in collision cases
+// the heuristic gets wrong today.
+func TestParseActionFromHTTP_URLEncoded_ExplicitSubmitter(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		wantAction    string
+		wantSubmitter string
+		wantData      map[string]interface{}
+	}{
+		{
+			name:          "explicit submitter populates action",
+			body:          "lvt-submitter=save&title=hello",
+			wantAction:    "save",
+			wantSubmitter: "save",
+			wantData: map[string]interface{}{
+				"title": "hello",
+			},
+		},
+		{
+			name:          "lvt-action takes precedence over lvt-submitter",
+			body:          "lvt-action=foo&lvt-submitter=bar&title=hello",
+			wantAction:    "foo",
+			wantSubmitter: "bar",
+			wantData: map[string]interface{}{
+				"title": "hello",
+			},
+		},
+		{
+			// Heuristic alone would misroute to "search" (sole empty-value field).
+			// Explicit submitter wins and routes to "save". The empty "search"
+			// input is preserved as user data.
+			name:          "explicit submitter beats empty user input collision",
+			body:          "search=&lvt-submitter=save&title=hello",
+			wantAction:    "save",
+			wantSubmitter: "save",
+			wantData: map[string]interface{}{
+				"search": "",
+				"title":  "hello",
+			},
+		},
+		{
+			// Heuristic returns "" (ambiguous) for two empty-value fields.
+			// Explicit submitter resolves the ambiguity.
+			name:          "explicit submitter resolves ambiguous heuristic",
+			body:          "delete=&archive=&lvt-submitter=delete&title=hello",
+			wantAction:    "delete",
+			wantSubmitter: "delete",
+			wantData: map[string]interface{}{
+				"delete":  "",
+				"archive": "",
+				"title":   "hello",
+			},
+		},
+		{
+			// Documented heuristic workaround: <button name="action"> is excluded
+			// from the empty-value scan to avoid <form action> ambiguity. An
+			// explicit submitter routes correctly even when the clicked button
+			// is named "action".
+			name:          "explicit submitter resolves <button name=action> collision",
+			body:          "action=&lvt-submitter=action&title=hello",
+			wantAction:    "action",
+			wantSubmitter: "action",
+			wantData: map[string]interface{}{
+				"action": "",
+				"title":  "hello",
+			},
+		},
+		{
+			// lvt-submitter must not be echoed back into msg.Data.
+			name:          "lvt-submitter is consumed, not surfaced as user data",
+			body:          "lvt-submitter=save&name=Jane",
+			wantAction:    "save",
+			wantSubmitter: "save",
+			wantData: map[string]interface{}{
+				"name": "Jane",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			msg, err := ParseActionFromHTTP(req)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if msg.Action != tt.wantAction {
+				t.Errorf("Action = %q, want %q", msg.Action, tt.wantAction)
+			}
+			if msg.Submitter != tt.wantSubmitter {
+				t.Errorf("Submitter = %q, want %q", msg.Submitter, tt.wantSubmitter)
+			}
+			if _, ok := msg.Data["lvt-submitter"]; ok {
+				t.Errorf("lvt-submitter must not appear in msg.Data, got %v", msg.Data["lvt-submitter"])
+			}
+
+			for key, want := range tt.wantData {
+				got := msg.Data[key]
+				if got != want {
+					t.Errorf("Data[%q] = %v, want %v", key, got, want)
+				}
+			}
+			for key := range msg.Data {
+				if _, ok := tt.wantData[key]; !ok {
+					t.Errorf("Unexpected data field: %q = %v", key, msg.Data[key])
+				}
+			}
+		})
+	}
+}
+
+// TestParseActionFromHTTP_Multipart_ExplicitSubmitter mirrors the URL-encoded
+// explicit-submitter coverage for multipart form bodies. It exercises both the
+// individual-fields branch and the JSON-data-envelope branch (the proposal
+// requires lvt-submitter to take precedence even when a JSON "data" envelope
+// is present).
+func TestParseActionFromHTTP_Multipart_ExplicitSubmitter(t *testing.T) {
+	t.Run("submitter populates action with individual fields", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		multipartField(t, writer, "lvt-submitter", "save")
+		multipartField(t, writer, "title", "hello")
+		closeMultipart(t, writer)
+
+		req := httptest.NewRequest("POST", "/", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+
+		msg, err := ParseActionFromHTTP(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if msg.Action != "save" {
+			t.Errorf("Action = %q, want %q", msg.Action, "save")
+		}
+		if msg.Submitter != "save" {
+			t.Errorf("Submitter = %q, want %q", msg.Submitter, "save")
+		}
+		if _, ok := msg.Data["lvt-submitter"]; ok {
+			t.Error("lvt-submitter must not appear in msg.Data")
+		}
+		if msg.Data["title"] != "hello" {
+			t.Errorf("Data[title] = %v, want %q", msg.Data["title"], "hello")
+		}
+	})
+
+	t.Run("lvt-action takes precedence over lvt-submitter", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		multipartField(t, writer, "lvt-action", "foo")
+		multipartField(t, writer, "lvt-submitter", "bar")
+		multipartField(t, writer, "title", "hello")
+		closeMultipart(t, writer)
+
+		req := httptest.NewRequest("POST", "/", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+
+		msg, err := ParseActionFromHTTP(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if msg.Action != "foo" {
+			t.Errorf("Action = %q, want %q", msg.Action, "foo")
+		}
+		// Submitter is preserved as diagnostic context even when lvt-action wins.
+		if msg.Submitter != "bar" {
+			t.Errorf("Submitter = %q, want %q (preserved as diagnostic)", msg.Submitter, "bar")
+		}
+	})
+
+	t.Run("submitter beats empty user input collision", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		multipartField(t, writer, "search", "") // legitimate empty user input
+		multipartField(t, writer, "lvt-submitter", "save")
+		multipartField(t, writer, "title", "hello")
+		closeMultipart(t, writer)
+
+		req := httptest.NewRequest("POST", "/", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+
+		msg, err := ParseActionFromHTTP(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if msg.Action != "save" {
+			t.Errorf("Action = %q, want %q (heuristic would have misrouted to \"search\")", msg.Action, "save")
+		}
+		if msg.Data["search"] != "" {
+			t.Errorf("Data[search] = %v, want empty string preserved", msg.Data["search"])
+		}
+	})
+
+	t.Run("submitter resolves ambiguous heuristic", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		multipartField(t, writer, "delete", "")
+		multipartField(t, writer, "archive", "")
+		multipartField(t, writer, "lvt-submitter", "delete")
+		multipartField(t, writer, "title", "hello")
+		closeMultipart(t, writer)
+
+		req := httptest.NewRequest("POST", "/", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+
+		msg, err := ParseActionFromHTTP(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if msg.Action != "delete" {
+			t.Errorf("Action = %q, want %q (heuristic ambiguous)", msg.Action, "delete")
+		}
+	})
+
+	t.Run("submitter takes precedence with JSON data envelope", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		multipartField(t, writer, "lvt-submitter", "save")
+		multipartField(t, writer, "data", `{"title":"hello"}`)
+		closeMultipart(t, writer)
+
+		req := httptest.NewRequest("POST", "/", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+
+		msg, err := ParseActionFromHTTP(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if msg.Action != "save" {
+			t.Errorf("Action = %q, want %q (lvt-submitter must win even with JSON data envelope)", msg.Action, "save")
+		}
+		if msg.Data["title"] != "hello" {
+			t.Errorf("Data[title] = %v, want %q", msg.Data["title"], "hello")
+		}
+		if _, ok := msg.Data["lvt-submitter"]; ok {
+			t.Error("lvt-submitter must not appear in msg.Data")
+		}
+	})
+}
+
+// TestParseActionFromWebSocket_Submitter exercises the WS path's submitter
+// fallback: when action="" but submitter is set, the server promotes
+// submitter to action; when action is set, submitter is preserved as
+// diagnostic context but never overrides.
+func TestParseActionFromWebSocket_Submitter(t *testing.T) {
+	tests := []struct {
+		name          string
+		data          string
+		wantAction    string
+		wantSubmitter string
+	}{
+		{
+			name:          "empty action falls back to submitter",
+			data:          `{"action":"","submitter":"X","data":{}}`,
+			wantAction:    "X",
+			wantSubmitter: "X",
+		},
+		{
+			name:          "missing action falls back to submitter",
+			data:          `{"submitter":"X","data":{}}`,
+			wantAction:    "X",
+			wantSubmitter: "X",
+		},
+		{
+			name:          "explicit action wins over submitter",
+			data:          `{"action":"Y","submitter":"X","data":{}}`,
+			wantAction:    "Y",
+			wantSubmitter: "X",
+		},
+		{
+			name:          "no submitter leaves action empty",
+			data:          `{"action":"","data":{}}`,
+			wantAction:    "",
+			wantSubmitter: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseActionFromWebSocket([]byte(tt.data))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if msg.Action != tt.wantAction {
+				t.Errorf("Action = %q, want %q", msg.Action, tt.wantAction)
+			}
+			if msg.Submitter != tt.wantSubmitter {
+				t.Errorf("Submitter = %q, want %q", msg.Submitter, tt.wantSubmitter)
+			}
+		})
+	}
+}
+
+// TestParseActionFromHTTP_JSON_Submitter exercises the JSON HTTP content-type
+// path: the JSON decoder populates ActionMessage.Submitter, and
+// resolveSubmitterFallback fills Action when it would otherwise be empty.
+func TestParseActionFromHTTP_JSON_Submitter(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		wantAction    string
+		wantSubmitter string
+	}{
+		{
+			name:          "empty action falls back to submitter (JSON HTTP)",
+			body:          `{"action":"","submitter":"X","data":{}}`,
+			wantAction:    "X",
+			wantSubmitter: "X",
+		},
+		{
+			name:          "explicit action wins over submitter (JSON HTTP)",
+			body:          `{"action":"Y","submitter":"X","data":{}}`,
+			wantAction:    "Y",
+			wantSubmitter: "X",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			msg, err := ParseActionFromHTTP(req)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if msg.Action != tt.wantAction {
+				t.Errorf("Action = %q, want %q", msg.Action, tt.wantAction)
+			}
+			if msg.Submitter != tt.wantSubmitter {
+				t.Errorf("Submitter = %q, want %q", msg.Submitter, tt.wantSubmitter)
+			}
+		})
+	}
+}
+
 // TestMergeData tests merging of data maps with precedence.
 func TestMergeData(t *testing.T) {
 	tests := []struct {

--- a/internal/send/message_test.go
+++ b/internal/send/message_test.go
@@ -1055,6 +1055,34 @@ func TestParseActionFromHTTP_Multipart_ExplicitSubmitter(t *testing.T) {
 			t.Error("lvt-submitter must not appear in msg.Data")
 		}
 	})
+
+	// Proposal Out of Scope #6: routing-layer fields live at the envelope level;
+	// a "submitter" key inside the JSON data blob is user data, not routing.
+	t.Run("form lvt-submitter wins over submitter inside JSON data blob", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		multipartField(t, writer, "lvt-submitter", "save")
+		multipartField(t, writer, "data", `{"title":"hello","submitter":"other"}`)
+		closeMultipart(t, writer)
+
+		req := httptest.NewRequest("POST", "/", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+
+		msg, err := ParseActionFromHTTP(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if msg.Action != "save" {
+			t.Errorf("Action = %q, want %q (form-level lvt-submitter must win over JSON data submitter)", msg.Action, "save")
+		}
+		if msg.Submitter != "save" {
+			t.Errorf("Submitter = %q, want %q (envelope-level)", msg.Submitter, "save")
+		}
+		if msg.Data["submitter"] != "other" {
+			t.Errorf("Data[submitter] = %v, want %q (user data inside JSON blob, not routing)", msg.Data["submitter"], "other")
+		}
+	})
 }
 
 // TestParseActionFromWebSocket_Submitter exercises the WS path's submitter


### PR DESCRIPTION
## Summary

Implements **Phase 1** of [`docs/proposals/explicit-submitter.md`](https://github.com/livetemplate/livetemplate/blob/main/docs/proposals/explicit-submitter.md) (PR #382): server-side acceptance of an explicit submitter field on the wire, replacing the empty-value button heuristic in collision-prone cases.

**Backwards-compatible.** Old clients keep working via the existing heuristic, which stays as a fallback. New clients (Phase 2, separate PR) will populate `lvt-submitter` (forms) and `submitter` (WS).

Closes the server-side portion of #237 (P1 correctness). Phase 2 (client emits) and Phase 3 (deprecation warning) are separate follow-ups.

## What changed

- `ActionMessage` gains `Submitter string \`json:"submitter,omitempty"\``
- New `resolveSubmitterFallback(msg)` helper: `msg.Action ← msg.Submitter` when `Action` is empty (idempotent, safe to call from any parser)
- All four parsers call it: `ParseActionFromHTTP` (JSON branch), `ParseActionFromWebSocket`, `parseURLEncodedForm`, `parseMultipartForm`
- `lvt-submitter` added to `actionFields` skiplist (urlencoded + multipart) so it isn't echoed back as user data
- In `parseMultipartForm`, `lvt-submitter` is read **before** the `jsonDataParsed` branch (same control-flow position as `lvt-action`) so it takes precedence regardless of whether a JSON `data` envelope is present
- Resolution-order doc comment added to `parseMultipartForm` mirroring `parseURLEncodedForm` — both now document: `lvt-action → lvt-submitter → heuristic → ""`

## Out of scope

- **Phase 2**: client emits `lvt-submitter` (HTTP) and `submitter` (WS). Cross-repo work in `livetemplate/client`.
- **Phase 3**: deprecation warning on the heuristic with rate-limited logging + `LVT_FORM_SUBMITTER_COMPAT=silent` env-var suppression.
- **Phase 4**: heuristic removal — gated on the no-JS support decision (see proposal Q3).
- **`lvt-form:emit-submitter` directive**: Phase 2/lite-JS opt-in.

## Test plan

- [x] New tests in `internal/send/message_test.go` covering all three content types (JSON, urlencoded, multipart)
- [x] Collision cases: legitimate empty input + explicit submitter, two empty fields + explicit submitter, `<button name="action">` resolution
- [x] Precedence: `lvt-action` always wins over `lvt-submitter`
- [x] WS path: `action="" + submitter="X"` → action becomes `"X"`; `action="Y" + submitter="X"` → action stays `"Y"`
- [x] `lvt-submitter` not echoed back into `msg.Data`
- [x] `go test ./internal/send/...` passes (with and without `-race`)
- [x] Full test suite passes via pre-commit (300s timeout, includes pubsub Docker tests)
- [x] Linters pass: errcheck, govet, ineffassign, staticcheck, unparam, unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)