### PR TITLE
feat: lifecycle/Context/Session ergonomics helpers (closes #339 #340 #341 #345)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ LiveTemplate is a high-performance Go library for building reactive web applicat
 Controllers hold dependencies (singleton, never cloned). State holds pure data (cloned per session). Action methods: `func (c *Controller) Action(state State, ctx *Context) (State, error)`. Mount runs on every HTTP request and WebSocket connect.
 
 **Key caveats:**
-- **Mount() guard pattern:** Mount runs on POST too, so guard side effects: `if ctx.Action() == "" { trackPageView() }` — only fires on GET, not form submissions.
+- **Mount() guard pattern:** Mount runs on POST too, so guard side effects with the connect-kind helpers: `if ctx.IsInitialMount() { trackPageView() }` (initial HTTP GET only) or `if ctx.IsReconnect() { ... }` (WS reconnect with restored state). The older `if ctx.Action() == ""` idiom still works but conflates GETs with WS connects/reconnects and internal navigate POSTs.
 - **BroadcastAction ordering:** `ctx.With*()` creates shallow copies. Call `ctx.BroadcastAction()` AFTER all `With*()` calls, or broadcasts queued before the copy won't propagate.
 - **AssertPureState[T]():** Use in tests to catch dependency types accidentally in state structs.
 

--- a/context.go
+++ b/context.go
@@ -28,7 +28,35 @@ type UploadAccessor interface {
 type FlashSetter interface {
 	setFlash(key, message string, expiry time.Duration)
 	clearFlashKey(key string)
+	clearAllFlash()
 }
+
+// ConnectKind classifies the lifecycle path that produced this Context.
+// Use Context.IsInitialMount() and Context.IsReconnect() instead of
+// inspecting this value directly — those helpers encode the intended
+// guard patterns.
+type ConnectKind int
+
+const (
+	// ConnectKindAction is the default — a user-triggered action
+	// (form submit, button click, server-dispatched broadcast).
+	ConnectKindAction ConnectKind = iota
+
+	// ConnectKindInitialMount indicates Mount was invoked on an HTTP GET
+	// request (initial page load or page refresh, not an action POST).
+	ConnectKindInitialMount
+
+	// ConnectKindNewConnect indicates Mount/OnConnect was invoked on the
+	// first WebSocket connection for this session group (no prior
+	// persisted state was restored).
+	ConnectKindNewConnect
+
+	// ConnectKindReconnect indicates Mount/OnConnect was invoked on a
+	// WebSocket connect where persisted state was restored from
+	// SessionStore (true reconnect, or a returning user with a surviving
+	// session).
+	ConnectKindReconnect
+)
 
 // broadcastRequest represents a deferred broadcast action to be dispatched
 // to other connections in the same session group after the current action completes.
@@ -54,6 +82,7 @@ type Context struct {
 	flashSetter FlashSetter
 	formSchema  *FormSchema
 	broadcasts  []broadcastRequest
+	connectKind ConnectKind
 
 	// HTTP context (nil for WebSocket actions)
 	w          http.ResponseWriter
@@ -238,6 +267,53 @@ func (c *Context) WithAction(action string) *Context {
 	return &newCtx
 }
 
+// WithConnectKind returns a new Context with the given connect classification.
+// This is set by the framework when constructing the lifecycle Context —
+// controllers should not call it directly. Use IsInitialMount / IsReconnect
+// to read the classification.
+func (c *Context) WithConnectKind(kind ConnectKind) *Context {
+	newCtx := *c
+	newCtx.connectKind = kind
+	return &newCtx
+}
+
+// IsInitialMount reports whether this Mount call is from an initial HTTP GET
+// (page load or refresh). Returns false for HTTP POST actions, WebSocket
+// new-connects, and WebSocket reconnects. Use this to guard one-time setup
+// that should only run on a page load — for example, spawning a background
+// goroutine, kicking off lazy data fetches, or recording analytics:
+//
+//	func (c *MyController) Mount(state State, ctx *livetemplate.Context) (State, error) {
+//	    if ctx.IsInitialMount() {
+//	        state.Loading = true
+//	        state.Data = ""
+//	    }
+//	    return state, nil
+//	}
+//
+// This replaces the older `ctx.Action() == ""` idiom, which also returned
+// true for WebSocket connects/reconnects and internal POST navigations.
+func (c *Context) IsInitialMount() bool {
+	return c.connectKind == ConnectKindInitialMount
+}
+
+// IsReconnect reports whether this Mount/OnConnect call is from a WebSocket
+// connect where persisted state was restored — a true reconnect, or a
+// returning user with a surviving session. Use this when a pattern needs
+// to recover background-pushed state across network blips, for example
+// re-announcing presence or skipping a re-fetch the previous connection
+// already completed:
+//
+//	func (c *ChatController) OnConnect(state State, ctx *livetemplate.Context) (State, error) {
+//	    if ctx.IsReconnect() {
+//	        state.SystemMessages = append(state.SystemMessages, "[reconnected]")
+//	    }
+//	    return state, nil
+//	}
+func (c *Context) IsReconnect() bool {
+	return c.connectKind == ConnectKindReconnect
+}
+
 // WithData returns a new Context with the given data.
 func (c *Context) WithData(data map[string]interface{}) *Context {
 	newCtx := *c
@@ -402,6 +478,28 @@ func (c *Context) SetFlash(key, message string, opts ...FlashOption) {
 func (c *Context) ClearFlash(key string) {
 	if c.flashSetter != nil {
 		c.flashSetter.clearFlashKey(key)
+	}
+}
+
+// ClearAllFlash atomically clears every flash message on this connection.
+// Use this when navigating to a context where prior flash messages are no
+// longer relevant — for example, on logout or before redirecting to a
+// section where a stale "Saved!" notification from a different page would
+// be confusing.
+//
+// Mirrors ClearFlash but operates on all keys at once. Field-validation
+// errors (set via ctx.SetError) are unaffected.
+//
+// Example:
+//
+//	func (c *AuthController) Logout(state AuthState, ctx *livetemplate.Context) (AuthState, error) {
+//	    ctx.ClearAllFlash()
+//	    state.User = nil
+//	    return state, nil
+//	}
+func (c *Context) ClearAllFlash() {
+	if c.flashSetter != nil {
+		c.flashSetter.clearAllFlash()
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -318,8 +318,9 @@ func (c *Context) IsInitialMount() bool {
 	return c.connectKind == ConnectKindInitialMount
 }
 
-// IsReconnect reports whether this Mount/OnConnect call is from a WebSocket
-// connect where persisted state was restored. Use this when a pattern needs
+// IsReconnect reports whether previously persisted state was restored from
+// SessionStore for this Mount/OnConnect call — that is, "state was restored",
+// not "a prior WebSocket connection existed." Use this when a pattern needs
 // to recover background-pushed state across network blips, for example
 // re-announcing presence or skipping a re-fetch the previous connection
 // already completed:

--- a/context.go
+++ b/context.go
@@ -347,6 +347,10 @@ func (c *Context) IsInitialMount() bool {
 // IsReconnect does NOT track whether a prior WebSocket connection actually
 // existed — distinguishing that would require additional bookkeeping in
 // SessionStore.
+//
+// During a __navigate__ re-mount, this value reflects the underlying WS
+// connect-kind, not the navigate event — see docs/references/navigate.md
+// for the full preservation rules.
 func (c *Context) IsReconnect() bool {
 	return c.connectKind == ConnectKindReconnect
 }
@@ -365,6 +369,10 @@ func (c *Context) IsReconnect() bool {
 //	    }
 //	    return state, nil
 //	}
+//
+// During a __navigate__ re-mount, this value reflects the underlying WS
+// connect-kind, not the navigate event — see docs/references/navigate.md
+// for the full preservation rules.
 func (c *Context) IsNewConnect() bool {
 	return c.connectKind == ConnectKindNewConnect
 }

--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package livetemplate
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -32,9 +33,9 @@ type FlashSetter interface {
 }
 
 // ConnectKind classifies the lifecycle path that produced this Context.
-// Use Context.IsInitialMount() and Context.IsReconnect() instead of
-// inspecting this value directly — those helpers encode the intended
-// guard patterns.
+// Use Context.IsInitialMount(), Context.IsNewConnect(), and
+// Context.IsReconnect() instead of inspecting this value directly — those
+// helpers encode the intended guard patterns.
 type ConnectKind int
 
 const (
@@ -57,6 +58,25 @@ const (
 	// session).
 	ConnectKindReconnect
 )
+
+// String returns a stable human-readable name for the ConnectKind, suitable
+// for log lines and slog attributes. Unknown values fall back to
+// "ConnectKind(<int>)" rather than panicking so future variants don't break
+// existing log scrapers.
+func (k ConnectKind) String() string {
+	switch k {
+	case ConnectKindAction:
+		return "action"
+	case ConnectKindInitialMount:
+		return "initial_mount"
+	case ConnectKindNewConnect:
+		return "new_connect"
+	case ConnectKindReconnect:
+		return "reconnect"
+	default:
+		return fmt.Sprintf("ConnectKind(%d)", int(k))
+	}
+}
 
 // broadcastRequest represents a deferred broadcast action to be dispatched
 // to other connections in the same session group after the current action completes.
@@ -268,9 +288,10 @@ func (c *Context) WithAction(action string) *Context {
 }
 
 // WithConnectKind returns a new Context with the given connect classification.
-// This is set by the framework when constructing the lifecycle Context —
-// controllers should not call it directly. Use IsInitialMount / IsReconnect
-// to read the classification.
+// The framework sets this at lifecycle-Context construction time; production
+// controllers typically read the classification via IsInitialMount,
+// IsNewConnect, and IsReconnect rather than calling this builder directly.
+// Tests that need to construct a Context with a specific kind may use it.
 func (c *Context) WithConnectKind(kind ConnectKind) *Context {
 	newCtx := *c
 	newCtx.connectKind = kind
@@ -298,8 +319,7 @@ func (c *Context) IsInitialMount() bool {
 }
 
 // IsReconnect reports whether this Mount/OnConnect call is from a WebSocket
-// connect where persisted state was restored — a true reconnect, or a
-// returning user with a surviving session. Use this when a pattern needs
+// connect where persisted state was restored. Use this when a pattern needs
 // to recover background-pushed state across network blips, for example
 // re-announcing presence or skipping a re-fetch the previous connection
 // already completed:
@@ -310,8 +330,43 @@ func (c *Context) IsInitialMount() bool {
 //	    }
 //	    return state, nil
 //	}
+//
+// Semantics — IsReconnect is true whenever the framework's SessionStore
+// returned previously persisted state for this group, which includes:
+//
+//   - A true WebSocket reconnect after a network blip.
+//   - A returning user with a surviving SessionStore entry (e.g. opened a
+//     bookmark after the prior tab was closed).
+//   - The very first WebSocket connect that follows an HTTP GET in the same
+//     session: the HTTP-path Mount persists state, then the WS connect
+//     restores it. This is detectable in user controllers and may be
+//     unexpected; pair this helper with [IsNewConnect] when you need to
+//     distinguish a brand-new WS session from one that has any persisted
+//     history.
+//
+// IsReconnect does NOT track whether a prior WebSocket connection actually
+// existed — distinguishing that would require additional bookkeeping in
+// SessionStore.
 func (c *Context) IsReconnect() bool {
 	return c.connectKind == ConnectKindReconnect
+}
+
+// IsNewConnect reports whether this Mount/OnConnect call is the first
+// WebSocket connection for this session group with no prior persisted state.
+// Mutually exclusive with IsReconnect (which fires when state was restored)
+// and IsInitialMount (which fires on the HTTP-path Mount).
+//
+// Use this to gate one-time-per-WebSocket-session setup that must NOT run
+// again on a reconnect:
+//
+//	func (c *ChatController) OnConnect(state State, ctx *livetemplate.Context) (State, error) {
+//	    if ctx.IsNewConnect() {
+//	        c.metrics.NewSessions.Inc()
+//	    }
+//	    return state, nil
+//	}
+func (c *Context) IsNewConnect() bool {
+	return c.connectKind == ConnectKindNewConnect
 }
 
 // WithData returns a new Context with the given data.

--- a/context_test.go
+++ b/context_test.go
@@ -403,3 +403,51 @@ func TestContext_GetString_NumericValues(t *testing.T) {
 		t.Errorf("GetString(zero) = %q, want %q", got, "0")
 	}
 }
+
+// TestContext_ConnectKindHelpers exhaustively verifies the IsInitialMount /
+// IsReconnect matrix across every ConnectKind value, including the default
+// (zero-value) case where WithConnectKind was never called.
+func TestContext_ConnectKindHelpers(t *testing.T) {
+	tests := []struct {
+		name           string
+		set            bool // false => leave ConnectKind defaulted (zero-value path)
+		kind           ConnectKind
+		wantInitialMnt bool
+		wantReconnect  bool
+	}{
+		{name: "default (no WithConnectKind)", set: false, wantInitialMnt: false, wantReconnect: false},
+		{name: "ConnectKindAction", set: true, kind: ConnectKindAction, wantInitialMnt: false, wantReconnect: false},
+		{name: "ConnectKindInitialMount", set: true, kind: ConnectKindInitialMount, wantInitialMnt: true, wantReconnect: false},
+		{name: "ConnectKindNewConnect", set: true, kind: ConnectKindNewConnect, wantInitialMnt: false, wantReconnect: false},
+		{name: "ConnectKindReconnect", set: true, kind: ConnectKindReconnect, wantInitialMnt: false, wantReconnect: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := NewContext(context.Background(), "", nil)
+			if tc.set {
+				ctx = ctx.WithConnectKind(tc.kind)
+			}
+			if got := ctx.IsInitialMount(); got != tc.wantInitialMnt {
+				t.Errorf("IsInitialMount() = %v, want %v", got, tc.wantInitialMnt)
+			}
+			if got := ctx.IsReconnect(); got != tc.wantReconnect {
+				t.Errorf("IsReconnect() = %v, want %v", got, tc.wantReconnect)
+			}
+		})
+	}
+}
+
+// TestContext_WithConnectKindIsImmutable verifies WithConnectKind follows the
+// same copy-on-write pattern as WithAction/WithUserID — the receiver is
+// untouched and a new Context is returned.
+func TestContext_WithConnectKindIsImmutable(t *testing.T) {
+	parent := NewContext(context.Background(), "", nil)
+	child := parent.WithConnectKind(ConnectKindReconnect)
+
+	if parent.IsReconnect() {
+		t.Error("parent Context mutated by WithConnectKind, want it untouched")
+	}
+	if !child.IsReconnect() {
+		t.Error("child Context did not record ConnectKindReconnect")
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -405,21 +405,24 @@ func TestContext_GetString_NumericValues(t *testing.T) {
 }
 
 // TestContext_ConnectKindHelpers exhaustively verifies the IsInitialMount /
-// IsReconnect matrix across every ConnectKind value, including the default
-// (zero-value) case where WithConnectKind was never called.
+// IsNewConnect / IsReconnect matrix across every ConnectKind value, including
+// the default (zero-value) case where WithConnectKind was never called. The
+// helpers must be mutually exclusive — at most one can be true for any
+// given Context.
 func TestContext_ConnectKindHelpers(t *testing.T) {
 	tests := []struct {
 		name           string
 		set            bool // false => leave ConnectKind defaulted (zero-value path)
 		kind           ConnectKind
 		wantInitialMnt bool
+		wantNewConnect bool
 		wantReconnect  bool
 	}{
-		{name: "default (no WithConnectKind)", set: false, wantInitialMnt: false, wantReconnect: false},
-		{name: "ConnectKindAction", set: true, kind: ConnectKindAction, wantInitialMnt: false, wantReconnect: false},
-		{name: "ConnectKindInitialMount", set: true, kind: ConnectKindInitialMount, wantInitialMnt: true, wantReconnect: false},
-		{name: "ConnectKindNewConnect", set: true, kind: ConnectKindNewConnect, wantInitialMnt: false, wantReconnect: false},
-		{name: "ConnectKindReconnect", set: true, kind: ConnectKindReconnect, wantInitialMnt: false, wantReconnect: true},
+		{name: "default (no WithConnectKind)", set: false, wantInitialMnt: false, wantNewConnect: false, wantReconnect: false},
+		{name: "ConnectKindAction", set: true, kind: ConnectKindAction, wantInitialMnt: false, wantNewConnect: false, wantReconnect: false},
+		{name: "ConnectKindInitialMount", set: true, kind: ConnectKindInitialMount, wantInitialMnt: true, wantNewConnect: false, wantReconnect: false},
+		{name: "ConnectKindNewConnect", set: true, kind: ConnectKindNewConnect, wantInitialMnt: false, wantNewConnect: true, wantReconnect: false},
+		{name: "ConnectKindReconnect", set: true, kind: ConnectKindReconnect, wantInitialMnt: false, wantNewConnect: false, wantReconnect: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -430,10 +433,41 @@ func TestContext_ConnectKindHelpers(t *testing.T) {
 			if got := ctx.IsInitialMount(); got != tc.wantInitialMnt {
 				t.Errorf("IsInitialMount() = %v, want %v", got, tc.wantInitialMnt)
 			}
+			if got := ctx.IsNewConnect(); got != tc.wantNewConnect {
+				t.Errorf("IsNewConnect() = %v, want %v", got, tc.wantNewConnect)
+			}
 			if got := ctx.IsReconnect(); got != tc.wantReconnect {
 				t.Errorf("IsReconnect() = %v, want %v", got, tc.wantReconnect)
 			}
+			// Mutual exclusion: at most one helper may be true at a time.
+			trueCount := 0
+			for _, b := range []bool{tc.wantInitialMnt, tc.wantNewConnect, tc.wantReconnect} {
+				if b {
+					trueCount++
+				}
+			}
+			if trueCount > 1 {
+				t.Errorf("test case advertises %d true helpers — they must be mutually exclusive", trueCount)
+			}
 		})
+	}
+}
+
+// TestConnectKind_String verifies the Stringer produces stable, human-readable
+// names for every defined value plus a safe fallback for unknown values
+// (future variants must not panic existing log scrapers).
+func TestConnectKind_String(t *testing.T) {
+	cases := map[ConnectKind]string{
+		ConnectKindAction:       "action",
+		ConnectKindInitialMount: "initial_mount",
+		ConnectKindNewConnect:   "new_connect",
+		ConnectKindReconnect:    "reconnect",
+		ConnectKind(99):         "ConnectKind(99)", // unknown future value
+	}
+	for k, want := range cases {
+		if got := k.String(); got != want {
+			t.Errorf("ConnectKind(%d).String() = %q, want %q", int(k), got, want)
+		}
 	}
 }
 

--- a/docs/proposals/patterns.md
+++ b/docs/proposals/patterns.md
@@ -2225,10 +2225,10 @@ State is pure data (`AssertPureState` still passes) and gets repopulated on ever
 - `chromedp.Click` on a `<select>` doesn't open the native dropdown. **Fix:** `chromedp.SetValue(selector, value)` + dispatch a synthetic `change` event via `chromedp.Evaluate`. Extract this into a test helper (`selectValueAndDispatchChange`) and reuse.
 - `chromedp.Click` doesn't reliably trigger event-delegation handlers. **Fix:** `document.querySelector(...).click()` via `chromedp.Evaluate`.
 
-**`Mount()` reading URL query params:** `Mount` runs on POST too, so guard URL reads with `if ctx.Action() == ""`. Also **validate** query param values against an allowed set — unknown values should silently fall back to the current state field (not 404, not flash error). Bookmarks with stale values shouldn't crash. Always call the filter function OUTSIDE the guard so initial render AND POSTs both populate the table:
+**`Mount()` reading URL query params:** `Mount` runs on POST too, so guard URL reads with `if ctx.IsInitialMount()` (preferred — true only on initial HTTP GET) or the older `if ctx.Action() == ""` (also true on WS connects/reconnects and internal navigate POSTs). Also **validate** query param values against an allowed set — unknown values should silently fall back to the current state field (not 404, not flash error). Bookmarks with stale values shouldn't crash. Always call the filter function OUTSIDE the guard so initial render AND POSTs both populate the table:
 ```go
 func (c *URLFiltersController) Mount(state URLFiltersState, ctx *Context) (URLFiltersState, error) {
-    if ctx.Action() == "" {
+    if ctx.IsInitialMount() {
         if s := ctx.QueryString("status"); validStatuses[s] { state.Status = s }
         if s := ctx.QueryString("sort"); validSorts[s] { state.Sort = s }
     }

--- a/docs/references/controller-pattern.md
+++ b/docs/references/controller-pattern.md
@@ -188,7 +188,7 @@ func (c *TodoController) OnConnect(state TodoState, ctx *livetemplate.Context) (
 - Start background jobs
 - Subscribe to real-time data feeds
 
-**Heads-up — `ctx.IsReconnect()` on the first WS:** When a browser does the normal flow (HTTP GET → server-renders → WebSocket connects), the framework persists state at the end of the HTTP-path Mount, then *restores* that state when the WebSocket opens. The WS-path `OnConnect` therefore sees `ctx.IsReconnect() == true` even though no prior WebSocket connection ever existed. If your `OnConnect` needs to distinguish "brand-new session" from "WS resumed after a blip", pair `IsReconnect()` with [`IsNewConnect()`](#) or gate on per-session state. See the `IsReconnect` godoc for the full semantics.
+**Heads-up — `ctx.IsReconnect()` on the first WS:** When a browser does the normal flow (HTTP GET → server-renders → WebSocket connects), the framework persists state at the end of the HTTP-path Mount, then *restores* that state when the WebSocket opens. The WS-path `OnConnect` therefore sees `ctx.IsReconnect() == true` even though no prior WebSocket connection ever existed. If your `OnConnect` needs to distinguish "brand-new session" from "WS resumed after a blip", pair `IsReconnect()` with `IsNewConnect()` or gate on per-session state. See the `IsReconnect` godoc for the full semantics.
 
 ### OnDisconnect
 

--- a/docs/references/controller-pattern.md
+++ b/docs/references/controller-pattern.md
@@ -188,6 +188,8 @@ func (c *TodoController) OnConnect(state TodoState, ctx *livetemplate.Context) (
 - Start background jobs
 - Subscribe to real-time data feeds
 
+**Heads-up — `ctx.IsReconnect()` on the first WS:** When a browser does the normal flow (HTTP GET → server-renders → WebSocket connects), the framework persists state at the end of the HTTP-path Mount, then *restores* that state when the WebSocket opens. The WS-path `OnConnect` therefore sees `ctx.IsReconnect() == true` even though no prior WebSocket connection ever existed. If your `OnConnect` needs to distinguish "brand-new session" from "WS resumed after a blip", pair `IsReconnect()` with [`IsNewConnect()`](#) or gate on per-session state. See the `IsReconnect` godoc for the full semantics.
+
 ### OnDisconnect
 
 Called when a WebSocket connection is closed:

--- a/docs/references/controller-pattern.md
+++ b/docs/references/controller-pattern.md
@@ -139,6 +139,32 @@ func (c *TodoController) Mount(state TodoState, ctx *livetemplate.Context) (Todo
 - Set up computed fields
 - Initialize state based on user context
 
+**Guarding side effects per connect kind:** Mount runs on HTTP GET, HTTP POST actions, WebSocket new-connect, and WebSocket reconnect. Use `ctx.IsInitialMount()` to limit one-time setup (e.g. starting a background goroutine) to initial page loads, and `ctx.IsReconnect()` to detect a WebSocket reconnect that restored persisted state:
+
+```go
+func (c *TodoController) Mount(state TodoState, ctx *livetemplate.Context) (TodoState, error) {
+    if ctx.IsInitialMount() {
+        // Only on initial HTTP GET — not POST actions, not WS connects.
+        state.Loading = true
+        go c.warmCacheFor(ctx.UserID())
+    }
+    return state, nil
+}
+```
+
+```go
+func (c *ChatController) OnConnect(state ChatState, ctx *livetemplate.Context) (ChatState, error) {
+    if ctx.IsReconnect() {
+        // Network blipped — re-announce presence, skip re-fetches the prior
+        // connection already completed.
+        state.SystemMessages = append(state.SystemMessages, "[reconnected]")
+    }
+    return state, nil
+}
+```
+
+The older `ctx.Action() == ""` idiom still works (it returns true for GET, internal navigate POSTs, and WS connects/reconnects), but the new helpers disambiguate the four lifecycle paths and make intent obvious to readers.
+
 ### OnConnect
 
 Called when a WebSocket connection is established:

--- a/docs/references/navigate.md
+++ b/docs/references/navigate.md
@@ -65,6 +65,14 @@ if ctx.Action() == "" && !state.PageViewTracked {
 }
 ```
 
+**`ConnectKind` behavior during navigate re-mounts:** The dispatch loop applies `WithAction("")` to the WS connection's lifecycle Context for `__navigate__`, which shallow-copies the Context and preserves `connectKind`. So inside a navigate re-mount:
+
+- `ctx.IsInitialMount()` is always **false** (the GET fired earlier, with a different Context).
+- `ctx.IsNewConnect()` reflects the *original* WS connect-time classification — true if the underlying WS was the first connect for this group, false otherwise.
+- `ctx.IsReconnect()` likewise reflects the original WS classification — true if state was restored when the WS first connected.
+
+Only `IsInitialMount()` is guaranteed false inside a navigate re-mount; the other two helpers report the underlying WS's connect-kind, not a navigate-specific value.
+
 ### Read query params from `ctx`
 
 Inside Mount, `ctx.GetString("filter")` and friends return whatever was in `msg.Data` for a `__navigate__`, or the URL query for the initial GET. Same call site, same data shape — your Mount code does not need to branch on "am I initial vs. navigate."

--- a/docs/references/navigate.md
+++ b/docs/references/navigate.md
@@ -42,20 +42,28 @@ If the WebSocket is not OPEN, the client falls through to fetch-based navigation
 
 Mount runs on every HTTP request, every WS connect, AND every `__navigate__`. Crucially, **inside Mount, a `__navigate__` re-run is indistinguishable from a connect-time Mount** — the dispatch loop deliberately rebinds `ctx.Action()` to `""` for navigate so handlers don't have to special-case it. (Grep `mount.go` for `WithAction("") // ctx.Action()=="" matches connect-time Mount`.)
 
-That means the standard `if ctx.Action() == "" { ... }` guard from the controller-pattern docs filters out form POSTs but does **not** filter out navigate re-mounts. If you have side effects that must fire exactly once per session (analytics page-view, audit log, expensive bootstrap), gate them on per-session state, not on `ctx.Action()`:
+That means the standard `if ctx.Action() == "" { ... }` guard from the controller-pattern docs filters out form POSTs but does **not** filter out navigate re-mounts — it still fires on each `__navigate__`. There are two ways to handle one-time side effects (analytics page-view, audit log, expensive bootstrap):
+
+**Preferred — `ctx.IsInitialMount()`:** Returns true only for the initial HTTP GET, false for WS new-connects, reconnects, *and* `__navigate__` re-mounts (which dispatch through the WS event loop as an action, not as a GET). Side effects fire exactly once per initial page load:
 
 ```go
 func (c *Controller) Mount(state State, ctx *livetemplate.Context) (State, error) {
-    if ctx.Action() == "" && !state.PageViewTracked {
+    if ctx.IsInitialMount() {
         c.analytics.TrackPageView(ctx.UserID())
-        state.PageViewTracked = true
     }
     state.Filter = ctx.GetString("filter")
     return state, nil
 }
 ```
 
-State persists across navigate re-mounts within the same session, so the `PageViewTracked` flag survives. This pattern is the recommended workaround until a first-class "is this the initial mount" signal lands; see issue [#346](https://github.com/livetemplate/livetemplate/issues/346) for the related discussion on `BroadcastAction` semantics inside navigate Mount.
+**Fallback — `ctx.Action() == ""` + persist flag:** If you still use the older idiom (which is true for GETs, WS connects, *and* navigate re-mounts), gate side effects on per-session state so they don't fire repeatedly:
+
+```go
+if ctx.Action() == "" && !state.PageViewTracked {
+    c.analytics.TrackPageView(ctx.UserID())
+    state.PageViewTracked = true
+}
+```
 
 ### Read query params from `ctx`
 

--- a/docs/references/session.md
+++ b/docs/references/session.md
@@ -37,7 +37,7 @@ In this example, `Filter` and `Page` survive page refreshes because they are per
 
 **Mount() lifecycle:** `Mount()` is called on every HTTP request (GET and POST) and every WebSocket connect (new and reconnect). It receives the current state (with persisted fields restored, ephemeral fields at zero value) and returns refreshed state. This ensures data is always fresh from the database. Keep Mount cheap -- it runs on every request.
 
-**Mount on POST:** Since Mount runs before actions on HTTP POST, it must populate ephemeral fields (e.g., `state.Items = db.GetItems(state.Filter)`). Persisted fields like `Filter` and `Page` are already restored from the SessionStore before Mount receives the state. Guard side effects with `ctx.Action() == ""` to restrict them to page loads.
+**Mount on POST:** Since Mount runs before actions on HTTP POST, it must populate ephemeral fields (e.g., `state.Items = db.GetItems(state.Filter)`). Persisted fields like `Filter` and `Page` are already restored from the SessionStore before Mount receives the state. Guard side effects with `ctx.IsInitialMount()` (preferred — true only on HTTP GET) or the older `ctx.Action() == ""` (true on GET, internal navigate POSTs, and WS connects/reconnects).
 
 ### State Persistence Matrix
 

--- a/flash_lifecycle_test.go
+++ b/flash_lifecycle_test.go
@@ -1,6 +1,7 @@
 package livetemplate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http/httptest"
@@ -593,4 +594,73 @@ func TestClearFlashThroughPublicAPI(t *testing.T) {
 	if got := fmt.Sprintf("%v", v); got != "" {
 		t.Errorf("ClearFlashAction: flash slot = %q, want %q (empty after clear)", got, "")
 	}
+}
+
+// TestClearAllFlashRemovesAllFlashMessages verifies that clearAllFlash drops
+// every flash entry on the connection, including those with and without an
+// expiry, while leaving non-flash entries (field errors) intact. Mirrors the
+// single-key TestClearFlashRemovesMessage but exercises the bulk-clear path
+// used by Context.ClearAllFlash (e.g. on logout).
+func TestClearAllFlashRemovesAllFlashMessages(t *testing.T) {
+	cs := newFlashState()
+
+	// Mix of flash entries: one with expiry, one without.
+	cs.setFlash("success", "Saved!", time.Hour)
+	cs.setFlash("warning", "Heads up", 0)
+	// Plus a field-validation error — must survive the clear.
+	cs.setError("email", "Invalid address")
+
+	if !flashPresent(cs, "success") || !flashPresent(cs, "warning") {
+		t.Fatal("setup: flash not present before clearAllFlash")
+	}
+
+	cs.clearAllFlash()
+
+	if flashPresent(cs, "success") {
+		t.Error("'success' flash still present after clearAllFlash")
+	}
+	if flashPresent(cs, "warning") {
+		t.Error("'warning' flash still present after clearAllFlash")
+	}
+	// Direct check on the expiry map — clearAllFlash drops it entirely.
+	if len(cs.flashExpiry) != 0 {
+		t.Errorf("flashExpiry has %d entries after clearAllFlash, want 0", len(cs.flashExpiry))
+	}
+	// Field error survives: validation state is a different namespace.
+	if got := cs.getMessages()["email"]; got != "Invalid address" {
+		t.Errorf("field error 'email' = %q after clearAllFlash, want 'Invalid address' (must survive)", got)
+	}
+}
+
+// TestClearAllFlashNoOpWhenEmpty verifies clearAllFlash is safe to call on a
+// connection with no flash messages — it must not panic when flashExpiry is
+// already nil and messages contains no flash entries.
+func TestClearAllFlashNoOpWhenEmpty(t *testing.T) {
+	cs := &connState{messages: make(map[string]string)} // flashExpiry left nil
+	cs.setError("name", "Required")
+
+	cs.clearAllFlash() // must not panic
+
+	if got := cs.getMessages()["name"]; got != "Required" {
+		t.Errorf("field error 'name' = %q after no-op clearAllFlash, want 'Required'", got)
+	}
+}
+
+// TestClearAllFlashViaContext verifies the public Context.ClearAllFlash entry
+// point flows through to the connState bulk-clear implementation.
+func TestClearAllFlashViaContext(t *testing.T) {
+	cs := newFlashState()
+	cs.setFlash("info", "Hello", 0)
+	cs.setFlash("error", "Oops", time.Hour)
+
+	ctx := NewContext(context.Background(), "", nil).WithFlashSetter(cs)
+	ctx.ClearAllFlash()
+
+	if flashPresent(cs, "info") || flashPresent(cs, "error") {
+		t.Error("Context.ClearAllFlash did not propagate to FlashSetter.clearAllFlash")
+	}
+
+	// Calling on a Context with no flashSetter must be a no-op (no panic).
+	bare := NewContext(context.Background(), "", nil)
+	bare.ClearAllFlash()
 }

--- a/handle_test.go
+++ b/handle_test.go
@@ -3045,3 +3045,119 @@ func TestHandle_PubSubSubscribeSuccessRegistersAll(t *testing.T) {
 		t.Errorf("SubscribeGroupActions should be called once, got %d", fb.groupActionCalls)
 	}
 }
+
+// ============================================================================
+// Issue #340: IsInitialMount / IsReconnect integration tests
+// ============================================================================
+//
+// connectKindState/controller capture the connect-kind flags observed by
+// Mount/OnConnect into persisted state. The persist tag on Count makes the
+// reconnect path restore prior state (which the framework uses to flag
+// IsReconnect=true). InitialMount/Reconnect are non-persist so they reflect
+// only the most recent Mount invocation.
+type connectKindState struct {
+	Count          int  `lvt:"persist"`
+	InitialMountWS bool // set by Mount — recorded as observed
+	ReconnectWS    bool // set by OnConnect — recorded as observed
+}
+
+type connectKindController struct{}
+
+func (c *connectKindController) Mount(state connectKindState, ctx *Context) (connectKindState, error) {
+	state.InitialMountWS = ctx.IsInitialMount()
+	state.ReconnectWS = ctx.IsReconnect()
+	return state, nil
+}
+
+func (c *connectKindController) OnConnect(state connectKindState, ctx *Context) (connectKindState, error) {
+	// OnConnect overwrites — both flags reflect the OnConnect call, which on
+	// the WS path always shares the lifecycle Context with Mount.
+	state.InitialMountWS = ctx.IsInitialMount()
+	state.ReconnectWS = ctx.IsReconnect()
+	state.Count++
+	return state, nil
+}
+
+// TestIsInitialMount_OnHTTPGet verifies that the HTTP GET path sets
+// ConnectKindInitialMount on the lifecycle Context. The test reads the
+// rendered HTML, which embeds the bool fields directly.
+func TestIsInitialMount_OnHTTPGet(t *testing.T) {
+	auth := &fixedGroupAuth{groupID: "connect-kind-http"}
+
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>im={{.InitialMountWS}} rc={{.ReconnectWS}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&connectKindController{}, AsState(&connectKindState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	bodyStr := string(body)
+
+	if !strings.Contains(bodyStr, "im=true") {
+		t.Errorf("HTTP GET: expected im=true in body, got: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "rc=false") {
+		t.Errorf("HTTP GET: expected rc=false in body, got: %s", bodyStr)
+	}
+}
+
+// TestIsReconnect_OnWSReconnect verifies that the WS reconnect path sets
+// ConnectKindReconnect on the lifecycle Context after persisted state was
+// restored. Uses reconnectWSRaw to close and reopen the WS — the second
+// connect restores Count via the persist tag, which is the signal the
+// framework uses to flag IsReconnect.
+func TestIsReconnect_OnWSReconnect(t *testing.T) {
+	auth := &fixedGroupAuth{groupID: "connect-kind-ws"}
+
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>im={{.InitialMountWS}} rc={{.ReconnectWS}} c={{.Count}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&connectKindController{}, AsState(&connectKindState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	// First connect: persist fields are empty, so this is ConnectKindNewConnect.
+	ws1, initialMsg := connectWSRaw(t, wsURL)
+	if v := treeDynamic(t, initialMsg, "0"); v != "false" {
+		t.Errorf("WS new-connect: im want false, got %q", v)
+	}
+	if v := treeDynamic(t, initialMsg, "1"); v != "false" {
+		t.Errorf("WS new-connect: rc want false, got %q", v)
+	}
+
+	// Reconnect: state persisted, so the WS path should flag ConnectKindReconnect.
+	ws2, reconnectMsg := reconnectWSRaw(t, wsURL, ws1)
+	defer func() {
+		if err := ws2.Close(); err != nil {
+			t.Logf("ws2 close: %v", err)
+		}
+	}()
+	if v := treeDynamic(t, reconnectMsg, "0"); v != "false" {
+		t.Errorf("WS reconnect: im want false (only HTTP GET sets it), got %q", v)
+	}
+	if v := treeDynamic(t, reconnectMsg, "1"); v != "true" {
+		t.Errorf("WS reconnect: rc want true after state restored, got %q. Full msg: %s", v, string(reconnectMsg))
+	}
+}

--- a/handle_test.go
+++ b/handle_test.go
@@ -3116,6 +3116,61 @@ func TestIsInitialMount_OnHTTPGet(t *testing.T) {
 	}
 }
 
+// TestIsReconnect_OnHTTPGetThenWSConnect pins the behavior that the very
+// first WS connect following an HTTP GET reports IsReconnect()=true. This
+// is because the HTTP-path Mount persists state, which the WS then
+// restores — restorePersistedState succeeds, the WS path sets
+// ConnectKindReconnect, and IsReconnect() returns true even though no prior
+// WebSocket connection ever existed.
+//
+// The behavior is intentional per the IsReconnect godoc, but it is easy to
+// overlook. Controllers that want "second-or-later WS connect" semantics
+// should pair IsReconnect with IsNewConnect or gate on per-session state.
+// See also the navigate.md doc note about connectKind preservation across
+// __navigate__ re-mounts.
+func TestIsReconnect_OnHTTPGetThenWSConnect(t *testing.T) {
+	auth := &fixedGroupAuth{groupID: "connect-kind-http-then-ws"}
+
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>im={{.InitialMountWS}} rc={{.ReconnectWS}} c={{.Count}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&connectKindController{}, AsState(&connectKindState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Step 1: HTTP GET. The HTTP-path Mount persists state, so a subsequent
+	// WS connect on the same session group will observe restored state.
+	resp, err := http.Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("HTTP GET failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// Step 2: WS connect from the same group. restorePersistedState
+	// succeeds → ConnectKindReconnect → IsReconnect()=true even though
+	// this is the very first WebSocket for the group.
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	ws, msg := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	if v := treeDynamic(t, msg, "0"); v != "false" {
+		t.Errorf("first WS after HTTP GET: im want false, got %q", v)
+	}
+	if v := treeDynamic(t, msg, "1"); v != "true" {
+		t.Errorf("first WS after HTTP GET: rc want true (state was restored from HTTP-path Mount), got %q. Full msg: %s", v, string(msg))
+	}
+}
+
 // TestIsReconnect_OnWSReconnect verifies that the WS reconnect path sets
 // ConnectKindReconnect on the lifecycle Context after persisted state was
 // restored. Uses reconnectWSRaw to close and reopen the WS — the second

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -1,6 +1,10 @@
 package livetemplate
 
-import "reflect"
+import (
+	"fmt"
+	"log/slog"
+	"reflect"
+)
 
 // =============================================================================
 // Controller Lifecycle Methods
@@ -117,6 +121,63 @@ func isValidLifecycleSignature(methodType reflect.Type, stateType reflect.Type) 
 	}
 
 	return true
+}
+
+// validateLifecycleSignatures walks the controller's methods and emits an
+// slog.Warn for any method whose name matches a known lifecycle name but
+// whose signature doesn't validate. Called once at handler construction
+// (Template.Handle) so the mismatch surfaces at server boot, before users
+// notice the "method never runs" symptom in development.
+//
+// Lifecycle methods recognized:
+//   - Mount, OnConnect: func(state StateType, ctx *Context) (StateType, error)
+//   - OnDisconnect:     func()
+//
+// Methods with these names but a wrong signature are silently skipped at
+// dispatch time by callLifecycleMethod / callOnDisconnect. This warning is
+// non-fatal — controllers that happen to define a helper method with one
+// of these names continue to function exactly as before.
+func validateLifecycleSignatures(controller interface{}, state interface{}) {
+	controllerType := reflect.TypeOf(controller)
+	stateType := reflect.TypeOf(state)
+	// callLifecycleMethod sees dereferenced value types (e.g. TodoState not
+	// *TodoState) — mirror HasActionMethod's dereference so the validator
+	// agrees with the dispatch path. Without this, valid Mount(value, *Context)
+	// methods are flagged as mismatches against a pointer expected type.
+	if stateType != nil && stateType.Kind() == reflect.Pointer {
+		stateType = stateType.Elem()
+	}
+
+	for _, name := range []string{"Mount", "OnConnect"} {
+		m, ok := controllerType.MethodByName(name)
+		if !ok {
+			continue
+		}
+		if isValidLifecycleSignature(m.Type, stateType) {
+			continue
+		}
+		slog.Warn("lifecycle method has invalid signature — will be skipped at runtime",
+			slog.String("component", "live_handler"),
+			slog.String("method", name),
+			slog.String("controller", controllerType.String()),
+			slog.String("expected",
+				fmt.Sprintf("func(%s, *livetemplate.Context) (%s, error)",
+					stateType, stateType)),
+			slog.String("got", m.Type.String()))
+	}
+
+	if m, ok := controllerType.MethodByName("OnDisconnect"); ok {
+		// OnDisconnect signature mirror of callOnDisconnect's check:
+		// NumIn = 1 (receiver only), NumOut = 0.
+		if m.Type.NumIn() != 1 || m.Type.NumOut() != 0 {
+			slog.Warn("lifecycle method has invalid signature — will be skipped at runtime",
+				slog.String("component", "live_handler"),
+				slog.String("method", "OnDisconnect"),
+				slog.String("controller", controllerType.String()),
+				slog.String("expected", "func()"),
+				slog.String("got", m.Type.String()))
+		}
+	}
 }
 
 // callOnDisconnect invokes OnDisconnect() on a controller if it exists.

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -140,11 +140,18 @@ func isValidLifecycleSignature(methodType reflect.Type, stateType reflect.Type) 
 func validateLifecycleSignatures(controller interface{}, state interface{}) {
 	controllerType := reflect.TypeOf(controller)
 	stateType := reflect.TypeOf(state)
+	// In production state.Inner() is the result of AsState and never nil;
+	// guard anyway so a misconfigured caller doesn't get a spurious "all
+	// lifecycle methods invalid" warning. callLifecycleMethod will surface
+	// the underlying issue at dispatch time.
+	if stateType == nil {
+		return
+	}
 	// callLifecycleMethod sees dereferenced value types (e.g. TodoState not
 	// *TodoState) — mirror HasActionMethod's dereference so the validator
 	// agrees with the dispatch path. Without this, valid Mount(value, *Context)
 	// methods are flagged as mismatches against a pointer expected type.
-	if stateType != nil && stateType.Kind() == reflect.Pointer {
+	if stateType.Kind() == reflect.Pointer {
 		stateType = stateType.Elem()
 	}
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -346,6 +346,23 @@ func TestValidateLifecycleSignatures_PointerStateMatchesValueReceiverMethod(t *t
 	}
 }
 
+// TestValidateLifecycleSignatures_NilStateIsSilent guards against a
+// spurious "all lifecycle methods invalid" warning when state.Inner()
+// returns nil. In production this shouldn't happen, but the early return
+// makes the failure mode explicit and quiet.
+func TestValidateLifecycleSignatures_NilStateIsSilent(t *testing.T) {
+	var buf syncBuf
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	validateLifecycleSignatures(&validLifecycleController{}, nil)
+
+	if strings.Contains(buf.String(), "invalid signature") {
+		t.Errorf("nil state should not produce invalid-signature warnings; got:\n%s", buf.String())
+	}
+}
+
 func TestValidateLifecycleSignatures_NoLifecycleMethodsIsSilent(t *testing.T) {
 	var buf syncBuf
 	prev := slog.Default()

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -3,6 +3,8 @@ package livetemplate
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -216,5 +218,143 @@ func TestCallOnDisconnect_WrongSignature(t *testing.T) {
 
 	if ctrl.Called {
 		t.Error("OnDisconnect with wrong signature should not be called")
+	}
+}
+
+// ============================================================================
+// Issue #341: validateLifecycleSignatures warn-at-boot
+// ============================================================================
+//
+// validateLifecycleSignatures runs at handler construction. The test installs
+// a slog handler against a syncBuf (defined in session_impl_test.go) for the
+// duration of the test so warnings land in a buffer we can assert against.
+
+// validLifecycleController has correct Mount, OnConnect, and OnDisconnect
+// signatures — must NOT trigger any warning.
+type validLifecycleController struct{}
+
+func (c *validLifecycleController) Mount(state testTodoState, ctx *Context) (testTodoState, error) {
+	return state, nil
+}
+func (c *validLifecycleController) OnConnect(state testTodoState, ctx *Context) (testTodoState, error) {
+	return state, nil
+}
+func (c *validLifecycleController) OnDisconnect() {}
+
+// wrongMountSigController has the Mount name but a bogus signature — must warn.
+type wrongMountSigController struct{}
+
+func (c *wrongMountSigController) Mount() error { return nil }
+
+// wrongOnConnectSigController has OnConnect with extra params — must warn.
+type wrongOnConnectSigController struct{}
+
+func (c *wrongOnConnectSigController) OnConnect(state testTodoState, ctx *Context, extra string) (testTodoState, error) {
+	return state, nil
+}
+
+// wrongOnDisconnectSigController has OnDisconnect with a return value — must warn.
+type wrongOnDisconnectSigController struct{}
+
+func (c *wrongOnDisconnectSigController) OnDisconnect() error { return nil }
+
+func TestValidateLifecycleSignatures_ValidIsSilent(t *testing.T) {
+	var buf syncBuf
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	validateLifecycleSignatures(&validLifecycleController{}, testTodoState{})
+
+	if strings.Contains(buf.String(), "invalid signature") {
+		t.Errorf("valid controller emitted invalid-signature warning:\n%s", buf.String())
+	}
+}
+
+func TestValidateLifecycleSignatures_WarnsOnWrongMount(t *testing.T) {
+	var buf syncBuf
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	validateLifecycleSignatures(&wrongMountSigController{}, testTodoState{})
+
+	out := buf.String()
+	if !strings.Contains(out, "invalid signature") {
+		t.Errorf("missing 'invalid signature' in warning output:\n%s", out)
+	}
+	if !strings.Contains(out, `method=Mount`) {
+		t.Errorf("warning missing method=Mount:\n%s", out)
+	}
+	// The controller type should appear so users can locate the offender.
+	if !strings.Contains(out, "wrongMountSigController") {
+		t.Errorf("warning missing controller type name:\n%s", out)
+	}
+}
+
+func TestValidateLifecycleSignatures_WarnsOnWrongOnConnect(t *testing.T) {
+	var buf syncBuf
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	validateLifecycleSignatures(&wrongOnConnectSigController{}, testTodoState{})
+
+	if !strings.Contains(buf.String(), `method=OnConnect`) {
+		t.Errorf("expected method=OnConnect warning, got:\n%s", buf.String())
+	}
+}
+
+func TestValidateLifecycleSignatures_WarnsOnWrongOnDisconnect(t *testing.T) {
+	var buf syncBuf
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	validateLifecycleSignatures(&wrongOnDisconnectSigController{}, testTodoState{})
+
+	if !strings.Contains(buf.String(), `method=OnDisconnect`) {
+		t.Errorf("expected method=OnDisconnect warning, got:\n%s", buf.String())
+	}
+}
+
+// TestValidateLifecycleSignatures_NoLifecycleMethodsIsSilent covers a
+// controller that defines unrelated action methods only — validator must
+// not warn on them.
+type onlyActionsController struct{}
+
+func (c *onlyActionsController) Increment(state testTodoState, ctx *Context) (testTodoState, error) {
+	return state, nil
+}
+
+// TestValidateLifecycleSignatures_PointerStateMatchesValueReceiverMethod
+// guards the dereference fix: AsState wraps a pointer, but lifecycle methods
+// are declared on the value type. The validator must dereference the state
+// type to agree with callLifecycleMethod, which sees the dereferenced value.
+func TestValidateLifecycleSignatures_PointerStateMatchesValueReceiverMethod(t *testing.T) {
+	var buf syncBuf
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// Pointer state, value-receiver lifecycle methods — the production setup
+	// (AsState(&Foo{}) + func (c *C) Mount(state Foo, ...) ...).
+	validateLifecycleSignatures(&validLifecycleController{}, &testTodoState{})
+
+	if strings.Contains(buf.String(), "invalid signature") {
+		t.Errorf("false positive on pointer state + value-receiver lifecycle method:\n%s", buf.String())
+	}
+}
+
+func TestValidateLifecycleSignatures_NoLifecycleMethodsIsSilent(t *testing.T) {
+	var buf syncBuf
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	validateLifecycleSignatures(&onlyActionsController{}, testTodoState{})
+
+	if strings.Contains(buf.String(), "invalid signature") {
+		t.Errorf("warning emitted for non-lifecycle method:\n%s", buf.String())
 	}
 }

--- a/mount.go
+++ b/mount.go
@@ -252,6 +252,20 @@ func (c *connState) clearFlashKey(key string) {
 	delete(c.flashExpiry, flashKey(key))
 }
 
+// clearAllFlash removes every flash message on this connection while
+// preserving field-validation errors. Called by Context.ClearAllFlash.
+func (c *connState) clearAllFlash() {
+	c.messagesMu.Lock()
+	defer c.messagesMu.Unlock()
+	for k := range c.messages {
+		if strings.HasPrefix(k, lvtcontext.FlashPrefix) {
+			delete(c.messages, k)
+		}
+	}
+	// Drop the expiry map outright — matches the lazy-init pattern in setFlash.
+	c.flashExpiry = nil
+}
+
 // pruneExpiredFlash removes only flash messages whose expiry has
 // passed. Flash messages without an expiry (expiry == zero time) are
 // NOT removed — they persist until explicitly cleared via ClearFlash.
@@ -446,8 +460,10 @@ func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Otherwise, always start with a fresh clone (ephemeral).
 	ctx := r.Context()
 	var typedState interface{}
+	var isReconnect bool
 	if restored, ok := h.restorePersistedState(ctx, groupID); ok {
 		typedState = restored
+		isReconnect = true
 	} else {
 		typedState, err = h.cloneStateTyped()
 		if err != nil {
@@ -605,10 +621,15 @@ func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// Use r.Context() (not context.Background()) so Mount/OnConnect cancel on disconnect (#303).
 	wsQueryData := send.QueryParamsToData(r)
+	connectKind := ConnectKindNewConnect
+	if isReconnect {
+		connectKind = ConnectKindReconnect
+	}
 	lifecycleCtx := NewContext(ctx, "", wsQueryData)
 	lifecycleCtx = lifecycleCtx.WithUserID(userID)
 	lifecycleCtx = lifecycleCtx.WithFlashSetter(connSt)
 	lifecycleCtx = lifecycleCtx.WithSession(newLocalSession(h, groupID))
+	lifecycleCtx = lifecycleCtx.WithConnectKind(connectKind)
 
 	// Call Mount on every WebSocket connect (new session AND reconnect).
 	// Mount() refreshes state from the database, ensuring actions always
@@ -1056,10 +1077,15 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Create lifecycle context with query params
 	queryData := send.QueryParamsToData(r)
+	connectKind := ConnectKindAction
+	if r.Method == http.MethodGet && !isAssetRequest {
+		connectKind = ConnectKindInitialMount
+	}
 	lifecycleCtx := NewContext(ctx, "", queryData)
 	lifecycleCtx = lifecycleCtx.WithUserID(userID)
 	lifecycleCtx = lifecycleCtx.WithFlashSetter(connSt)
 	lifecycleCtx = lifecycleCtx.WithSession(newLocalSession(h, groupID))
+	lifecycleCtx = lifecycleCtx.WithConnectKind(connectKind)
 
 	// Read flash messages from cookie (set by POST redirect)
 	if flashCookie, err := r.Cookie("lvt-flash"); err == nil && flashCookie.Value != "" {

--- a/session_impl.go
+++ b/session_impl.go
@@ -1,12 +1,25 @@
 package livetemplate
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/livetemplate/livetemplate/internal/session"
 	"github.com/livetemplate/livetemplate/pubsub"
 )
+
+// ErrSessionDisconnected is returned by Session.TriggerAction when the
+// session's connection group has no active connections and no PubSub
+// broadcaster is configured (single-instance mode). Background goroutines
+// using the canonical cancellation pattern should test for it via
+// errors.Is(err, ErrSessionDisconnected) and exit cleanly; other errors
+// (e.g. empty action, empty groupID) are caller bugs and warrant logging.
+//
+// In multi-instance mode (PubSubBroadcaster configured), TriggerAction
+// returns nil even with zero local connections — see the TriggerAction
+// godoc for the multi-instance disconnect contract.
+var ErrSessionDisconnected = errors.New("livetemplate: session disconnected")
 
 // localSession is the concrete implementation of the Session interface.
 // It dispatches server-initiated actions to every connection in a specific
@@ -122,7 +135,7 @@ func (s *localSession) TriggerAction(action string, data map[string]interface{})
 	gab, hasRemote := s.handler.config.PubSubBroadcaster.(pubsub.GroupActionBroadcaster)
 
 	if len(connections) == 0 && !hasRemote {
-		return fmt.Errorf("livetemplate: no connected sessions for group %q", s.groupID)
+		return fmt.Errorf("%w (group %q)", ErrSessionDisconnected, s.groupID)
 	}
 
 	// Defensive shallow copy of the caller's data map. Dispatch happens

--- a/session_impl.go
+++ b/session_impl.go
@@ -135,7 +135,11 @@ func (s *localSession) TriggerAction(action string, data map[string]interface{})
 	gab, hasRemote := s.handler.config.PubSubBroadcaster.(pubsub.GroupActionBroadcaster)
 
 	if len(connections) == 0 && !hasRemote {
-		return fmt.Errorf("%w (group %q)", ErrSessionDisconnected, s.groupID)
+		// Preserve the literal "no connected sessions" substring from the
+		// pre-sentinel error format so existing string-matching callers (log
+		// scrapers, ad-hoc grep-based monitoring) keep working. New callers
+		// should use errors.Is(err, ErrSessionDisconnected).
+		return fmt.Errorf("%w — no connected sessions for group %q", ErrSessionDisconnected, s.groupID)
 	}
 
 	// Defensive shallow copy of the caller's data map. Dispatch happens

--- a/session_impl_test.go
+++ b/session_impl_test.go
@@ -3,6 +3,7 @@ package livetemplate
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http/httptest"
@@ -201,8 +202,13 @@ func TestLocalSession_TriggerActionDisconnectedReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected TriggerAction to return an error when no connections exist, got nil")
 	}
-	if !strings.Contains(err.Error(), "no connected sessions") {
-		t.Errorf("Expected 'no connected sessions' in error, got: %v", err)
+	if !errors.Is(err, ErrSessionDisconnected) {
+		t.Errorf("Expected errors.Is(err, ErrSessionDisconnected) to be true, got: %v", err)
+	}
+	// The groupID must still surface in err.Error() so existing log scrapers
+	// (and humans reading server logs) keep working.
+	if !strings.Contains(err.Error(), "never-connected-group") {
+		t.Errorf("Expected groupID in error string, got: %v", err)
 	}
 }
 

--- a/session_impl_test.go
+++ b/session_impl_test.go
@@ -210,6 +210,12 @@ func TestLocalSession_TriggerActionDisconnectedReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "never-connected-group") {
 		t.Errorf("Expected groupID in error string, got: %v", err)
 	}
+	// Pin the pre-sentinel substring so callers doing
+	// strings.Contains(err.Error(), "no connected sessions") keep matching
+	// across the sentinel migration.
+	if !strings.Contains(err.Error(), "no connected sessions") {
+		t.Errorf("Expected legacy substring 'no connected sessions' to survive in error message, got: %v", err)
+	}
 }
 
 // chainedTriggerState exercises the dispatched->TriggerAction->dispatched

--- a/template.go
+++ b/template.go
@@ -1512,6 +1512,7 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 	}
 
 	mountCfg.Capabilities = detectCapabilities(controller, state.Inner(), &mountCfg)
+	validateLifecycleSignatures(controller, state.Inner())
 
 	limits := session.NewConnectionLimits(mountCfg.MaxConnections, mountCfg.MaxConnectionsPerGroup)
 	metrics := observe.NewMetrics(slog.Default())


### PR DESCRIPTION
## Summary

Bundles four small ergonomics follow-ups from the Session 3 patterns work (`livetemplate/examples#70`) and the PR #344 review cycle. All four overlap on `context.go`, `mount.go`, `lifecycle.go`, and the same documentation surface, so they land as one coherent PR for v0.9.0+ "Context/Session/lifecycle polish."

- **Closes #339** — `ErrSessionDisconnected` exported sentinel; `Session.TriggerAction` wraps via `fmt.Errorf("%w …", …)` so background goroutines can `errors.Is(err, livetemplate.ErrSessionDisconnected)` instead of string-matching.
- **Closes #340** — `ConnectKind` enum + `WithConnectKind` builder + `ctx.IsInitialMount()` / `ctx.IsReconnect()` helpers. Replaces the ambiguous `ctx.Action() == ""` idiom (which conflated HTTP GET, WS connect/reconnect, and internal navigate POSTs). Wired at the WS-connect site and the HTTP-serve site in `mount.go`. The older idiom continues to work.
- **Closes #341** — `validateLifecycleSignatures` walks the controller at handler construction and emits `slog.Warn` for any `Mount`/`OnConnect`/`OnDisconnect` method whose signature doesn't validate. Hooked into `Template.Handle` next to `detectCapabilities`. Includes pointer-deref of the state type so `AsState(&Foo{})` + value-receiver lifecycle methods don't false-positive.
- **Closes #345** — `Context.ClearAllFlash()` atomically clears every flash message while preserving field-validation errors. Companion to the persist-until-cleared flash lifecycle from PR #344.

All four are fully backward-compatible.

## Behavior note worth flagging for review

`ctx.IsReconnect()` returns `true` whenever `restorePersistedState` returns ok — which includes the **first WS connect that follows the HTTP GET** for the same session group (state was persisted by HTTP Mount, restored by WS). This is consistent with the issue's description ("WS reconnect, or returning user with persisted state") but may surprise users who expect "second-or-later WS connect" semantics. Refining this to track "had-prior-WS-connection" in SessionStore is left as a separate design decision — flagged for maintainer judgment, see the e2e test docstring for the observation.

## Test plan

- [x] `go fmt ./...` clean
- [x] `golangci-lint run --enable-only=errcheck,govet,ineffassign,staticcheck,unparam,unused` — 0 issues
- [x] `go test ./... -timeout 300s` — all pass (incl. Redis testcontainers)
- [x] `go test -race` on new + adjacent tests — pass
- [x] Go-level integration tests added:
  - `TestContext_ConnectKindHelpers` (matrix over all 4 `ConnectKind` values)
  - `TestIsInitialMount_OnHTTPGet`, `TestIsReconnect_OnWSReconnect` (real httptest + WS dial + reconnect)
  - `TestValidateLifecycleSignatures_{ValidIsSilent, WarnsOnWrong{Mount,OnConnect,OnDisconnect}, PointerStateMatchesValueReceiverMethod, NoLifecycleMethodsIsSilent}`
  - `TestClearAllFlash{RemovesAllFlashMessages, NoOpWhenEmpty, ViaContext}`
  - Updated `TestLocalSession_TriggerActionDisconnectedReturnsError` to assert `errors.Is(err, ErrSessionDisconnected)` and still surface groupID in `err.Error()`
- [x] **Chromedp e2e tests** (live in a follow-up PR against `livetemplate/lvt` once that repo bumps its `livetemplate` version): `TestE2E_IsInitialMount_RendersInInitialHTML`, `TestE2E_IsReconnect_ReflectsStateRestoration`, `TestE2E_ClearAllFlash_RemovesAllFlashFromDOM`, `TestE2E_ErrSessionDisconnected_HappyPathStillWorks`. All four ran green against this branch.

## Docs updated

- `CLAUDE.md` Mount-guard pattern line — now prefers `IsInitialMount`, keeps `Action() == ""` as fallback
- `docs/references/controller-pattern.md` — adds an explicit Mount-guard section with both helpers
- `docs/references/session.md` — POST-Mount guard updated
- `docs/references/navigate.md` — `__navigate__` re-mount guard updated, notes that `IsInitialMount()` correctly excludes navigate re-mounts (vs. `Action() == ""` which doesn't)
- `docs/proposals/patterns.md` — URL-query-filter pattern updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)