### PR TITLE
refactor: remove reserved Sync action

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -204,6 +204,19 @@ jobs:
         repository: livetemplate/docs
         path: docs
 
+    - name: Use matching docs branch if available
+      working-directory: docs
+      env:
+        DOCS_REF: ${{ github.head_ref || github.ref_name }}
+      run: |
+        if git ls-remote --exit-code --heads origin "$DOCS_REF" >/dev/null 2>&1; then
+          echo "Using livetemplate/docs branch: $DOCS_REF"
+          git fetch origin "$DOCS_REF" --depth=1
+          git checkout FETCH_HEAD
+        else
+          echo "No matching livetemplate/docs branch for $DOCS_REF; using default branch"
+        fi
+
     - name: Checkout client library
       uses: actions/checkout@v4
       with:
@@ -283,6 +296,19 @@ jobs:
         repository: livetemplate/docs
         path: docs
 
+    - name: Use matching docs branch if available
+      working-directory: docs
+      env:
+        DOCS_REF: ${{ github.head_ref || github.ref_name }}
+      run: |
+        if git ls-remote --exit-code --heads origin "$DOCS_REF" >/dev/null 2>&1; then
+          echo "Using livetemplate/docs branch: $DOCS_REF"
+          git fetch origin "$DOCS_REF" --depth=1
+          git checkout FETCH_HEAD
+        else
+          echo "No matching livetemplate/docs branch for $DOCS_REF; using default branch"
+        fi
+
     - name: Checkout client library
       uses: actions/checkout@v4
       with:
@@ -358,6 +384,19 @@ jobs:
       with:
         repository: livetemplate/docs
         path: docs
