### PR TITLE
ci: add test-docs-progressive-enhancement cross-repo job

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -337,6 +337,82 @@ jobs:
         CGO_ENABLED: 1
         LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
 
+  test-docs-progressive-enhancement:
+    name: Test Docs Progressive Enhancement against Core Changes
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout core library (this PR/branch)
+      uses: actions/checkout@v4
+      with:
+        path: livetemplate
+
+    - name: Checkout LVT (for testing package)
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/lvt
+        path: lvt
+
+    - name: Checkout docs
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/docs
+        path: docs
+
+    - name: Checkout client library
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/client
+        path: livetemplate/client
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: livetemplate/client/package-lock.json
+
+    - name: Build client library
+      working-directory: livetemplate/client
+      run: |
+        echo "Installing client dependencies..."
+        npm ci
+        echo "Building client library..."
+        npm run build
+        echo "OK: Client library built successfully"
+        ls -la dist/
+
+    - name: Add replace directives to docs (parent module)
+      working-directory: docs
+      run: |
+        echo "Adding replace directives to docs..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../lvt
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Add replace directives to docs/e2e (separate module)
+      working-directory: docs/e2e
+      run: |
+        echo "Adding replace directives to docs/e2e..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
+        go mod edit -replace=github.com/livetemplate/docs=../
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Run progressive-enhancement e2e against core
+      working-directory: docs/e2e/progressive-enhancement
+      run: go test -v -count=1 -timeout=15m ./...
+      env:
+        CGO_ENABLED: 1
+        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
+
   test-tinkerdown:
     name: Test Tinkerdown against Core Changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Sibling cross-repo CI job to `test-docs-todos` (#402), covering the new `progressive-enhancement` recipe folded in [livetemplate/docs#14](https://github.com/livetemplate/docs/pull/14).

Verbatim clone of `test-docs-todos` with `working-directory: docs/e2e/progressive-enhancement` and the run-step name swapped — runs the merged Tier A (JS+WS), Tier B (no-WS, including the gorilla/websocket handshake-rejection sentinel), and Tier C (raw HTTP POST → 303 PRG) e2e suite against this branch's core changes.

## Test plan

- [ ] CI runs the new job and goes green on first attempt (docs `main` already has `docs/e2e/progressive-enhancement/` after #14 merged minutes ago, so no chicken-and-egg this time)
- [ ] Existing jobs (`test-examples`, `test-docs`, `test-docs-todos`, `test-tinkerdown`) remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)