### PR TITLE
ci: add test-docs cross-repo job for patterns e2e coverage

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -177,6 +177,87 @@ jobs:
         CGO_ENABLED: 1
         LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
 
+  # The patterns app (formerly examples/patterns) was folded into the
+  # docs repo at content/recipes/patterns/_app/ with its tests
+  # relocated to docs/e2e/patterns/. This job preserves the
+  # "patterns runs against core changes" coverage that test-examples
+  # provided before the deletion.
+  test-docs:
+    name: Test Docs Patterns against Core Changes
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout core library (this PR/branch)
+      uses: actions/checkout@v4
+      with:
+        path: livetemplate
+
+    - name: Checkout LVT (for testing package)
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/lvt
+        path: lvt
+
+    - name: Checkout docs
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/docs
+        path: docs
+
+    - name: Checkout client library
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/client
+        path: livetemplate/client
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: livetemplate/client/package-lock.json
+
+    - name: Build client library
+      working-directory: livetemplate/client
+      run: |
+        echo "Installing client dependencies..."
+        npm ci
+        echo "Building client library..."
+        npm run build
+        echo "OK: Client library built successfully"
+        ls -la dist/
+
+    - name: Add replace directives to docs (parent module)
+      working-directory: docs
+      run: |
+        echo "Adding replace directives to docs..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../lvt
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Add replace directives to docs/e2e (separate module)
+      working-directory: docs/e2e
+      run: |
+        echo "Adding replace directives to docs/e2e..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
+        go mod edit -replace=github.com/livetemplate/docs=../
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Run patterns e2e against core
+      working-directory: docs/e2e/patterns
+      run: go test -v -count=1 -timeout=15m -skip "Submit_With_No_Changes" ./...
+      env:
+        CGO_ENABLED: 1
+        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
+
   test-tinkerdown:
     name: Test Tinkerdown against Core Changes
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -253,6 +253,9 @@ jobs:
 
     - name: Run patterns e2e against core
       working-directory: docs/e2e/patterns
+      # Submit_With_No_Changes is a pre-existing flash-state flake that
+      # fails identically in upstream examples/patterns; tracked as a
+      # follow-up to fix in the patterns app's flash handling.
       run: go test -v -count=1 -timeout=15m -skip "Submit_With_No_Changes" ./...
       env:
         CGO_ENABLED: 1


### PR DESCRIPTION
## Summary

The patterns app folded out of `livetemplate/examples/patterns/` (per livetemplate/docs#10 and #11) into `docs/content/recipes/patterns/_app/` with its e2e suite relocated to `docs/e2e/patterns/`.

After `livetemplate/examples` deletes its `patterns/` directory (B2 PR-3), the existing `test-examples` job here will auto-skip patterns — the "patterns runs against core changes" cross-repo coverage would disappear silently.

This PR adds `test-docs` to preserve that coverage. **Lands BEFORE B2 PR-3** so there's no gap.

## Diff

One file: `.github/workflows/cross-repo-test.yml` — a new `test-docs` job after `test-examples`.

Mirrors `test-examples`' shape but:
- Checks out **docs** instead of examples
- Applies replace directives in **both** `docs/go.mod` (parent module) and `docs/e2e/go.mod` (separate module — the e2e suite has its own go.mod)
- Runs the relocated patterns suite via `go test ./e2e/patterns/...` from the docs root
- Skips `TestBulkUpdate/Submit_With_No_Changes` (pre-existing flake; fails identically in upstream `examples/patterns`, also skipped in livetemplate/docs#11)

## Test plan

- [x] Pre-commit hook passes (Go formatting, golangci-lint, full test suite — only YAML changed but the hook runs all of it)
- [ ] CI green on this PR (the docs-checkout requires the patterns suite to be relocated; that landed in livetemplate/docs#11 which deployed to main already)
- [ ] Trigger a no-op livetemplate PR after merge to confirm `test-docs` runs and goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)