+
+    - name: Use matching docs branch if available
+      working-directory: docs
+      env:
+        DOCS_REF: ${{ github.head_ref || github.ref_name }}
+      run: |
+        if git ls-remote --exit-code --heads origin "$DOCS_REF" >/dev/null 2>&1; then
+          echo "Using livetemplate/docs branch: $DOCS_REF"
+          git fetch origin "$DOCS_REF" --depth=1
+          git checkout FETCH_HEAD
+        else
+          echo "No matching livetemplate/docs branch for $DOCS_REF; using default branch"
+        fi
 
     - name: Checkout client library
       uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- simplify state management — remove WithSharedState/WithStatePersistence, add Sync() lifecycle ([#298](https://github.com/livefir/livetemplate/issues/298))
+- simplify state management and persistence defaults ([#298](https://github.com/livefir/livetemplate/issues/298))
 - make state persistence opt-in via WithStatePersistence() ([#295](https://github.com/livefir/livetemplate/issues/295))
 - per-connection state persists to session store for page refresh ([#290](https://github.com/livefir/livetemplate/issues/290))
 
@@ -222,14 +222,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 actions no longer auto-broadcast state or persist to SessionStore.
-Use WithSharedState() to restore the old behavior for backward compatibility.
 
 Key changes:
 - Remove auto-broadcast and SessionStore persist from WebSocket action loop
 - Add ctx.BroadcastAction() API for explicit cross-connection dispatch
 - Restructure WS message loop to select-based event loop (readPump + DispatchChan)
 - Add GroupActionMessage type and Redis PubSub support for cross-instance broadcast
-- Add WithSharedState() option for backward compatibility
 - Handle BroadcastAction from both WebSocket and HTTP POST paths
 
 

--- a/broadcast_test.go
+++ b/broadcast_test.go
@@ -261,7 +261,7 @@ func connectWSWithAuth(t *testing.T, wsURL, username, password string) *websocke
 	return ws
 }
 
-// --- Sync lifecycle tests ---
+// --- Explicit peer refresh tests ---
 
 type syncDBItem struct {
 	ID   string
@@ -305,15 +305,16 @@ func (c *syncController) Add(state itemsState, ctx *Context) (itemsState, error)
 	id := fmt.Sprintf("item-%d", len(state.Items)+1)
 	c.DB.addItem(ctx.UserID(), id, text)
 	state.Items = c.DB.getItems(ctx.UserID())
+	ctx.BroadcastAction("Refresh", nil)
 	return state, nil
 }
 
-func (c *syncController) Sync(state itemsState, ctx *Context) (itemsState, error) {
+func (c *syncController) Refresh(state itemsState, ctx *Context) (itemsState, error) {
 	state.Items = c.DB.getItems(ctx.UserID())
 	return state, nil
 }
 
-func TestSyncLifecycle_AutoDispatchesToPeers(t *testing.T) {
+func TestBroadcastAction_ExplicitRefreshDispatchesToPeers(t *testing.T) {
 	db := &syncDB{items: make(map[string][]syncDBItem)}
 
 	auth := NewBasicAuthenticator(func(username, password string) (bool, error) {
@@ -367,7 +368,7 @@ func TestSyncLifecycle_AutoDispatchesToPeers(t *testing.T) {
 	update2 := readWSUpdate(t, ws2, 3*time.Second)
 	meta2, _ := update2["meta"].(map[string]interface{})
 	if meta2["success"] != true {
-		t.Errorf("Tab 2 expected success=true from Sync dispatch, got %v", meta2["success"])
+		t.Errorf("Tab 2 expected success=true from Refresh dispatch, got %v", meta2["success"])
 	}
 
 	items := db.getItems("alice")
@@ -387,7 +388,7 @@ func (c *noSyncController) Add(state itemsState, ctx *Context) (itemsState, erro
 	return state, nil
 }
 
-func TestSyncLifecycle_NotDispatchedWithoutMethod(t *testing.T) {
+func TestBroadcastAction_NoAutomaticPeerDispatch(t *testing.T) {
 	// fixedGroupAuth forces all connections into the same group regardless of auth,
 	// so connectWS (unauthenticated) still shares groupID "no-sync-test".
 	auth := &fixedGroupAuth{groupID: "no-sync-test"}
@@ -437,6 +438,6 @@ func TestSyncLifecycle_NotDispatchedWithoutMethod(t *testing.T) {
 	}
 	_, _, err = ws2.ReadMessage()
 	if err == nil {
-		t.Error("Tab 2 should NOT receive update when controller has no Sync() method")
+		t.Error("Tab 2 should NOT receive update without explicit BroadcastAction")
 	}
 }

--- a/docs/guides/ephemeral-components.md
+++ b/docs/guides/ephemeral-components.md
@@ -82,13 +82,13 @@ func (c *Controller) OnConnect(state AppState, ctx *livetemplate.Context) (AppSt
     return state, nil
 }
 
-func (c *Controller) Sync(state AppState, ctx *livetemplate.Context) (AppState, error) {
+func (c *Controller) Refresh(state AppState, ctx *livetemplate.Context) (AppState, error) {
     state = initComponents(state)
     return state, nil
 }
 ```
 
-All three hooks must call `initComponents` because non-persistent fields (like `*toast.Container`) are nil after deserialization. Missing any hook causes a nil-pointer panic on that code path.
+Any action that can run after state has been deserialized or independently dispatched must call `initComponents` because non-persistent fields (like `*toast.Container`) may be nil on that code path.
 
 ### Adding Messages
 

--- a/docs/proposals/patterns.md
+++ b/docs/proposals/patterns.md
@@ -1619,43 +1619,41 @@ func (c *Controller) Save(state FlashState, ctx *livetemplate.Context) (FlashSta
 
 ### Category 7: Real-Time & Multi-User
 
-#### 26. Multi-User Sync
+#### 26. Multi-User Refresh
 
 **Source:** Phoenix LiveView (PubSub broadcast + handle_info)
 
-**LiveTemplate (Tier 1):** The `Sync()` handler is auto-dispatched to peer connections in the same session group. Multiple tabs or users see the same state changes in real-time.
+**LiveTemplate (Tier 1):** The mutating action explicitly broadcasts a peer refresh action to connections in the same session group. Multiple tabs or users see the same state changes in real time.
 
 **Also implemented in:** `chat/`, `shared-notepad/`
 
 ```go
-type SyncController struct {
+type RefreshController struct {
     mu      sync.Mutex
     counter int
 }
 
-type SyncState struct {
+type RefreshState struct {
     Title   string
     Counter int
 }
 
-// Sync is a reserved method name (mount.go:158, syncMethodName = "Sync").
-// The framework auto-dispatches it to peer connections in the same session
-// group after any action completes, without requiring an explicit
-// BroadcastAction call. The state parameter is the peer's LOCAL state.
-// The handler reads the shared counter from the controller (singleton)
-// so all peers see the same value.
-func (c *SyncController) Sync(state SyncState, ctx *livetemplate.Context) (SyncState, error) {
+// RefreshCounter is explicitly broadcast to peers after Increment. The state
+// parameter is the peer's LOCAL state. The handler reads the shared counter
+// from the controller (singleton) so all peers see the same value.
+func (c *RefreshController) RefreshCounter(state RefreshState, ctx *livetemplate.Context) (RefreshState, error) {
     c.mu.Lock()
     state.Counter = c.counter
     c.mu.Unlock()
     return state, nil
 }
 
-func (c *SyncController) Increment(state SyncState, ctx *livetemplate.Context) (SyncState, error) {
+func (c *RefreshController) Increment(state RefreshState, ctx *livetemplate.Context) (RefreshState, error) {
     c.mu.Lock()
     c.counter++
     state.Counter = c.counter
     c.mu.Unlock()
+    ctx.BroadcastAction("RefreshCounter", nil)
     return state, nil
 }
 ```
@@ -1663,15 +1661,15 @@ func (c *SyncController) Increment(state SyncState, ctx *livetemplate.Context) (
 ```html
 {{define "content"}}
 <article>
-    <h3>Multi-User Sync</h3>
-    <p><small>Open this page in two tabs. Changes sync automatically.</small></p>
+    <h3>Multi-User Refresh</h3>
+    <p><small>Open this page in two tabs. Changes refresh peers explicitly.</small></p>
     <p>Counter: {{.Counter}}</p>
     <button name="increment">Increment</button>
 </article>
 {{end}}
 ```
 
-**Key features:** `Sync()` handler, session group auto-sync, multi-tab real-time updates
+**Key features:** `BroadcastAction`, session group peer refresh, multi-tab real-time updates
 
 ---
 
@@ -2377,7 +2375,7 @@ without --cpus + throttle-disable flags: t=27ms click, t=4022 t=5022 t=6022 ... 
 
 Fix: drop `--cpus 0.5`, add `--shm-size 256m` and `--disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --disable-features=IntensiveWakeUpThrottling`. Released as [livetemplate/lvt#314](https://github.com/livetemplate/lvt/pull/314) → **lvt v0.1.4**. After bumping `examples/go.mod`, the Session 5 PR #79's flaky "Test All Examples" CI is also fixed (it was failing for the same root cause). When designing future `TriggerAction`-driven patterns, no test workaround is needed at v0.1.4+; before the bump, the only viable workaround was `chromedp.Sleep` + `Evaluate` (which the AI review explicitly rejects).
 
-**`Sync()` auto-dispatch fires after EVERY action, not just broadcast fan-out.** Verified at `livetemplate/mount.go:1466-1468`: `processBroadcastsAndSync` runs after every action's render and unconditionally dispatches `Sync` to peer connections when `HasSync && !syncExplicitlyBroadcast`, regardless of whether the action queued any broadcasts. Pattern #26 (Multi-User Sync) relies on this: `Increment` never calls `BroadcastAction`, but peers still get `Sync` and re-pull the shared counter from the controller. This is the simplest correct way to express "any peer state changed" without an explicit broadcast.
+**Cross-connection updates are explicit.** Pattern #26 (Multi-User Refresh) calls `BroadcastAction("RefreshCounter", nil)` from `Increment`, and peers re-pull the shared counter from the controller. Nothing crosses connections unless the action asks for it.
 
 **`lvt:"persist"` semantics: storage is keyed by SESSION GROUP, not connection.** Two tabs in the same browser share the group cookie → share persisted state. Pattern #28 (Presence) intentionally does NOT persist `Username`/`Joined` so two tabs joined as different users can coexist; Pattern #27 (Broadcasting) similarly leaves `Username` un-persisted. Pattern #29 (Reconnection Recovery) DOES persist `Counter`/`Notes` because that's the canonical demo. The decision is documented in `state_realtime.go` per-field comments — useful pedagogical contrast for readers learning the framework.
 
@@ -2476,7 +2474,7 @@ Fix: drop `--cpus 0.5`, add `--shm-size 256m` and `--disable-background-timer-th
 
 **Scope:** Patterns #26–31
 
-- [x] Implement Multi-User Sync (#26) — reserved `Sync()` method auto-dispatches after every action's render to peers in same session group (`mount.go:1466-1468`); `Mount()` seeds late-joiners from shared controller state; `Increment` does not call `BroadcastAction`.
+- [x] Implement Multi-User Refresh (#26) — `Increment` explicitly broadcasts `RefreshCounter` to peers in the same session group; `Mount()` seeds late-joiners from shared controller state.
 - [x] Implement Broadcasting (#27) — `ctx.BroadcastAction("NewMessage", nil)` after lock release (deadlock prevention with connection registry mutex); `Mount()` snapshots `c.messages` for new connections; `Username` intentionally not `lvt:"persist"` so two tabs in one browser stay independent.
 - [x] Implement Presence Tracking (#28) — Join/Leave + `BroadcastAction("PresenceChanged")`; `Mount()` seeds `OnlineCount` for late-joining tabs; documented limitations: close-tab leak (no `OnDisconnect` state/ctx) + same-username collision (map keys on username).
 - [x] Implement Reconnection Recovery (#29) — `Counter` and `Notes` tagged `lvt:"persist"`; full page reload restores via session-group cookie. Template explainer covers `lvt:"persist"` (server-side, survives reconnect) vs `lvt-form:preserve` (client-side, survives in-DOM during other re-renders).

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -142,9 +142,6 @@ func (c *Controller) Mount(state S, ctx *livetemplate.Context) (S, error)
 // Called on each WebSocket connect (including reconnects)
 func (c *Controller) OnConnect(state S, ctx *livetemplate.Context) (S, error)
 
-// Called on peer connections after any action in the same session group
-func (c *Controller) Sync(state S, ctx *livetemplate.Context) (S, error)
-
 // Called when a WebSocket disconnects
 func (c *Controller) OnDisconnect()
 ```

--- a/docs/references/current-limitations.md
+++ b/docs/references/current-limitations.md
@@ -56,7 +56,7 @@ See [Session Reference — State Safety](session.md#state-safety) for the full e
 
 | Limitation | Detail | Workaround |
 |-----------|--------|-----------|
-| Tabs don't auto-sync by default | Each connection owns its state independently | Implement `Sync()` on the controller for automatic cross-tab sync, or use `ctx.BroadcastAction()` for custom sync |
+| Tabs don't update each other by default | Each connection owns its state independently | Use `ctx.BroadcastAction()` to explicitly refresh peer connections |
 | Concurrent HTTP requests serialized | Per-group mutex in HTTP mode processes one action at a time | By design — prevents data races on shared state |
 
 See [Session Reference](session.md) for session stores and connection management.

--- a/docs/references/server-actions.md
+++ b/docs/references/server-actions.md
@@ -412,11 +412,12 @@ When a user has multiple tabs or devices connected:
 ```
 User clicks button in Tab 1
     └─► Tab 1's action method called
+        └─► action may call ctx.BroadcastAction("RefreshTodos", nil)
         └─► Tab 1 receives update
-        └─► Tab 2, Tab 3 receive Sync() dispatch (if controller implements Sync)
+        └─► Tab 2, Tab 3 receive the explicit peer action
 ```
 
-> When the controller implements a `Sync()` method, other tabs automatically receive a Sync dispatch after each action. Without `Sync()`, use `ctx.BroadcastAction("ActionName", nil)` for explicit cross-tab sync.
+> Cross-tab updates are explicit: call `ctx.BroadcastAction("ActionName", nil)` from the action that changed shared state.
 
 **Server Action (TriggerAction):**
 ```

--- a/docs/references/session.md
+++ b/docs/references/session.md
@@ -56,23 +56,28 @@ Fields tagged with `lvt:"persist"` follow this persistence schedule. Untagged fi
 | Server action | Persisted (once per group) | In-memory for connection lifetime |
 | Page refresh | Restored from store | Zero value, loaded by Mount() |
 
-### Sync Lifecycle Method
-
-When the controller implements a `Sync()` method, the framework automatically dispatches it to peer connections in the same session group after every action. This is the recommended way to keep multiple tabs in sync:
+### Explicit Peer Refresh
 
 ```go
-func (c *TodoController) Sync(state TodoState, ctx *livetemplate.Context) (TodoState, error) {
+func (c *TodoController) Add(state TodoState, ctx *livetemplate.Context) (TodoState, error) {
+    c.DB.AddItem(ctx.UserID(), ctx.GetString("text"))
     state.Items = c.DB.GetItems(ctx.UserID())
-    return state, nil  // Peer connections reload from database
+    ctx.BroadcastAction("RefreshTodos", nil)
+    return state, nil
+}
+
+func (c *TodoController) RefreshTodos(state TodoState, ctx *livetemplate.Context) (TodoState, error) {
+    state.Items = c.DB.GetItems(ctx.UserID())
+    return state, nil
 }
 ```
 
 **How it works:**
 - Each browser gets a unique session ID (via cookie: `livetemplate-id`)
 - All tabs in the same browser share this session ID (`groupID`)
-- After any action, `Sync` is dispatched to all other connections in the group
-- Each connection runs `Sync` with its own state, reloading from the database
-- If the controller does not implement `Sync()`, no cross-tab dispatch occurs
+- After a successful action, queued `BroadcastAction` calls dispatch to other connections in the group
+- Each peer connection runs the named action with its own state, reloading from the database
+- If the action does not call `BroadcastAction`, no cross-tab dispatch occurs
 
 ## State Safety
 
@@ -185,7 +190,7 @@ State is deserialized fresh on each `Get()`, preventing reference sharing across
 
 #### Broadcast Scoping
 
-Both `Sync()` auto-dispatch and explicit `BroadcastAction()` are scoped to the sender's `groupID`. The [ConnectionRegistry](#connection-registry) filters recipients via `GetByGroup(groupID)` — messages only reach connections in the same group. Different groups are never informed of each other's updates.
+`BroadcastAction()` is scoped to the sender's `groupID`. The [ConnectionRegistry](#connection-registry) filters recipients via `GetByGroup(groupID)` — messages only reach connections in the same group. Different groups are never informed of each other's updates.
 
 #### HTTP Request Isolation
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -2330,7 +2330,7 @@ func TestPerConnectionState_ActionPersistsAcrossReconnect(t *testing.T) {
 	}
 }
 
-// TestPerConnectionState_NoAutoBroadcast verifies that without a Sync() method,
+// TestPerConnectionState_NoAutoBroadcast verifies that without BroadcastAction,
 // WS2 does NOT receive an automatic update when WS1 performs an action.
 func TestPerConnectionState_NoAutoBroadcast(t *testing.T) {
 	auth := &fixedGroupAuth{groupID: "no-autobroadcast-test"}
@@ -2906,9 +2906,9 @@ func TestEphemeral_DispatchedActionNotPersisted(t *testing.T) {
 	}
 }
 
-// TestEphemeral_SyncStillWorks verifies that Sync() auto-dispatches
-// to peer connections in ephemeral mode (uses in-memory registry, not SessionStore).
-func TestEphemeral_SyncStillWorks(t *testing.T) {
+// TestEphemeral_BroadcastActionStillWorks verifies that explicit BroadcastAction
+// dispatches to peer connections in ephemeral mode (uses in-memory registry, not SessionStore).
+func TestEphemeral_BroadcastActionStillWorks(t *testing.T) {
 	db := &syncDB{items: make(map[string][]syncDBItem)}
 	auth := &fixedGroupAuth{groupID: "ephemeral-sync-test"}
 
@@ -2941,7 +2941,7 @@ func TestEphemeral_SyncStillWorks(t *testing.T) {
 		}
 	}()
 
-	// WS1 adds an item — Sync should auto-dispatch to WS2
+	// WS1 adds an item and explicitly broadcasts Refresh to WS2.
 	addMsg, _ := json.Marshal(map[string]interface{}{
 		"action": "add",
 		"data":   map[string]interface{}{"text": "test item"},
@@ -2953,12 +2953,12 @@ func TestEphemeral_SyncStillWorks(t *testing.T) {
 	// WS1 gets its own action response
 	readWSUpdate(t, ws1, 3*time.Second)
 
-	// WS2 should receive the Sync dispatch (in-memory, not via SessionStore).
+	// WS2 should receive the Refresh dispatch (in-memory, not via SessionStore).
 	// Dynamic "0" is {{len .Items}} = "1" after Add.
 	update2 := readWSUpdate(t, ws2, 3*time.Second)
 	if tree, ok := update2["tree"].(map[string]interface{}); ok {
 		if v, ok := tree["0"].(string); ok && v != "1" {
-			t.Errorf("Ephemeral Sync: expected len(Items)=1 on WS2, got %q", v)
+			t.Errorf("Ephemeral BroadcastAction: expected len(Items)=1 on WS2, got %q", v)
 		}
 	}
 }

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -17,11 +17,6 @@ import "reflect"
 //   Called every time a WebSocket connects (including reconnects).
 //   Use for subscriptions or refresh logic.
 //
-// - Sync(state, ctx) -> (state, error)
-//   Called on peer connections after any successful action in the same session group.
-//   Use for reloading state from database to keep connections in sync.
-//   The framework auto-dispatches this when the controller implements it.
-//
 // - OnDisconnect()
 //   Called when WebSocket closes. Use for cleanup (unsubscribe, stop goroutines).
 //

--- a/mount.go
+++ b/mount.go
@@ -111,8 +111,6 @@ type LiveHandler interface {
 	MetricsHandler() http.Handler
 }
 
-const syncMethodName = "Sync"
-
 // ephemeralSweepTTL is how long idle HTTP template cache entries survive in ephemeral
 // mode before being evicted by the sweep loop. 30 minutes balances memory reclamation
 // for abandoned sessions vs keeping diff baselines alive for active users between
@@ -136,7 +134,6 @@ type mountConfig struct {
 	UploadConfigs          map[string]uploadtypes.UploadConfig // Upload field configurations
 	wsBufferSize           int                                 // WebSocket send buffer size per connection (default: 50)
 	ProgressiveEnhancement bool                                // Enable non-JS form submission support with PRG pattern (default: true)
-	HasSync                bool                                // Controller implements Sync() lifecycle method (detected once at Handle() time via reflection, not per-request)
 	Capabilities           []string                            // Controller capabilities detected at setup (e.g., ["change"])
 }
 
@@ -794,7 +791,7 @@ eventLoop:
 
 			// actionNavigate re-runs Mount with msg.Data as query params. Rebind
 			// actionCtx itself (not a discarded copy) so BroadcastAction calls
-			// inside Mount land on the context that processBroadcastsAndSync reads.
+			// inside Mount land on the context that processBroadcasts reads.
 			var newState interface{}
 			var actionErr error
 			if msg.Action == actionNavigate {
@@ -824,7 +821,7 @@ eventLoop:
 			if actionErr == nil {
 				h.persistState(r.Context(), groupID, connSt.state)
 				connection.Stores = connSt.state
-				h.processBroadcastsAndSync(groupID, connection, actionCtx.pendingBroadcasts())
+				h.processBroadcasts(groupID, connection, actionCtx.pendingBroadcasts())
 			}
 
 			// Generate tree update
@@ -1339,7 +1336,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	httpTmpl.SetUploadRegistry(uploadRegistry)
 
 	if actionErr == nil {
-		h.processBroadcastsAndSync(groupID, nil, actionCtx.pendingBroadcasts())
+		h.processBroadcasts(groupID, nil, actionCtx.pendingBroadcasts())
 	}
 
 	// Check if we should return HTML for progressive enhancement
@@ -1516,20 +1513,11 @@ func (h *liveHandler) restorePersistedState(ctx context.Context, groupID string)
 	return state, true
 }
 
-// processBroadcastsAndSync dispatches pending broadcasts and auto-dispatches Sync
-// to peer connections if the controller implements it. Skips auto-Sync if the
-// controller already explicitly broadcast a "Sync" action.
+// processBroadcasts dispatches pending broadcasts to peer connections.
 // Non-blocking: EnqueueDispatch uses a buffered channel with a default case.
-func (h *liveHandler) processBroadcastsAndSync(groupID string, excludeConn *session.Connection, broadcasts []broadcastRequest) {
-	syncExplicitlyBroadcast := false
+func (h *liveHandler) processBroadcasts(groupID string, excludeConn *session.Connection, broadcasts []broadcastRequest) {
 	for _, br := range broadcasts {
 		h.dispatchBroadcastToGroup(groupID, excludeConn, br.Action, br.Data)
-		if br.Action == syncMethodName {
-			syncExplicitlyBroadcast = true
-		}
-	}
-	if h.config.HasSync && !syncExplicitlyBroadcast {
-		h.dispatchBroadcastToGroup(groupID, excludeConn, syncMethodName, nil)
 	}
 }
 
@@ -2501,9 +2489,6 @@ func (h *liveHandler) handleUploadComplete(ctx context.Context, rawData []byte, 
 			slog.Any("error", err))
 		return nil // Don't fail the upload, just skip the update
 	}
-
-	// Dispatch Sync to peer connections for upload completion visibility
-	h.dispatchBroadcastToGroup(state.groupID, connection, syncMethodName, nil)
 
 	return nil
 }

--- a/template.go
+++ b/template.go
@@ -1509,7 +1509,6 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 		UploadConfigs:          t.config.UploadConfigs,
 		wsBufferSize:           t.config.WebSocketBufferSize,
 		ProgressiveEnhancement: t.config.ProgressiveEnhancement,
-		HasSync:                HasActionMethod(controller, state.Inner(), syncMethodName),
 	}
 
 	mountCfg.Capabilities = detectCapabilities(controller, state.Inner(), &mountCfg)

--- a/upload_test.go
+++ b/upload_test.go
@@ -12,6 +12,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/livetemplate/livetemplate/internal/session"
+	"github.com/livetemplate/livetemplate/internal/upload"
+	"github.com/livetemplate/livetemplate/internal/uploadtypes"
 )
 
 // TestUploadConfig_Defaults verifies default behavior of UploadConfig zero values.
@@ -566,6 +570,84 @@ func TestHandleUploadAction_NilTempFileManager(t *testing.T) {
 	}
 	if err != nil {
 		t.Errorf("non-upload action: expected no error, got %v", err)
+	}
+}
+
+type uploadCompleteNoBroadcastState struct {
+	AvatarPath string
+}
+
+type uploadCompleteNoBroadcastController struct{}
+
+func (c *uploadCompleteNoBroadcastController) UploadAvatarComplete(state uploadCompleteNoBroadcastState, ctx *Context) (uploadCompleteNoBroadcastState, error) {
+	uploads := ctx.GetCompletedUploads("avatar")
+	if len(uploads) > 0 {
+		state.AvatarPath = uploads[0].TempPath
+	}
+	return state, nil
+}
+
+func TestHandleUploadComplete_DoesNotImplicitlyBroadcastToPeers(t *testing.T) {
+	tmpl, err := New("test", WithUpload("avatar", UploadConfig{}))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>{{.AvatarPath}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	registry := session.NewConnectionRegistry()
+	peer := &session.Connection{GroupID: "upload-group", UserID: "alice"}
+	registry.Register(peer, 1)
+	defer registry.Unregister(peer)
+
+	handler := &liveHandler{
+		config: mountConfig{
+			Template:   tmpl,
+			Controller: &uploadCompleteNoBroadcastController{},
+		},
+		registry: registry,
+	}
+
+	uploadRegistry := upload.NewRegistry()
+	if err := uploadRegistry.CreateUpload("avatar", UploadConfig{}); err != nil {
+		t.Fatalf("CreateUpload failed: %v", err)
+	}
+	uploadObj, ok := uploadRegistry.GetUpload("avatar").(*upload.Upload)
+	if !ok {
+		t.Fatal("expected *upload.Upload")
+	}
+	if err := uploadObj.AddEntry(&uploadtypes.UploadEntry{
+		ID:         "entry-1",
+		ClientName: "avatar.txt",
+		ClientType: "text/plain",
+		ClientSize: 1,
+		TempPath:   "/tmp/avatar.txt",
+	}); err != nil {
+		t.Fatalf("AddEntry failed: %v", err)
+	}
+
+	current := &session.Connection{
+		GroupID:  "upload-group",
+		UserID:   "alice",
+		Template: tmpl,
+	}
+	state := &connState{
+		state:    uploadCompleteNoBroadcastState{},
+		messages: make(map[string]string),
+		groupID:  "upload-group",
+	}
+	raw := []byte(`{"action":"upload_complete","upload_name":"avatar","entry_ids":["entry-1"]}`)
+
+	if err := handler.handleUploadComplete(context.Background(), raw, state, uploadRegistry, current); err != nil {
+		t.Fatalf("handleUploadComplete failed: %v", err)
+	}
+
+	select {
+	case req := <-peer.DispatchChan:
+		t.Fatalf("upload completion should not implicitly dispatch to peer, got action %q", req.Action)
+	default:
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove reserved `Sync()` detection and automatic peer dispatch
- keep cross-connection updates explicit through `ctx.BroadcastAction(...)`
- stop upload completion from implicitly dispatching to peers
- update library docs/tests around explicit peer refresh

## Tests
- `GOWORK=off go test ./...`
- pre-commit hook: go fmt, golangci-lint, Go tests