### PR TITLE
ci: add test-docs-todos cross-repo job for todos recipe coverage

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -261,6 +261,82 @@ jobs:
         CGO_ENABLED: 1
         LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
 
+  test-docs-todos:
+    name: Test Docs Todos against Core Changes
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout core library (this PR/branch)
+      uses: actions/checkout@v4
+      with:
+        path: livetemplate
+
+    - name: Checkout LVT (for testing package)
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/lvt
+        path: lvt
+
+    - name: Checkout docs
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/docs
+        path: docs
+
+    - name: Checkout client library
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/client
+        path: livetemplate/client
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: livetemplate/client/package-lock.json
+
+    - name: Build client library
+      working-directory: livetemplate/client
+      run: |
+        echo "Installing client dependencies..."
+        npm ci
+        echo "Building client library..."
+        npm run build
+        echo "OK: Client library built successfully"
+        ls -la dist/
+
+    - name: Add replace directives to docs (parent module)
+      working-directory: docs
+      run: |
+        echo "Adding replace directives to docs..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../lvt
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Add replace directives to docs/e2e (separate module)
+      working-directory: docs/e2e
+      run: |
+        echo "Adding replace directives to docs/e2e..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
+        go mod edit -replace=github.com/livetemplate/docs=../
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Run todos e2e against core
+      working-directory: docs/e2e/todos
+      run: go test -v -count=1 -timeout=15m ./...
+      env:
+        CGO_ENABLED: 1
+        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
+
   test-tinkerdown:
     name: Test Tinkerdown against Core Changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Sibling to the existing `test-docs` job (patterns coverage). Same shape: checkouts of livetemplate (this PR), lvt, docs, client; build client library locally; add replace directives in `docs/go.mod` and `docs/e2e/go.mod`; run `docs/e2e/todos` against this PR's core changes.
- Validates the SQLite + BasicAuth + `lvt/components` recipe end-to-end on every core PR. The todos recipe lives at livetemplate/docs#13 (in-flight); once that merges, this job exercises 16 chromedp subtests + WebSocket against the docs handler.

## Why no `-skip` filter

`test-docs` skips `Submit_With_No_Changes` due to a flash-state flake in the patterns app. The todos suite was clean against the docs handler in local validation — full pass against this PR's core code, no flakes observed.

## Test plan

- [x] Pre-commit gate clean (golangci-lint + tests, ~25s)
- [ ] Verify on a no-op core PR that `test-docs-todos` runs and goes green once docs#13 lands

## Related

- Companion: livetemplate/docs#13 (the migration this job validates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)