### PR TITLE
ci: add test-docs-login + test-docs-shared-notepad cross-repo jobs

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -452,6 +452,184 @@ jobs:
         CGO_ENABLED: 1
         LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
 
+  test-docs-login:
+    name: Test Docs Login against Core Changes
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout core library (this PR/branch)
+      uses: actions/checkout@v4
+      with:
+        path: livetemplate
+
+    - name: Checkout LVT (for testing package)
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/lvt
+        path: lvt
+
+    - name: Checkout docs
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/docs
+        path: docs
+
+    - name: Use matching docs branch if available
+      working-directory: docs
+      env:
+        DOCS_REF: ${{ github.head_ref || github.ref_name }}
+      run: |
+        if git ls-remote --exit-code --heads origin "$DOCS_REF" >/dev/null 2>&1; then
+          echo "Using livetemplate/docs branch: $DOCS_REF"
+          git fetch origin "$DOCS_REF" --depth=1
+          git checkout FETCH_HEAD
+        else
+          echo "No matching livetemplate/docs branch for $DOCS_REF; using default branch"
+        fi
+
+    - name: Checkout client library
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/client
+        path: livetemplate/client
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: livetemplate/client/package-lock.json
+
+    - name: Build client library
+      working-directory: livetemplate/client
+      run: |
+        echo "Installing client dependencies..."
+        npm ci
+        echo "Building client library..."
+        npm run build
+        echo "OK: Client library built successfully"
+        ls -la dist/
+
+    - name: Add replace directives to docs (parent module)
+      working-directory: docs
+      run: |
+        echo "Adding replace directives to docs..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../lvt
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Add replace directives to docs/e2e (separate module)
+      working-directory: docs/e2e
+      run: |
+        echo "Adding replace directives to docs/e2e..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
+        go mod edit -replace=github.com/livetemplate/docs=../
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Run login e2e against core
+      working-directory: docs/e2e/login
+      run: go test -v -count=1 -timeout=15m ./...
+      env:
+        CGO_ENABLED: 1
+        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
+
+  test-docs-shared-notepad:
+    name: Test Docs Shared Notepad against Core Changes
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout core library (this PR/branch)
+      uses: actions/checkout@v4
+      with:
+        path: livetemplate
+
+    - name: Checkout LVT (for testing package)
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/lvt
+        path: lvt
+
+    - name: Checkout docs
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/docs
+        path: docs
+
+    - name: Use matching docs branch if available
+      working-directory: docs
+      env:
+        DOCS_REF: ${{ github.head_ref || github.ref_name }}
+      run: |
+        if git ls-remote --exit-code --heads origin "$DOCS_REF" >/dev/null 2>&1; then
+          echo "Using livetemplate/docs branch: $DOCS_REF"
+          git fetch origin "$DOCS_REF" --depth=1
+          git checkout FETCH_HEAD
+        else
+          echo "No matching livetemplate/docs branch for $DOCS_REF; using default branch"
+        fi
+
+    - name: Checkout client library
+      uses: actions/checkout@v4
+      with:
+        repository: livetemplate/client
+        path: livetemplate/client
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: livetemplate/client/package-lock.json
+
+    - name: Build client library
+      working-directory: livetemplate/client
+      run: |
+        echo "Installing client dependencies..."
+        npm ci
+        echo "Building client library..."
+        npm run build
+        echo "OK: Client library built successfully"
+        ls -la dist/
+
+    - name: Add replace directives to docs (parent module)
+      working-directory: docs
+      run: |
+        echo "Adding replace directives to docs..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../lvt
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Add replace directives to docs/e2e (separate module)
+      working-directory: docs/e2e
+      run: |
+        echo "Adding replace directives to docs/e2e..."
+        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
+        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
+        go mod edit -replace=github.com/livetemplate/docs=../
+        go mod tidy
+        echo "OK: Replace directives added"
+
+    - name: Run shared-notepad e2e against core
+      working-directory: docs/e2e/shared-notepad
+      run: go test -v -count=1 -timeout=15m ./...
+      env:
+        CGO_ENABLED: 1
+        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
+
   test-tinkerdown:
     name: Test Tinkerdown against Core Changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Sibling CI jobs to `test-docs` / `test-docs-todos` / `test-docs-progressive-enhancement`, covering the two recipes that landed in livetemplate/docs#19 (`login` and `shared-notepad` folded as deep-dive recipes under `content/recipes/<slug>/`).

Each new job is a verbatim clone of `test-docs-progressive-enhancement` with the `working-directory` swapped — same matching-docs-branch fallback, same replace-directive plumbing for both `docs` and `docs/e2e` modules, same client build, same Go 1.26 / Node 20 setup.

Total `test-docs-*` jobs becomes 5 (`test-docs`, `test-docs-todos`, `test-docs-progressive-enhancement`, `test-docs-login`, `test-docs-shared-notepad`).

## Why ship the duplication

The five jobs differ only in `working-directory`. livetemplate#404 already tracks the reusable-workflow refactor that should fold these into a single callable. Shipping this PR with copy-paste duplication is consistent with the cadence the project has been using since #402 — the migrations land first, the consolidation follows in one focused PR. Flipping the order would have meant blocking docs migrations on CI cleanup.

## Test plan

- [x] Local `bash scripts/pre-commit.sh` clean (golangci-lint + full unit suite + pubsub Redis integration tests; 24.5s pubsub suite green)
- [ ] Both new jobs run on this PR (the matching-docs-branch fallback will check out `main` since the docs repo has no branch with this name)
- [ ] Both new jobs go green against docs main — verified post-CI

PR ordering: livetemplate/docs#19 already merged at `f05fcd8`, so `docs/e2e/login/` and `docs/e2e/shared-notepad/` exist on docs main and the new jobs can resolve their working directories on the first run — no chicken-and-egg rerun dance needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)