### PR TITLE
refactor(session): typed flashKey to prevent key-space confusion (#347)

### DIFF
--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 func newFlashState() *connState {
 	return &connState{
 		messages:    make(map[string]string),
-		flashExpiry: make(map[string]time.Time),
+		flashExpiry: make(map[flashKey]time.Time),
 	}
 }
 
@@ -36,7 +36,7 @@ func TestExpiredFlashAbsentFromGetMessagesSnapshot(t *testing.T) {
 		t.Fatal("flash not set")
 	}
 	// Backdate the deadline to simulate expiry having elapsed since SetFlash.
-	cs.flashExpiry["success"] = time.Now().Add(-1 * time.Second)
+	cs.flashExpiry[flashKey("success")] = time.Now().Add(-1 * time.Second)
 
 	// getMessages must NOT include the expired entry — it prunes before
 	// snapshotting so the next render walks a clean slate.
@@ -97,7 +97,7 @@ func TestFlashExpiryPrunesAfterDeadline(t *testing.T) {
 	// Backdate the expiry to force it to be past-due. Direct map write is safe
 	// here: these are sequential single-goroutine tests; setFlash initialized
 	// the map above so the nil-map panic path is excluded.
-	cs.flashExpiry["info"] = time.Now().Add(-1 * time.Second)
+	cs.flashExpiry[flashKey("info")] = time.Now().Add(-1 * time.Second)
 
 	cs.pruneExpiredFlash()
 
@@ -114,7 +114,7 @@ func TestFlashExpiryDoesNotAffectNonExpiredMessages(t *testing.T) {
 	cs.setFlash("info", "Transient...", time.Minute) // expires in 1 minute (not yet)
 
 	// Manually backdate only the "info" key to be past-due (sequential test, safe).
-	cs.flashExpiry["info"] = time.Now().Add(-1 * time.Second)
+	cs.flashExpiry[flashKey("info")] = time.Now().Add(-1 * time.Second)
 
 	cs.pruneExpiredFlash()
 
@@ -166,7 +166,7 @@ func TestFlashExpiryOverwrittenByNoExpiry(t *testing.T) {
 	cs.setFlash("key", "first", time.Hour)
 	// Backdate the expiry to force it to appear past-due. Direct map write is
 	// safe here: sequential single-goroutine test, map initialised above.
-	cs.flashExpiry["key"] = time.Now().Add(-1 * time.Second)
+	cs.flashExpiry[flashKey("key")] = time.Now().Add(-1 * time.Second)
 	// Overwrite with no expiry — prior deadline must be deleted from flashExpiry.
 	cs.setFlash("key", "updated", 0)
 	cs.pruneExpiredFlash()

--- a/mount.go
+++ b/mount.go
@@ -173,12 +173,23 @@ type wsReadMessage struct {
 	err  error
 }
 
+// flashKey is a bare flash key (no "_flash:" prefix), used as the map-key
+// type for connState.flashExpiry. It is a distinct type from the prefixed
+// string keys stored in connState.messages so that the deliberate key-space
+// asymmetry between the two maps cannot be silently violated by a future
+// contributor who reaches for lvtcontext.FlashPrefix by analogy.
+//
+// Conversions are explicit (flashKey(rawBareKey)) — the cast is the moment
+// a reader sees "we are deliberately keeping the bare key here, not the
+// prefixed one."
+type flashKey string
+
 type connState struct {
-	state       interface{}          // Typed state (cloned per session)
-	messages    map[string]string    // keys: field errors (plain) + flash (prefixed with "_flash:"); note: flashExpiry below uses bare keys
-	flashExpiry map[string]time.Time // keys: bare flash key WITHOUT "_flash:" prefix (unlike messages above)
-	messagesMu  sync.RWMutex         // Mutex for thread-safe message access
-	groupID     string               // Session/group ID for this connection
+	state       interface{}            // Typed state (cloned per session)
+	messages    map[string]string      // keys: field errors (plain) + flash (prefixed with "_flash:"); note: flashExpiry below uses bare keys (typed as flashKey)
+	flashExpiry map[flashKey]time.Time // keys: bare flash key WITHOUT "_flash:" prefix (typed flashKey, see comment above)
+	messagesMu  sync.RWMutex           // Mutex for thread-safe message access
+	groupID     string                 // Session/group ID for this connection
 }
 
 func (c *connState) setError(field, message string) {
@@ -231,13 +242,13 @@ func (c *connState) setFlash(key, message string, expiry time.Duration) {
 	c.messages[lvtcontext.FlashPrefix+key] = message
 	if expiry > 0 {
 		if c.flashExpiry == nil {
-			c.flashExpiry = make(map[string]time.Time)
+			c.flashExpiry = make(map[flashKey]time.Time)
 		}
-		c.flashExpiry[key] = time.Now().Add(expiry)
+		c.flashExpiry[flashKey(key)] = time.Now().Add(expiry)
 	} else {
 		// No expiry — persist until ClearFlash. Remove any prior expiry.
 		// delete on a nil map is a safe no-op in Go, so no nil guard needed.
-		delete(c.flashExpiry, key)
+		delete(c.flashExpiry, flashKey(key))
 	}
 }
 
@@ -249,7 +260,7 @@ func (c *connState) clearFlashKey(key string) {
 	defer c.messagesMu.Unlock()
 	delete(c.messages, lvtcontext.FlashPrefix+key)
 	// delete on a nil map is a safe no-op in Go, so no nil guard needed here.
-	delete(c.flashExpiry, key)
+	delete(c.flashExpiry, flashKey(key))
 }
 
 // pruneExpiredFlash removes only flash messages whose expiry has
@@ -282,7 +293,7 @@ func (c *connState) pruneExpiredFlash() {
 	now := time.Now()
 	for key, exp := range c.flashExpiry {
 		if now.After(exp) {
-			delete(c.messages, lvtcontext.FlashPrefix+key)
+			delete(c.messages, lvtcontext.FlashPrefix+string(key))
 			delete(c.flashExpiry, key)
 		}
 	}

--- a/mount.go
+++ b/mount.go
@@ -173,15 +173,7 @@ type wsReadMessage struct {
 	err  error
 }
 
-// flashKey is a bare flash key (no "_flash:" prefix), used as the map-key
-// type for connState.flashExpiry. It is a distinct type from the prefixed
-// string keys stored in connState.messages so that the deliberate key-space
-// asymmetry between the two maps cannot be silently violated by a future
-// contributor who reaches for lvtcontext.FlashPrefix by analogy.
-//
-// Conversions are explicit (flashKey(rawBareKey)) — the cast is the moment
-// a reader sees "we are deliberately keeping the bare key here, not the
-// prefixed one."
+// flashKey is a bare flash key (no "_flash:" prefix) — distinct from prefixed keys in connState.messages.
 type flashKey string
 
 type connState struct {


### PR DESCRIPTION
## Summary

Closes #347. Defensive **defined type** to prevent silent breakage of the deliberate key-space asymmetry between `connState.messages` and `connState.flashExpiry`.

**No behavior change. No public API change.** Internal-only hardening.

## The trap this prevents

`connState` has two maps that store flash data:

- `messages` — keys prefixed with `_flash:` (e.g. `"_flash:info"`)
- `flashExpiry` — bare keys, no prefix (e.g. `"info"`)

This is correct, and documented in the struct comment. But a future contributor following `messages`'s naming convention by analogy could write:

```go
// WRONG — silently breaks expiry:
c.flashExpiry[lvtcontext.FlashPrefix+key] = time.Now().Add(d)
```

This compiles, passes all tests (the wrong key is never looked up), and causes flash messages to never expire — no error, just user-visible "my 5-second notification persists indefinitely."

## The fix (Option 1 from the issue)

```go
type flashKey string

flashExpiry map[flashKey]time.Time
```

Note: `type flashKey string` is a **defined type**, not a type alias. A true alias (`type flashKey = string`) would be structurally identical to `string` and would *not* prevent this misuse — the compiler would still accept `lvtcontext.FlashPrefix+key`. The compile-time enforcement works precisely because `flashKey` is a defined type.

Every access site converts explicitly: `flashKey(rawBareKey)`. The cast is the point — it's the moment a reader sees "we're deliberately keeping the bare key here, not the prefixed one." A future write that uses `lvtcontext.FlashPrefix+key` fails to compile against `map[flashKey]time.Time`.

## Why Option 1 over Options 2/3

The issue lists three mitigations. Option 1 (defined type) is the most defensive: the type system *enforces* the rule rather than relying on a comment that could rot. Options 2 and 3 (helper constructors / expanded comments) leave the same silent-failure path open.

## Test plan

- [x] All flash tests pass (`go test -run Flash ./...`)
- [x] Full test suite passes via pre-commit (300s timeout)
- [x] Linters pass: errcheck, govet, ineffassign, staticcheck, unparam, unused
- [x] No behavior diff in flash lifecycle tests — only the test setup line that constructs the map directly was updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)