### PR TITLE
Phase 0: pub/sub topic foundations (registry indexes + topics.go)

### DIFF
--- a/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-0.md
+++ b/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-0.md
@@ -153,10 +153,30 @@ exactly as the spec's contingency intends).
   other `lvt:` string. (2) else `validateDeveloperTopic(topic)` (segment
   grammar). (3) else the ACL (deny-all default; only `SelfTopic()` exempt). The
   grammar is **never** applied to `lvt:` topics (it excludes `:`).
+  **Layering (must hold):** validation runs **in `ctx.Subscribe`, before** the
+  `registry.SubscribeConnectionToTopic` call — the registry methods deliberately
+  do **not** validate (reserved identity topics like `UserTopic`/`SelfTopic`
+  legitimately bypass `validateDeveloperTopic`; validating inside the registry
+  would wrongly reject them and double-validate developer topics). The registry
+  is the index; `ctx.Subscribe` is the gate.
+- **Bare `*` is spec-permitted (confirmed against the proposal — not a gap).**
+  A single-segment `*` pattern passes `validateDeveloperTopic` and matches any
+  *single-segment* concrete topic. Proposal §2 "Grammar": segments may be `*`
+  "any number of times" — one `*` segment is valid. It is **bounded** (does not
+  match multi-segment topics — count mismatch) and **ACL-gated** (deny-all
+  default; a bare-`*` developer subscribe still needs `WithTopicACL`/
+  `WithOpenTopics`). Adding a validator rejection would *contradict the spec
+  grammar* and pre-empt Phase 3's valve (which narrows the validator only for
+  non-trailing/multiple `*`, never bare `*`). No change; recorded so Phase 1
+  and reviewers don't re-litigate.
 - **`dispatchToTopic` (Phase 1) must inject the matcher:**
   `registry.GetByTopicExcept(concrete, excludeConn, segmentMatch)`. The registry
   cannot reach `segmentMatch` itself (import cycle) — passing it is the caller's
-  responsibility; nil + pattern subscribers = panic by design.
+  responsibility; nil + pattern subscribers = panic by design. *Optional
+  (Phase 1's call):* a named wrapper `func topicMatch(p, c string) bool { return
+  segmentMatch(p, c) }` at the single call site gives audits a stable grep
+  anchor; passing `segmentMatch` directly is also fine (it is itself a named,
+  greppable symbol). Phase 1 decides — recorded so the option isn't lost.
 - **⚠ Latent race Phase 1 MUST resolve: subscribe-after-Unregister leak.**
   `Unregister()` sets `conn.subscribedTopics = nil` and drops the conn from all
   indexes. `SubscribeConnectionToTopic` has **no** connection-liveness guard

--- a/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-0.md
+++ b/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-0.md
@@ -169,6 +169,15 @@ exactly as the spec's contingency intends).
   grammar* and pre-empt Phase 3's valve (which narrows the validator only for
   non-trailing/multiple `*`, never bare `*`). No change; recorded so Phase 1
   and reviewers don't re-litigate.
+- **⚠ Phase 1: guard empty-`UserID` reserved topics.** `UserTopic("")` →
+  `"lvt:user:"` (the constructor is intentionally pure — proposal §5; no Phase 0
+  change). Phase 1's `ctx.Subscribe`/`SelfTopic()` MUST reject an empty-`UserID`
+  reserved subscribe before it reaches the registry, or `"lvt:user:"` could
+  match across anonymous connections. The spec already has the adjacent
+  invariant (proposal §1: anonymous `SelfTopic()` is `lvt:session:<GroupID>`,
+  never empty; an empty `SelfTopic()` from a misimplemented Authenticator is
+  logged `slog.Error`) — Phase 1 must additionally cover the out-of-band
+  `UserTopic("")` vector at the `Subscribe` gate.
 - **`dispatchToTopic` (Phase 1) must inject the matcher:**
   `registry.GetByTopicExcept(concrete, excludeConn, segmentMatch)`. The registry
   cannot reach `segmentMatch` itself (import cycle) — passing it is the caller's

--- a/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-0.md
+++ b/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-0.md
@@ -1,0 +1,226 @@
+# Phase 0 — Learnings
+
+**Session:** 2026-05-17 / claude-code   **Status at exit:** in progress
+**Plan reference:** Phase 0 in docs/proposals/broadcast-action-redesign-proposal.md
+
+## Audit (start) — findings
+
+Read-only verification against live code (worktree `broadcast-redesign-phase-0`,
+branched from `main` @ `19774be3`). No prior phase to read.
+
+- **No symbol collision.** `grep -rn 'byTopic\|byTopicPattern\|segmentMatch' internal/session/`
+  → none. `topics.go` does not exist at repo root. Safe to add.
+- **`ConnectionRegistry`** (`internal/session/registry.go:319-325`): fields
+  `byGroup`, `byUser`, `mu sync.RWMutex`, `metrics`, `dispatchBufferSize`.
+  `NewConnectionRegistry()` (`:330-335`) initializes `byGroup`/`byUser`.
+- **`Unregister()`** (`registry.go:392-426`) is the **sole** index-cleanup path.
+  Removes from `byGroup`/`byUser` under `r.mu.Lock()` via `removeConnection`,
+  deletes emptied map keys, then calls `conn.Close()`.
+- **Risky assumption — confirmed.** `Connection.Close()` (`registry.go:182`) only
+  signals writePump shutdown + closes the socket; it does **not** mutate registry
+  indices and does **not** call `Unregister()`. The slow-client path
+  (`Send()` → `go c.Close()`, ~`registry.go:146`) closes the socket but index
+  removal still flows through `Unregister()` later. **No third path bypasses
+  `Unregister()`** → topic-map cleanup wired there is necessary and sufficient.
+- **`removeConnection(conns, target)`** (`registry.go:572`): reused verbatim for
+  the topic-map slice removal.
+- **`DispatchRequest`** (`registry.go:69-72`): `{ Action string; Data map[...] }`.
+  No `Kind` field today (see Deviations — deferred).
+- **Surface is `UserTopic` only.** No `SessionTopic`/`GlobalTopic` references in
+  the tree to mirror (spec §5 / Appendix B forbid them).
+
+The audit did **not** reshape the task list — the plan's predicted reuse targets
+and grep anchors all held against live code.
+
+## What shipped
+
+Pure-additive infrastructure; **no existing dispatch/broadcast path touched**
+(`BroadcastAction` fully functional, as required through Phases 0–4).
+
+- **`internal/session/registry.go`**
+  - `ConnectionRegistry.byTopic` + `byTopicPattern map[string][]*Connection`;
+    initialized in `NewConnectionRegistry()`.
+  - `Connection.subscribedTopics map[string]struct{}` — per-connection
+    membership set; the GC root `Unregister()` walks. Guarded by the existing
+    `ConnectionRegistry.mu` (no new lock).
+  - `SubscribeConnectionToTopic` / `UnsubscribeConnectionFromTopic` /
+    `GetByTopicExcept` + unexported `isPatternTopic` helper. Reuses
+    `removeConnection`; mirrors the `GetByGroupExcept` copy contract and the
+    `byGroup`/`byUser` empty-slice-delete idiom.
+  - `Unregister()` topic-GC: walks `conn.subscribedTopics`, removes from
+    `byTopic`/`byTopicPattern` by `*`-presence, deletes emptied keys, nils the
+    set. O(t), inside the existing locked cleanup section.
+- **`topics.go`** (new, package `livetemplate`) — `UserTopic` (only identity
+  constructor), `isReservedTopic`, `validateDeveloperTopic`,
+  `isValidSegmentChar`, `segmentMatch` (general-case, multi-`*`).
+- **Tests** — `internal/session/registry_topic_test.go` (6 tests, injected
+  test matcher, `-race`); `topics_test.go` (`TestUserTopic`,
+  `TestIsReservedTopic`, `TestValidateDeveloperTopic`, and `TestSegmentMatch`
+  with 27 edge-case rows = the executable matcher spec). All green with
+  `-race`. Phase 0's gate is unit-tests-only ("No e2e yet" per the plan —
+  nothing is wired to exercise; e2e arrives with behavior in Phases 1–3).
+
+**`segmentMatch` authored by the assistant** at the user's explicit request
+(the learning-mode contribution was offered; the user replied "Implement
+segmentMatch"). Split-and-compare; the `len()`-equality check is the
+topic-isolation boundary (bounds `*` to exactly one segment); `* vs ""` guarded
+explicitly so the matcher is total, not dependent on the upstream validator.
+
+## Deviations from plan
+
+- **`DispatchRequest.Kind` deferred to Phase 1.** The spec lists it as *optional*
+  ("Optionally add a `Kind` field … forward-compatible placeholder"). A
+  zero-valued field with no consumer is dead code in Phase 0 (no dispatch path
+  branches on it until Phase 1). **Decision: add it in Phase 1 when it has a real
+  consumer.** Phase 1's audit should add `Kind` (single `KindAction`,
+  zero-valued, backward-compatible) to `DispatchRequest` at that time.
+
+- **`GetByTopicExcept` signature gained a `match` parameter (forced by the
+  package boundary).** The proposal §"Critical files" describes
+  `GetByTopicExcept(concrete, excludeConn)` resolving the union with
+  `segmentMatch`. But `segmentMatch` lives in `topics.go` (package
+  `livetemplate`) and `internal/session` cannot import the root package
+  (import cycle — the `Connection` `interface{}` fields exist precisely to
+  avoid it). Realized as
+  `GetByTopicExcept(concrete string, excludeConn *Connection, match func(pattern, concrete string) bool)`
+  — the matcher is **dependency-injected** by the caller. This is a faithful
+  realization of the spec's intent (the union is still
+  `byTopic ∪ {pattern : match}`), not a semantic change. `match` is **required**
+  — passing nil with pattern subscribers present panics by design (loud
+  programmer-error, never a silent exact-only degradation). **Phase 1
+  consequence:** `dispatchToTopic` must call
+  `registry.GetByTopicExcept(concrete, excl, segmentMatch)`.
+
+## New scope surfaced (rolled into the Surfaced-Scope & Deferral Ledger)
+
+- **`GOWORK=off` is mandatory for *manual* go commands in any phase's worktree
+  (recurs every phase).** The user's global rule places worktrees at
+  `<repo>/.worktrees/<feature>`, physically nested under the main module. A
+  shared workspace `/home/adnaan/code/livetemplate/go.work` lists `./livetemplate`
+  (the main checkout) — *not* the nested worktree — as its sole relevant `use`
+  entry, so a hand-run `go build|vet|test` from the worktree resolves packages
+  against the **outer** module and fails (`main module … does not contain
+  package …/.worktrees/…`). **The pre-commit hook is NOT affected** —
+  `scripts/pre-commit.sh` already prefixes every go invocation with `GOWORK=off`
+  (verified: lines 18 `go fmt`, 35 `golangci-lint`, 154 `go test`), so the gate
+  needs no change. **Adjustment for every later phase's Audit:** prefix manual
+  go commands with `GOWORK=off`; the hook handles itself. Environment invariant
+  of the nested-worktree workflow, not a code change.
+- **Matcher dependency-injection across the `internal/session` ↔ root package
+  boundary** (see Deviations → `GetByTopicExcept`). Surfaced as a design point
+  Phase 1 inherits: the root package owns `segmentMatch`; the registry takes it
+  as a parameter. No trie/radix index (spec §2) — flat O(P) scan retained.
+- **Pre-existing `-race` flake: `TestRangeBuildLatency_PostPhase7`
+  (NOT introduced here; reproduced on untouched `main`).** A full
+  `go test -race ./...` fails this one root-package test:
+  `range_build_latency_test.go:107` asserts hard wall-clock ceilings
+  (N=1000 → 50ms, N=10000 → 250ms) with **no `-race`/`-short` guard**. Under
+  the race detector's instrumentation those medians become ~109ms and ~1.04s
+  (≈2–4× — the documented race-detector overhead profile). **Verified
+  pre-existing:** the same test fails identically on a clean `main` checkout
+  (no Phase 0 changes) — `median=109.148571ms ceiling=50ms`,
+  `median=1.070363473s ceiling=250ms` — i.e. a structural race-vs-wall-clock
+  artifact in unrelated streaming-range ("Phase 7") code, with **zero** code
+  path from `topics.go` / the registry topic methods. `internal/session`
+  itself passed `-race` (31s). The **pre-commit gate is non-race**
+  (`go test -v ./... -timeout=300s`) and passes this test and the whole suite.
+  Out of Phase 0 scope to fix (the plan's scope guard limits Phase 0 to
+  registry/topics; modifying a prior project's latency test is scope creep).
+  **Adjustment for later phases:** do not gate a phase on a *full*
+  `-race ./...` run; scope `-race` to the concurrency-relevant package(s) the
+  phase touches (Phase 0: `internal/session` — passed) and rely on the non-race
+  300s suite for the gate. Phase 2 (Redis) especially: scope `-race` to
+  `pubsub`/`session`. Candidate standalone follow-up (not this wave): guard the
+  latency test with `if testing.Short() || raceEnabled { t.Skip(...) }`.
+
+No Appendix-B alternative was reintroduced. Multi-segment wildcards remain
+**IN v1** (the general-case `segmentMatch`/`byTopicPattern` shipped as planned —
+Phase 3's risk valve can still narrow *only* `validateDeveloperTopic` if needed,
+exactly as the spec's contingency intends).
+
+## Adjustments recommended for the next phase
+
+- **Per-connection membership vs. Redis ref-count are different layers (do not
+  conflate).** Phase 0's `Connection.subscribedTopics` is an idempotent **set**
+  (membership; double-subscribe = one entry, single unsubscribe clears). Phase 2's
+  `subscribedChannels map[string]int` in `pubsub/redis.go` is a **ref-count**
+  (many distinct connections on one instance → one Redis `SUBSCRIBE`; a
+  multiplexing concern). Phase 1/2 audits must keep these distinct.
+- **`Subscribe` (Phase 1) wires the validators Phase 0 delivered, in this order:**
+  (1) `isReservedTopic(topic)` → if true, admit **only** on exact
+  `topic == ctx.SelfTopic()` (a one-liner at the call site — no extra helper
+  needed; `isReservedTopic` is the reusable classification half); reject every
+  other `lvt:` string. (2) else `validateDeveloperTopic(topic)` (segment
+  grammar). (3) else the ACL (deny-all default; only `SelfTopic()` exempt). The
+  grammar is **never** applied to `lvt:` topics (it excludes `:`).
+- **`dispatchToTopic` (Phase 1) must inject the matcher:**
+  `registry.GetByTopicExcept(concrete, excludeConn, segmentMatch)`. The registry
+  cannot reach `segmentMatch` itself (import cycle) — passing it is the caller's
+  responsibility; nil + pattern subscribers = panic by design.
+- **⚠ Latent race Phase 1 MUST resolve: subscribe-after-Unregister leak.**
+  `Unregister()` sets `conn.subscribedTopics = nil` and drops the conn from all
+  indexes. `SubscribeConnectionToTopic` has **no** connection-liveness guard
+  (Phase 0 needs none — no caller). Once Phase 1's `ctx.Subscribe` calls it from
+  action-handler code, a subscribe that races a WS drop (handler still running
+  when the socket closes) will lazily re-create `subscribedTopics` and re-insert
+  a **dead** conn into `byTopic`/`byTopicPattern` — a permanent leak Topic-GC
+  cannot reclaim (the conn will never `Unregister` again). `r.mu` serializes the
+  maps but does **not** order this against connection lifecycle. The existing
+  `EnqueueDispatch` defends the analogous race with a `select { case <-c.done: }`
+  check. **Phase 1 must choose and implement one policy** (Phase 0 deliberately
+  does not — adding it now would be behavior with no caller):
+  **(a)** registry-level `<-conn.done` short-circuit in
+  `SubscribeConnectionToTopic`, silent-drop, matching `EnqueueDispatch`; or
+  **(b)** an error return surfaced from `ctx.Subscribe` so the controller learns
+  the subscription was refused. (a) is the lower-surprise match to existing
+  registry behavior; (b) is more honest if Mount-time subscribe failure should
+  be observable. Record the choice in `phase-1.md`.
+- **Add the deferred `DispatchRequest.Kind`** (single `KindAction`, zero-valued,
+  backward-compatible) in Phase 1 when the dispatch path has a real consumer.
+- **Prefix manual go commands with `GOWORK=off`** in the worktree (see New
+  scope). The pre-commit hook already self-handles this — do **not** add
+  `GOWORK` handling to the hook. The gate is `GOWORK=off go test -v ./...
+  -timeout=300s` (**no `-race`**); use `-race` separately for the
+  concurrency-sensitive registry code as Phase 0 did (it passed).
+
+## Open questions for the user
+
+- **None blocking.** Non-blocking note recorded for transparency: gopls suggests
+  `strings.SplitSeq` over `strings.Split` (the `stringsseq` modernize hint).
+  Kept `strings.Split` — it is clearer for a security-boundary function and is
+  **not** in the enforced pre-commit linter set
+  (`errcheck,govet,ineffassign,staticcheck,unparam,unused`); staticcheck has no
+  such check, so the gate is unaffected. Revisit only if project style adopts
+  the iterator forms repo-wide.
+- Phase 0 closes with a single local commit on branch
+  `broadcast-redesign-phase-0`; **PR creation is left to the user** (not
+  auto-pushed), per the harness "commit/push only when asked" rule and the plan.
+
+## File / commit / V-item pointers
+
+- **Code:** `internal/session/registry.go` (topic indexes, 3 methods,
+  `isPatternTopic`, `Unregister` GC, `Connection.subscribedTopics`),
+  `topics.go` (new).
+- **Tests:** `internal/session/registry_topic_test.go` (new, 6 tests),
+  `topics_test.go` (new, incl. 27-row `TestSegmentMatch`).
+- **Tracker:** this file + `progress.md` (Phase 0 row → complete; Ledger
+  "Surfaced during Phase 0" + this file's New-scope items).
+- **V-items:** Phase 0 has **no gating `V`-item** — its gate is the
+  registry+helper unit tests (all green with `-race`). `V1`–`V21` begin at
+  Phase 1. Phase 0 is the substrate they build on.
+- **Commit:** single Phase 0 close-out commit on branch
+  `broadcast-redesign-phase-0` (SHA recoverable via
+  `git log broadcast-redesign-phase-0`; a file cannot embed its own commit's
+  SHA). Pre-commit hook green; never `--no-verify`.
+- **Gate (non-race, = pre-commit):** `GOWORK=off go test ./... -timeout=300s`
+  all green; root package `ok 109.3s` (well within 300s — proves additive-only,
+  no regression). `golangci-lint` (errcheck,govet,ineffassign,staticcheck,
+  unparam,unused): **0 issues**.
+- **Full `-race` suite (`-timeout=600s`):** completed in 524s (no timeout);
+  all packages green **except** the pre-existing
+  `TestRangeBuildLatency_PostPhase7` latency flake documented under "New scope
+  surfaced" — verified identical on clean `main`, unrelated to Phase 0,
+  out-of-scope, and green in the non-race gate. `internal/session` (the only
+  concurrency-relevant Phase 0 code) passed `-race` (31s). No data races. The
+  earlier 240s `-race` FAIL was this same suite hitting the *tighter* timeout;
+  at 600s it ran to completion and isolated the single pre-existing flake.

--- a/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-0.md
+++ b/docs/proposals/broadcast-action-redesign-proposal/learnings/phase-0.md
@@ -1,6 +1,6 @@
 # Phase 0 — Learnings
 
-**Session:** 2026-05-17 / claude-code   **Status at exit:** in progress
+**Session:** 2026-05-17 / claude-code   **Status at exit:** complete
 **Plan reference:** Phase 0 in docs/proposals/broadcast-action-redesign-proposal.md
 
 ## Audit (start) — findings

--- a/docs/proposals/broadcast-action-redesign-proposal/learnings/progress.md
+++ b/docs/proposals/broadcast-action-redesign-proposal/learnings/progress.md
@@ -9,7 +9,7 @@
 
 | Phase | Status | Owner / session | Started | Completed | Learnings file | Notes |
 |---|---|---|---|---|---|---|
-| 0 — Foundations (registry + topics.go) | not started | — | — | — | `phase-0.md` | — |
+| 0 — Foundations (registry + topics.go) | complete | claude-code / 2026-05-17 | 2026-05-17 | 2026-05-17 | `phase-0.md` ✔ | Additive only; gate (non-race + lint) green. ⚠ Phase 1 must resolve the flagged subscribe-after-Unregister race (see `phase-0.md`). |
 | 1 — Context API + ACL (single instance) | not started | — | — | — | `phase-1.md` | — |
 | 2 — Cross-instance (Redis) | not started | — | — | — | `phase-2.md` | — |
 | 3 — Wildcards (multi-segment) | not started | — | — | — | `phase-3.md` | — |
@@ -57,7 +57,7 @@ The analog of a running budget: every phase rolls (a) scope surfaced mid-phase a
 
 ### Surfaced during Phase N (fill in as discovered)
 
-- _Phase 0:_ TBD
+- _Phase 0:_ (1) **⚠ Latent subscribe-after-`Unregister` leak** — `SubscribeConnectionToTopic` has no connection-liveness guard (none needed in Phase 0: no caller). Phase 1's `ctx.Subscribe` exposes it; Phase 1 **must** choose policy (a) registry `<-conn.done` short-circuit (matches `EnqueueDispatch`) or (b) `ctx.Subscribe` error return. See `phase-0.md`. (2) **`GOWORK=off` invariant** for manual go cmds in the nested worktree (pre-commit hook self-handles it — verified `scripts/pre-commit.sh:18,35,154`). (3) **`GetByTopicExcept` gained an injected `match` param** (forced by the `internal/session`→root import-cycle boundary; Phase 1 `dispatchToTopic` passes `segmentMatch`). (4) **Pre-existing `-race` flake `TestRangeBuildLatency_PostPhase7`** — hard wall-clock ceilings, no `-race`/`-short` guard; reproduced identically on clean `main`; unrelated to Phase 0; gate is non-race so unaffected; later phases must scope `-race` to relevant pkgs, not full `./...`. None map onto an Appendix-B alternative (multi-segment wildcards remain IN v1 as the spec intends).
 - _Phase 1:_ TBD
 - _Phase 2:_ TBD
 - _Phase 3:_ TBD

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -587,7 +587,7 @@ func (r *ConnectionRegistry) GetByTopicExcept(concrete string, excludeConn *Conn
 		// Loud, diagnosable programmer error (vs. an opaque nil-func panic
 		// inside the loop). Nil match is safe only with zero pattern
 		// subscribers — see TestGetByTopicExcept_NilMatchSafeWhenNoPatterns.
-		panic("session: GetByTopicExcept match is nil but pattern subscribers exist — Phase 1 dispatchToTopic must inject segmentMatch")
+		panic("session: GetByTopicExcept requires a non-nil match when pattern subscribers are indexed (callers must pass the segment matcher)")
 	}
 
 	seen := make(map[*Connection]struct{})

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -512,11 +512,8 @@ func (r *ConnectionRegistry) GetByGroupExcept(groupID string, excludeConn *Conne
 	return result
 }
 
-// isPatternTopic reports whether a topic string is a wildcard subscription
-// pattern (contains "*") rather than an exact topic. Full segment-grammar
-// validation lives in the root package (topics.go) and runs before any
-// connection reaches the registry; here only the exact-vs-pattern routing
-// decision is needed, for which "*"-presence is sufficient and self-contained.
+// isPatternTopic routes exact vs. wildcard topics; "*"-presence suffices
+// because the root-package grammar validator already ran before any subscribe.
 func isPatternTopic(topic string) bool {
 	return strings.Contains(topic, "*")
 }
@@ -586,10 +583,15 @@ func (r *ConnectionRegistry) GetByTopicExcept(concrete string, excludeConn *Conn
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	if match == nil && len(r.byTopicPattern) > 0 {
+		// Loud, diagnosable programmer error (vs. an opaque nil-func panic
+		// inside the loop). Nil match is safe only with zero pattern
+		// subscribers — see TestGetByTopicExcept_NilMatchSafeWhenNoPatterns.
+		panic("session: GetByTopicExcept match is nil but pattern subscribers exist — Phase 1 dispatchToTopic must inject segmentMatch")
+	}
+
 	seen := make(map[*Connection]struct{})
-	// Cap hint covers exact + pattern subscribers so a pattern-heavy publish
-	// (few/no exact subscribers) doesn't realloc on the first pattern hit.
-	result := make([]*Connection, 0, len(r.byTopic[concrete])+len(r.byTopicPattern))
+	result := make([]*Connection, 0, len(r.byTopic[concrete]))
 
 	add := func(conns []*Connection) {
 		for _, conn := range conns {

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -579,6 +579,14 @@ func (r *ConnectionRegistry) UnsubscribeConnectionFromTopic(conn *Connection, to
 // always pass a non-nil matcher; passing nil with patterns present panics by
 // design (a loud programmer error, never a silent exact-only degradation).
 func (r *ConnectionRegistry) GetByTopicExcept(concrete string, excludeConn *Connection, match func(pattern, concrete string) bool) []*Connection {
+	if isPatternTopic(concrete) {
+		// concrete must be a publishable topic; a "*" here would silently
+		// mis-resolve (pattern-keyed exact lookup + self-match against every
+		// indexed pattern). Loud over silent-wrong, symmetric with the
+		// nil-match guard below.
+		panic("session: GetByTopicExcept concrete topic must not contain \"*\" (publish to exact topics only)")
+	}
+
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -426,11 +426,8 @@ func (r *ConnectionRegistry) Unregister(conn *Connection) {
 		delete(r.byUser, conn.UserID)
 	}
 
-	// Remove from the topic indexes (Topic-GC-on-disconnect). Topics are
-	// many-to-many, so — unlike byGroup/byUser — there is no O(1) reverse
-	// lookup; walk this connection's own subscription set instead (O(t),
-	// t = topics this conn holds). Route each topic to the exact or pattern
-	// index by "*"-presence, mirroring SubscribeConnectionToTopic.
+	// Topics are many-to-many, so unlike byGroup/byUser there is no O(1)
+	// reverse lookup — walk the connection's own subscription set instead.
 	for topic := range conn.subscribedTopics {
 		index := r.byTopic
 		if isPatternTopic(topic) {
@@ -512,8 +509,8 @@ func (r *ConnectionRegistry) GetByGroupExcept(groupID string, excludeConn *Conne
 	return result
 }
 
-// isPatternTopic routes exact vs. wildcard topics; "*"-presence suffices
-// because the root-package grammar validator already ran before any subscribe.
+// isPatternTopic reports whether topic is a wildcard pattern (contains "*")
+// rather than an exact topic, selecting which index it belongs in.
 func isPatternTopic(topic string) bool {
 	return strings.Contains(topic, "*")
 }
@@ -522,8 +519,8 @@ func isPatternTopic(topic string) bool {
 //
 // Exact topics (no "*") go in byTopic; wildcard patterns in byTopicPattern.
 // Idempotent set semantics: a repeat subscribe is a no-op (the index slice
-// holds conn at most once per topic) — deliberately not a ref-count; see
-// phase-0.md. conn.subscribedTopics is lazily allocated here.
+// holds conn at most once per topic) — membership, deliberately not a
+// ref-count. conn.subscribedTopics is lazily allocated here.
 func (r *ConnectionRegistry) SubscribeConnectionToTopic(conn *Connection, topic string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -574,11 +571,13 @@ func (r *ConnectionRegistry) UnsubscribeConnectionFromTopic(conn *Connection, to
 // pattern scan is a linear O(P) pass over distinct patterns — there is no
 // trie/radix index, by design (proposal §2 "Matcher").
 //
-// match is injected by the caller (the root package's segmentMatch): the
-// matcher lives in topics.go (package livetemplate); internal/session cannot
-// import it without an import cycle, so it is passed in. match is REQUIRED —
-// passing nil while pattern subscribers exist panics by design (a loud
-// programmer-error signal, never a silent exact-only degradation).
+// match is dependency-injected: the segment matcher lives in the root package,
+// which internal/session cannot import without an import cycle, so it is passed
+// in. nil is safe ONLY when no pattern subscribers are registered — a
+// time-of-call property (a nil-passing caller is safe until the first pattern
+// subscriber, then panics). Callers that may face pattern subscribers must
+// always pass a non-nil matcher; passing nil with patterns present panics by
+// design (a loud programmer error, never a silent exact-only degradation).
 func (r *ConnectionRegistry) GetByTopicExcept(concrete string, excludeConn *Connection, match func(pattern, concrete string) bool) []*Connection {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -58,14 +58,9 @@ type Connection struct {
 	// Actions enqueued here are processed by the connection's select-based event loop.
 	DispatchChan chan *DispatchRequest
 
-	// subscribedTopics is this connection's pub/sub topic membership set — the
-	// GC root for topic cleanup on Unregister(). Topics are many-to-many (unlike
-	// GroupID/UserID), so the connection must carry its own subscription set;
-	// Unregister() walks it to remove this conn from the registry's byTopic/
-	// byTopicPattern indexes in O(t). Set semantics (idempotent): a repeated
-	// subscribe is one membership; a single unsubscribe clears it. Always
-	// accessed under ConnectionRegistry.mu (same discipline as byGroup/byUser),
-	// so it needs no separate lock. Lazily allocated on first subscribe.
+	// subscribedTopics is the GC root Unregister() walks to evict this conn from
+	// byTopic/byTopicPattern (no reverse index — topics are many-to-many).
+	// Accessed only under ConnectionRegistry.mu, so it needs no separate lock.
 	subscribedTopics map[string]struct{}
 }
 
@@ -528,14 +523,10 @@ func isPatternTopic(topic string) bool {
 
 // SubscribeConnectionToTopic adds conn to the registry index for topic.
 //
-// Exact topics (no "*") are indexed in byTopic; wildcard patterns in
-// byTopicPattern. Idempotent set semantics: a repeat subscribe to the same
-// topic is a no-op, so the index slice holds conn at most once per topic. This
-// per-connection membership is deliberately NOT the Phase-2 Redis-side
-// subscribedChannels ref-count (that collapses many distinct connections on one
-// instance to one Redis SUBSCRIBE — a multiplexing concern, not membership).
-// conn.subscribedTopics is the GC root Unregister() walks; it is lazily
-// allocated here.
+// Exact topics (no "*") go in byTopic; wildcard patterns in byTopicPattern.
+// Idempotent set semantics: a repeat subscribe is a no-op (the index slice
+// holds conn at most once per topic) — deliberately not a ref-count; see
+// phase-0.md. conn.subscribedTopics is lazily allocated here.
 func (r *ConnectionRegistry) SubscribeConnectionToTopic(conn *Connection, topic string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -596,7 +587,9 @@ func (r *ConnectionRegistry) GetByTopicExcept(concrete string, excludeConn *Conn
 	defer r.mu.RUnlock()
 
 	seen := make(map[*Connection]struct{})
-	result := make([]*Connection, 0, len(r.byTopic[concrete]))
+	// Cap hint covers exact + pattern subscribers so a pattern-heavy publish
+	// (few/no exact subscribers) doesn't realloc on the first pattern hit.
+	result := make([]*Connection, 0, len(r.byTopic[concrete])+len(r.byTopicPattern))
 
 	add := func(conns []*Connection) {
 		for _, conn := range conns {

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -4,6 +4,7 @@ package session
 
 import (
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 )
@@ -56,6 +57,16 @@ type Connection struct {
 	// Dispatch channel for broadcast actions from other connections.
 	// Actions enqueued here are processed by the connection's select-based event loop.
 	DispatchChan chan *DispatchRequest
+
+	// subscribedTopics is this connection's pub/sub topic membership set — the
+	// GC root for topic cleanup on Unregister(). Topics are many-to-many (unlike
+	// GroupID/UserID), so the connection must carry its own subscription set;
+	// Unregister() walks it to remove this conn from the registry's byTopic/
+	// byTopicPattern indexes in O(t). Set semantics (idempotent): a repeated
+	// subscribe is one membership; a single unsubscribe clears it. Always
+	// accessed under ConnectionRegistry.mu (same discipline as byGroup/byUser),
+	// so it needs no separate lock. Lazily allocated on first subscribe.
+	subscribedTopics map[string]struct{}
 }
 
 // wsMessage represents a WebSocket message to be sent asynchronously.
@@ -319,7 +330,9 @@ type MetricsRecorder interface {
 type ConnectionRegistry struct {
 	byGroup            map[string][]*Connection // groupID → connections
 	byUser             map[string][]*Connection // userID → connections  (empty string for anonymous)
-	mu                 sync.RWMutex             // Protects both maps
+	byTopic            map[string][]*Connection // exact pub/sub topic → connections
+	byTopicPattern     map[string][]*Connection // wildcard topic pattern (contains "*") → connections
+	mu                 sync.RWMutex             // Protects all four maps
 	metrics            MetricsRecorder          // Optional: metrics recorder for observability
 	dispatchBufferSize int                      // Dispatch channel buffer size (0 = use default)
 }
@@ -329,8 +342,10 @@ const defaultDispatchBufferSize = 16
 // NewConnectionRegistry creates a new empty connection registry.
 func NewConnectionRegistry() *ConnectionRegistry {
 	return &ConnectionRegistry{
-		byGroup: make(map[string][]*Connection),
-		byUser:  make(map[string][]*Connection),
+		byGroup:        make(map[string][]*Connection),
+		byUser:         make(map[string][]*Connection),
+		byTopic:        make(map[string][]*Connection),
+		byTopicPattern: make(map[string][]*Connection),
 	}
 }
 
@@ -416,6 +431,23 @@ func (r *ConnectionRegistry) Unregister(conn *Connection) {
 		delete(r.byUser, conn.UserID)
 	}
 
+	// Remove from the topic indexes (Topic-GC-on-disconnect). Topics are
+	// many-to-many, so — unlike byGroup/byUser — there is no O(1) reverse
+	// lookup; walk this connection's own subscription set instead (O(t),
+	// t = topics this conn holds). Route each topic to the exact or pattern
+	// index by "*"-presence, mirroring SubscribeConnectionToTopic.
+	for topic := range conn.subscribedTopics {
+		index := r.byTopic
+		if isPatternTopic(topic) {
+			index = r.byTopicPattern
+		}
+		index[topic] = removeConnection(index[topic], conn)
+		if len(index[topic]) == 0 {
+			delete(index, topic)
+		}
+	}
+	conn.subscribedTopics = nil
+
 	// Close the connection AFTER removing from indexes.
 	// This signals the done channel, which EnqueueDispatch checks before sending.
 	if err := conn.Close(); err != nil {
@@ -480,6 +512,109 @@ func (r *ConnectionRegistry) GetByGroupExcept(groupID string, excludeConn *Conne
 	for _, conn := range conns {
 		if conn != excludeConn {
 			result = append(result, conn)
+		}
+	}
+	return result
+}
+
+// isPatternTopic reports whether a topic string is a wildcard subscription
+// pattern (contains "*") rather than an exact topic. Full segment-grammar
+// validation lives in the root package (topics.go) and runs before any
+// connection reaches the registry; here only the exact-vs-pattern routing
+// decision is needed, for which "*"-presence is sufficient and self-contained.
+func isPatternTopic(topic string) bool {
+	return strings.Contains(topic, "*")
+}
+
+// SubscribeConnectionToTopic adds conn to the registry index for topic.
+//
+// Exact topics (no "*") are indexed in byTopic; wildcard patterns in
+// byTopicPattern. Idempotent set semantics: a repeat subscribe to the same
+// topic is a no-op, so the index slice holds conn at most once per topic. This
+// per-connection membership is deliberately NOT the Phase-2 Redis-side
+// subscribedChannels ref-count (that collapses many distinct connections on one
+// instance to one Redis SUBSCRIBE — a multiplexing concern, not membership).
+// conn.subscribedTopics is the GC root Unregister() walks; it is lazily
+// allocated here.
+func (r *ConnectionRegistry) SubscribeConnectionToTopic(conn *Connection, topic string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if conn.subscribedTopics == nil {
+		conn.subscribedTopics = make(map[string]struct{})
+	}
+	if _, already := conn.subscribedTopics[topic]; already {
+		return // idempotent: already subscribed
+	}
+	conn.subscribedTopics[topic] = struct{}{}
+
+	index := r.byTopic
+	if isPatternTopic(topic) {
+		index = r.byTopicPattern
+	}
+	index[topic] = append(index[topic], conn)
+}
+
+// UnsubscribeConnectionFromTopic removes conn from the registry index for topic.
+//
+// No-op if conn was not subscribed to topic. Emptied index entries are deleted
+// to prevent map-key leaks (same discipline as byGroup/byUser in Unregister).
+func (r *ConnectionRegistry) UnsubscribeConnectionFromTopic(conn *Connection, topic string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, subscribed := conn.subscribedTopics[topic]; !subscribed {
+		return
+	}
+	delete(conn.subscribedTopics, topic)
+
+	index := r.byTopic
+	if isPatternTopic(topic) {
+		index = r.byTopicPattern
+	}
+	index[topic] = removeConnection(index[topic], conn)
+	if len(index[topic]) == 0 {
+		delete(index, topic)
+	}
+}
+
+// GetByTopicExcept returns the deduped union of connections subscribed to a
+// concrete (publishable, no-"*") topic, excluding excludeConn (the publisher).
+//
+// Union = byTopic[concrete] ∪ { conns in byTopicPattern[p] : match(p, concrete) },
+// deduplicated by *Connection identity, returned as a defensive copy. The
+// pattern scan is a linear O(P) pass over distinct patterns — there is no
+// trie/radix index, by design (proposal §2 "Matcher").
+//
+// match is injected by the caller (the root package's segmentMatch): the
+// matcher lives in topics.go (package livetemplate); internal/session cannot
+// import it without an import cycle, so it is passed in. match is REQUIRED —
+// passing nil while pattern subscribers exist panics by design (a loud
+// programmer-error signal, never a silent exact-only degradation).
+func (r *ConnectionRegistry) GetByTopicExcept(concrete string, excludeConn *Connection, match func(pattern, concrete string) bool) []*Connection {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	seen := make(map[*Connection]struct{})
+	result := make([]*Connection, 0, len(r.byTopic[concrete]))
+
+	add := func(conns []*Connection) {
+		for _, conn := range conns {
+			if conn == excludeConn {
+				continue
+			}
+			if _, dup := seen[conn]; dup {
+				continue
+			}
+			seen[conn] = struct{}{}
+			result = append(result, conn)
+		}
+	}
+
+	add(r.byTopic[concrete])
+	for pattern, conns := range r.byTopicPattern {
+		if match(pattern, concrete) {
+			add(conns)
 		}
 	}
 	return result

--- a/internal/session/registry_topic_test.go
+++ b/internal/session/registry_topic_test.go
@@ -1,8 +1,11 @@
 package session
 
 import (
+	"fmt"
+	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -84,7 +87,7 @@ func TestGetByTopicExcept_DedupedUnion(t *testing.T) {
 
 	got := r.GetByTopicExcept("room/42", publisher, testSegmentMatch)
 	want := []string{"A", "B"}
-	if diff := connIDs(got, id); !equalStrings(diff, want) {
+	if diff := connIDs(got, id); !slices.Equal(diff, want) {
 		t.Errorf("GetByTopicExcept(room/42) = %v, want %v (A once, B via pattern, C excluded by topic, P excluded as sender)", diff, want)
 	}
 }
@@ -207,14 +210,57 @@ func TestUnsubscribeConnectionFromTopic_DifferentTopicKeepsOthers(t *testing.T) 
 	}
 }
 
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
+// TestConcurrentTopicSubscription gives the race detector something to
+// actually catch: sequential tests exercise lock correctness but not
+// contention. Each worker owns disjoint (conn, topic) pairs so the final state
+// is deterministic (every subscribe is matched by an unsubscribe → empty
+// registry), while a reader hammers GetByTopicExcept concurrently. Run with
+// -race. This validates Phase 0's lock discipline; it does NOT exercise the
+// subscribe-after-Unregister race (that is Phase 1's deferred concern — there
+// is no Unregister caller here).
+func TestConcurrentTopicSubscription(t *testing.T) {
+	r := NewConnectionRegistry()
+	const workers, iters = 8, 200
+
+	var workerWg sync.WaitGroup
+	stop := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	// Reader hammers the RLock path while writers contend on Lock.
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = r.GetByTopicExcept("room/42", nil, testSegmentMatch)
+			}
 		}
+	}()
+
+	for w := 0; w < workers; w++ {
+		workerWg.Add(1)
+		go func(w int) {
+			defer workerWg.Done()
+			conn := &Connection{}
+			exact := fmt.Sprintf("room/w%d", w)    // disjoint per worker
+			pattern := fmt.Sprintf("org/w%d/*", w) // → deterministic final state
+			for i := 0; i < iters; i++ {
+				r.SubscribeConnectionToTopic(conn, exact)
+				r.SubscribeConnectionToTopic(conn, pattern)
+				r.UnsubscribeConnectionFromTopic(conn, exact)
+				r.UnsubscribeConnectionFromTopic(conn, pattern)
+			}
+		}(w)
 	}
-	return true
+
+	workerWg.Wait() // every subscribe was matched 1:1 by an unsubscribe
+	close(stop)
+	<-readerDone
+
+	if len(r.byTopic) != 0 || len(r.byTopicPattern) != 0 {
+		t.Errorf("concurrent subscribe/unsubscribe left residue: byTopic=%d byTopicPattern=%d",
+			len(r.byTopic), len(r.byTopicPattern))
+	}
 }

--- a/internal/session/registry_topic_test.go
+++ b/internal/session/registry_topic_test.go
@@ -193,6 +193,20 @@ func TestGetByTopicExcept_EmptyRegistry(t *testing.T) {
 	}
 }
 
+// TestGetByTopicExcept_PanicsOnWildcardConcrete pins the other half of the
+// contract: GetByTopicExcept publishes to a concrete topic, so a "*" in
+// concrete is a programmer error and must panic loudly rather than
+// silently mis-resolve.
+func TestGetByTopicExcept_PanicsOnWildcardConcrete(t *testing.T) {
+	r := NewConnectionRegistry()
+	defer func() {
+		if recover() == nil {
+			t.Error("GetByTopicExcept with a wildcard concrete must panic")
+		}
+	}()
+	r.GetByTopicExcept("room/*", nil, testSegmentMatch)
+}
+
 // TestGetByTopicExcept_NilMatchSafeWhenNoPatterns documents the contract: a nil
 // match is safe iff there are no pattern subscribers (the pattern loop is
 // skipped, so match is never invoked). With pattern subscribers present, a nil

--- a/internal/session/registry_topic_test.go
+++ b/internal/session/registry_topic_test.go
@@ -173,6 +173,22 @@ func TestGetByTopicExcept_EmptyRegistry(t *testing.T) {
 	}
 }
 
+// TestGetByTopicExcept_NilMatchSafeWhenNoPatterns documents the contract: a nil
+// match is safe iff there are no pattern subscribers (the pattern loop is
+// skipped, so match is never invoked). With pattern subscribers present, a nil
+// match panics by design (a loud programmer error — never a silent exact-only
+// degradation); that path is intentionally not exercised here.
+func TestGetByTopicExcept_NilMatchSafeWhenNoPatterns(t *testing.T) {
+	r := NewConnectionRegistry()
+	conn := &Connection{}
+	r.SubscribeConnectionToTopic(conn, "exact/only") // exact, no patterns indexed
+
+	got := r.GetByTopicExcept("exact/only", nil, nil) // nil match — must not panic
+	if len(got) != 1 {
+		t.Errorf("nil match with no pattern subscribers = %d conns, want 1", len(got))
+	}
+}
+
 // TestUnsubscribeConnectionFromTopic_DifferentTopicKeepsOthers covers the
 // non-nil-map path the no-op test does not: a connection subscribed to A,
 // unsubscribing a different topic B it never held, must still receive A.

--- a/internal/session/registry_topic_test.go
+++ b/internal/session/registry_topic_test.go
@@ -1,0 +1,169 @@
+package session
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// testSegmentMatch is a deliberately-independent, known-correct matcher used to
+// drive GetByTopicExcept's union/dedup logic. The real matcher lives in
+// package livetemplate (topics.go) and cannot be imported here (import cycle) —
+// GetByTopicExcept takes the matcher as a parameter precisely so this layer is
+// testable in isolation. This is NOT a copy of the contributed segmentMatch;
+// it only needs to be correct enough to exercise the registry.
+func testSegmentMatch(pattern, concrete string) bool {
+	p := strings.Split(pattern, "/")
+	c := strings.Split(concrete, "/")
+	if len(p) != len(c) {
+		return false
+	}
+	for i := range p {
+		if p[i] == "*" {
+			if c[i] == "" {
+				return false
+			}
+			continue
+		}
+		if p[i] != c[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func connIDs(conns []*Connection, id map[*Connection]string) []string {
+	out := make([]string, 0, len(conns))
+	for _, c := range conns {
+		out = append(out, id[c])
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestSubscribeConnectionToTopic_ExactAndPattern(t *testing.T) {
+	r := NewConnectionRegistry()
+	conn := &Connection{}
+
+	r.SubscribeConnectionToTopic(conn, "room/42") // exact
+	r.SubscribeConnectionToTopic(conn, "room/*")  // pattern
+
+	if len(r.byTopic["room/42"]) != 1 {
+		t.Errorf("byTopic[room/42] = %d conns, want 1", len(r.byTopic["room/42"]))
+	}
+	if len(r.byTopicPattern["room/*"]) != 1 {
+		t.Errorf("byTopicPattern[room/*] = %d conns, want 1", len(r.byTopicPattern["room/*"]))
+	}
+	if _, ok := conn.subscribedTopics["room/42"]; !ok {
+		t.Error("subscribedTopics missing exact topic")
+	}
+	if _, ok := conn.subscribedTopics["room/*"]; !ok {
+		t.Error("subscribedTopics missing pattern topic")
+	}
+}
+
+func TestGetByTopicExcept_DedupedUnion(t *testing.T) {
+	r := NewConnectionRegistry()
+	connA := &Connection{}
+	connB := &Connection{}
+	connC := &Connection{}
+	publisher := &Connection{}
+	id := map[*Connection]string{connA: "A", connB: "B", connC: "C", publisher: "P"}
+
+	// connA matches "room/42" via the exact index AND via two of its own
+	// patterns — it must still appear exactly once.
+	r.SubscribeConnectionToTopic(connA, "room/42")
+	r.SubscribeConnectionToTopic(connA, "room/*")
+	r.SubscribeConnectionToTopic(connA, "*/42")
+	// connB matches only via a pattern.
+	r.SubscribeConnectionToTopic(connB, "room/*")
+	// connC is subscribed to an unrelated topic.
+	r.SubscribeConnectionToTopic(connC, "other/9")
+	// publisher is subscribed but is the excluded sender.
+	r.SubscribeConnectionToTopic(publisher, "room/42")
+
+	got := r.GetByTopicExcept("room/42", publisher, testSegmentMatch)
+	want := []string{"A", "B"}
+	if diff := connIDs(got, id); !equalStrings(diff, want) {
+		t.Errorf("GetByTopicExcept(room/42) = %v, want %v (A once, B via pattern, C excluded by topic, P excluded as sender)", diff, want)
+	}
+}
+
+func TestGetByTopicExcept_ExcludesSender(t *testing.T) {
+	r := NewConnectionRegistry()
+	sender := &Connection{}
+	r.SubscribeConnectionToTopic(sender, "feed")
+
+	if got := r.GetByTopicExcept("feed", sender, testSegmentMatch); len(got) != 0 {
+		t.Errorf("sender must be excluded from its own publish, got %d conns", len(got))
+	}
+}
+
+func TestUnregister_TopicGC(t *testing.T) {
+	r := NewConnectionRegistry()
+	conn := &Connection{}
+	r.SubscribeConnectionToTopic(conn, "room/42")
+	r.SubscribeConnectionToTopic(conn, "room/*")
+
+	r.Unregister(conn)
+
+	if len(r.byTopic) != 0 {
+		t.Errorf("byTopic leaked %d keys after Unregister, want 0", len(r.byTopic))
+	}
+	if len(r.byTopicPattern) != 0 {
+		t.Errorf("byTopicPattern leaked %d keys after Unregister, want 0", len(r.byTopicPattern))
+	}
+	if conn.subscribedTopics != nil {
+		t.Errorf("conn.subscribedTopics = %v after Unregister, want nil", conn.subscribedTopics)
+	}
+}
+
+// TestSubscribeConnectionToTopic_Idempotent pins set semantics (NOT a
+// ref-count): a double subscribe is one membership, a single unsubscribe
+// clears it. Guards against a future regression that makes the in-process
+// membership accidentally ref-counted (the Redis layer ref-counts; this layer
+// must not).
+func TestSubscribeConnectionToTopic_Idempotent(t *testing.T) {
+	r := NewConnectionRegistry()
+	conn := &Connection{}
+
+	r.SubscribeConnectionToTopic(conn, "room/1")
+	r.SubscribeConnectionToTopic(conn, "room/1") // duplicate
+
+	if n := len(r.byTopic["room/1"]); n != 1 {
+		t.Fatalf("byTopic[room/1] = %d after double subscribe, want 1 (set, not ref-count)", n)
+	}
+
+	r.UnsubscribeConnectionFromTopic(conn, "room/1") // single unsubscribe
+
+	if got := r.GetByTopicExcept("room/1", nil, testSegmentMatch); len(got) != 0 {
+		t.Errorf("after one unsubscribe the conn must be gone, got %d (ref-count leak?)", len(got))
+	}
+	if _, ok := conn.subscribedTopics["room/1"]; ok {
+		t.Error("subscribedTopics still has room/1 after unsubscribe")
+	}
+}
+
+func TestUnsubscribeConnectionFromTopic_NoOpWhenNotSubscribed(t *testing.T) {
+	r := NewConnectionRegistry()
+	conn := &Connection{}
+
+	// Never subscribed — must not panic and must not create entries.
+	r.UnsubscribeConnectionFromTopic(conn, "never/subscribed")
+
+	if len(r.byTopic) != 0 || len(r.byTopicPattern) != 0 {
+		t.Error("unsubscribe of a never-subscribed topic created index entries")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/session/registry_topic_test.go
+++ b/internal/session/registry_topic_test.go
@@ -156,6 +156,41 @@ func TestUnsubscribeConnectionFromTopic_NoOpWhenNotSubscribed(t *testing.T) {
 	}
 }
 
+// TestGetByTopicExcept_EmptyRegistry locks the zero-subscriber path: a publish
+// to a topic nobody is subscribed to (fresh registry, both indexes empty) must
+// return an empty slice and never nil-panic — the very first real publish in
+// Phase 1 hits exactly this.
+func TestGetByTopicExcept_EmptyRegistry(t *testing.T) {
+	r := NewConnectionRegistry()
+
+	if got := r.GetByTopicExcept("room/42", nil, testSegmentMatch); len(got) != 0 {
+		t.Errorf("empty registry GetByTopicExcept = %d conns, want 0", len(got))
+	}
+	// Exact-only present, no pattern subscribers — and vice versa — still safe.
+	r.SubscribeConnectionToTopic(&Connection{}, "other/topic")
+	if got := r.GetByTopicExcept("room/42", nil, testSegmentMatch); len(got) != 0 {
+		t.Errorf("no matching subscriber GetByTopicExcept = %d conns, want 0", len(got))
+	}
+}
+
+// TestUnsubscribeConnectionFromTopic_DifferentTopicKeepsOthers covers the
+// non-nil-map path the no-op test does not: a connection subscribed to A,
+// unsubscribing a different topic B it never held, must still receive A.
+func TestUnsubscribeConnectionFromTopic_DifferentTopicKeepsOthers(t *testing.T) {
+	r := NewConnectionRegistry()
+	conn := &Connection{}
+	r.SubscribeConnectionToTopic(conn, "room/A")
+
+	r.UnsubscribeConnectionFromTopic(conn, "room/B") // never subscribed to B
+
+	if got := r.GetByTopicExcept("room/A", nil, testSegmentMatch); len(got) != 1 {
+		t.Errorf("unsubscribing a different topic dropped room/A: got %d, want 1", len(got))
+	}
+	if _, ok := conn.subscribedTopics["room/A"]; !ok {
+		t.Error("subscribedTopics lost room/A after unsubscribing an unrelated topic")
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/session/registry_topic_test.go
+++ b/internal/session/registry_topic_test.go
@@ -12,8 +12,8 @@ import (
 // drive GetByTopicExcept's union/dedup logic. The real matcher lives in
 // package livetemplate (topics.go) and cannot be imported here (import cycle) —
 // GetByTopicExcept takes the matcher as a parameter precisely so this layer is
-// testable in isolation. This is NOT a copy of the contributed segmentMatch;
-// it only needs to be correct enough to exercise the registry.
+// testable in isolation. This is NOT the root-package segmentMatch; it only
+// needs to be correct enough to exercise the registry's union/dedup.
 func testSegmentMatch(pattern, concrete string) bool {
 	p := strings.Split(pattern, "/")
 	c := strings.Split(concrete, "/")
@@ -101,11 +101,26 @@ func TestGetByTopicExcept_ExcludesSender(t *testing.T) {
 	}
 }
 
+// TestGetByTopicExcept_ExcludesSenderViaPattern pins sender exclusion when the
+// publisher matches only through a pattern (not the exact index) — the
+// exclude-vs-pattern interaction the exact-only ExcludesSender test misses.
+func TestGetByTopicExcept_ExcludesSenderViaPattern(t *testing.T) {
+	r := NewConnectionRegistry()
+	sender := &Connection{}
+	other := &Connection{}
+	r.SubscribeConnectionToTopic(sender, "room/*") // sender via pattern only
+	r.SubscribeConnectionToTopic(other, "room/*")
+
+	got := r.GetByTopicExcept("room/42", sender, testSegmentMatch)
+	if len(got) != 1 || got[0] != other {
+		t.Errorf("publisher matching via pattern must still be excluded; got %d conns, want [other]", len(got))
+	}
+}
+
 func TestUnregister_TopicGC(t *testing.T) {
 	r := NewConnectionRegistry()
-	// Bare Connection (no Register): relies on Close() nil-guarding its `done`
-	// channel — Unregister() calls conn.Close() and closing a nil channel
-	// would panic. Verified safe in the Phase 0 audit (registry.go Close()).
+	// Bare Connection (no Register): Unregister() calls conn.Close(), which
+	// nil-guards its `done` channel, so this is safe without a write pump.
 	conn := &Connection{}
 	r.SubscribeConnectionToTopic(conn, "room/42")
 	r.SubscribeConnectionToTopic(conn, "room/*")
@@ -163,8 +178,8 @@ func TestUnsubscribeConnectionFromTopic_NoOpWhenNotSubscribed(t *testing.T) {
 
 // TestGetByTopicExcept_EmptyRegistry locks the zero-subscriber path: a publish
 // to a topic nobody is subscribed to (fresh registry, both indexes empty) must
-// return an empty slice and never nil-panic — the very first real publish in
-// Phase 1 hits exactly this.
+// return an empty slice and never nil-panic — the first publish to an
+// unsubscribed topic hits exactly this.
 func TestGetByTopicExcept_EmptyRegistry(t *testing.T) {
 	r := NewConnectionRegistry()
 
@@ -217,9 +232,9 @@ func TestUnsubscribeConnectionFromTopic_DifferentTopicKeepsOthers(t *testing.T) 
 // contention. Each worker owns disjoint (conn, topic) pairs so the final state
 // is deterministic (every subscribe is matched by an unsubscribe → empty
 // registry), while a reader hammers GetByTopicExcept concurrently. Run with
-// -race. This validates Phase 0's lock discipline; it does NOT exercise the
-// subscribe-after-Unregister race (that is Phase 1's deferred concern — there
-// is no Unregister caller here).
+// -race. This validates the registry's lock discipline; it does NOT exercise a
+// subscribe-after-Unregister race (no Unregister caller here — that needs a
+// connection-liveness guard this layer does not yet have).
 func TestConcurrentTopicSubscription(t *testing.T) {
 	r := NewConnectionRegistry()
 	const workers, iters = 8, 200

--- a/internal/session/registry_topic_test.go
+++ b/internal/session/registry_topic_test.go
@@ -3,7 +3,6 @@ package session
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -40,7 +39,7 @@ func connIDs(conns []*Connection, id map[*Connection]string) []string {
 	for _, c := range conns {
 		out = append(out, id[c])
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out
 }
 
@@ -87,8 +86,8 @@ func TestGetByTopicExcept_DedupedUnion(t *testing.T) {
 
 	got := r.GetByTopicExcept("room/42", publisher, testSegmentMatch)
 	want := []string{"A", "B"}
-	if diff := connIDs(got, id); !slices.Equal(diff, want) {
-		t.Errorf("GetByTopicExcept(room/42) = %v, want %v (A once, B via pattern, C excluded by topic, P excluded as sender)", diff, want)
+	if ids := connIDs(got, id); !slices.Equal(ids, want) {
+		t.Errorf("GetByTopicExcept(room/42) = %v, want %v (A once, B via pattern, C excluded by topic, P excluded as sender)", ids, want)
 	}
 }
 
@@ -104,6 +103,9 @@ func TestGetByTopicExcept_ExcludesSender(t *testing.T) {
 
 func TestUnregister_TopicGC(t *testing.T) {
 	r := NewConnectionRegistry()
+	// Bare Connection (no Register): relies on Close() nil-guarding its `done`
+	// channel — Unregister() calls conn.Close() and closing a nil channel
+	// would panic. Verified safe in the Phase 0 audit (registry.go Close()).
 	conn := &Connection{}
 	r.SubscribeConnectionToTopic(conn, "room/42")
 	r.SubscribeConnectionToTopic(conn, "room/*")

--- a/topics.go
+++ b/topics.go
@@ -7,8 +7,8 @@ import (
 
 // topicReservedPrefix is the reserved namespace for identity-derived topics
 // (SelfTopic / UserTopic). Developer topic names must never start with it; a
-// connection may only subscribe to a reserved topic that is exactly its own
-// SelfTopic() (the anti-spoof rule, wired in Phase 1's Subscribe).
+// connection may only subscribe to a reserved topic exactly equal to its own
+// SelfTopic() (the anti-spoof rule).
 const topicReservedPrefix = "lvt:"
 
 // UserTopic returns the reserved topic that addresses every connection of the
@@ -23,30 +23,26 @@ func UserTopic(userID string) string {
 	return topicReservedPrefix + "user:" + userID
 }
 
-// isReservedTopic reports whether topic is in the reserved lvt: namespace.
-//
-// Shared by the constructor (its output trivially satisfies this) and, in
-// Phase 1, by Subscribe: a reserved-prefixed argument is admitted only by
-// *exact* string equality to the caller's SelfTopic() — every other lvt:
-// string is rejected (anti-spoof; prefix-equality would let lvt:user:alice*
-// capture lvt:user:alice2). That exact `topic == ctx.SelfTopic()` comparison
-// is a one-liner at the Phase-1 Subscribe call site; this predicate is the
-// reusable classification half it branches on.
+// isReservedTopic reports whether topic is in the reserved lvt: namespace. It
+// is the classification half of the anti-spoof rule: a reserved-prefixed topic
+// is admissible only by *exact* string equality to the connection's own
+// SelfTopic(); every other lvt: string must be rejected (prefix-equality would
+// let lvt:user:alice* capture lvt:user:alice2). The exact-equality check itself
+// lives in the caller; this predicate only answers "is this reserved?".
 func isReservedTopic(topic string) bool {
 	return strings.HasPrefix(topic, topicReservedPrefix)
 }
 
 // validateDeveloperTopic enforces the segment grammar for developer (non-lvt:)
-// topics, used by Subscribe in Phase 1 (the reserved namespace is validated
-// separately and first — this grammar is never applied to lvt: topics, which
-// legitimately contain ':').
+// topics. It is never applied to reserved lvt: topics (they legitimately
+// contain ':', validated separately by the reserved-namespace rule).
 //
 // Grammar (proposal §2): a non-empty, "/"-separated sequence of segments; each
 // segment is either a literal in [a-zA-Z0-9_-]+ or the single character "*".
-// Multiple "*" segments are allowed (general case — Phase 3's risk valve may
-// later tighten *only this validator* to reject non-trailing/multiple "*",
-// never the matcher). No empty segments (rejects "", leading/trailing/double
-// "/"). ":" is excluded by the segment charset.
+// Any number of "*" segments is allowed: only this validator may ever be
+// narrowed to a stricter wildcard subset — the matcher stays general-case. No
+// empty segments (rejects "", leading/trailing/double "/"). ":" is excluded by
+// the segment charset.
 func validateDeveloperTopic(topic string) error {
 	if topic == "" {
 		return fmt.Errorf("invalid topic: empty")
@@ -96,8 +92,8 @@ func isValidSegmentChar(b byte) bool {
 //   - "*" matches one NON-EMPTY segment; guarded explicitly so the matcher is
 //     total even if a degenerate concrete bypasses validateDeveloperTopic.
 //
-// General-case (multi-"*"): Phase 3's risk valve narrows validateDeveloperTopic,
-// never this function.
+// Stays general-case (multi-"*"): any wildcard tightening belongs in
+// validateDeveloperTopic, never here.
 func segmentMatch(pattern, concrete string) bool {
 	patternSegs := strings.Split(pattern, "/")
 	concreteSegs := strings.Split(concrete, "/")

--- a/topics.go
+++ b/topics.go
@@ -1,0 +1,136 @@
+package livetemplate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// topicReservedPrefix is the reserved namespace for identity-derived topics
+// (SelfTopic / UserTopic). Developer topic names must never start with it; a
+// connection may only subscribe to a reserved topic that is exactly its own
+// SelfTopic() (the anti-spoof rule, wired in Phase 1's Subscribe).
+const topicReservedPrefix = "lvt:"
+
+// UserTopic returns the reserved topic that addresses every connection of the
+// given authenticated user, across all of that user's devices and tabs
+// regardless of session-group strategy. It is a pure string constructor usable
+// out-of-band (webhook/cron) — e.g. handler.Publish(UserTopic("alice"), …).
+//
+// This is the only identity-topic constructor by design: there is deliberately
+// no SessionTopic() and no all-users GlobalTopic() (proposal §5 / Appendix B —
+// an ACL-exempt all-users primitive is the highest-blast-radius footgun).
+func UserTopic(userID string) string {
+	return topicReservedPrefix + "user:" + userID
+}
+
+// isReservedTopic reports whether topic is in the reserved lvt: namespace.
+//
+// Shared by the constructor (its output trivially satisfies this) and, in
+// Phase 1, by Subscribe: a reserved-prefixed argument is admitted only by
+// *exact* string equality to the caller's SelfTopic() — every other lvt:
+// string is rejected (anti-spoof; prefix-equality would let lvt:user:alice*
+// capture lvt:user:alice2). That exact `topic == ctx.SelfTopic()` comparison
+// is a one-liner at the Phase-1 Subscribe call site; this predicate is the
+// reusable classification half it branches on.
+func isReservedTopic(topic string) bool {
+	return strings.HasPrefix(topic, topicReservedPrefix)
+}
+
+// validateDeveloperTopic enforces the segment grammar for developer (non-lvt:)
+// topics, used by Subscribe in Phase 1 (the reserved namespace is validated
+// separately and first — this grammar is never applied to lvt: topics, which
+// legitimately contain ':').
+//
+// Grammar (proposal §2): a non-empty, "/"-separated sequence of segments; each
+// segment is either a literal in [a-zA-Z0-9_-]+ or the single character "*".
+// Multiple "*" segments are allowed (general case — Phase 3's risk valve may
+// later tighten *only this validator* to reject non-trailing/multiple "*",
+// never the matcher). No empty segments (rejects "", leading/trailing/double
+// "/"). ":" is excluded by the segment charset.
+func validateDeveloperTopic(topic string) error {
+	if topic == "" {
+		return fmt.Errorf("invalid topic: empty")
+	}
+	if isReservedTopic(topic) {
+		return fmt.Errorf("invalid topic %q: developer topics must not start with %q", topic, topicReservedPrefix)
+	}
+	for _, segment := range strings.Split(topic, "/") {
+		if segment == "*" {
+			continue
+		}
+		if segment == "" {
+			return fmt.Errorf("invalid topic %q: empty segment (no leading/trailing/double %q)", topic, "/")
+		}
+		for i := 0; i < len(segment); i++ {
+			if !isValidSegmentChar(segment[i]) {
+				return fmt.Errorf("invalid topic %q: segment %q has illegal character %q (allowed: [a-zA-Z0-9_-] or whole-segment %q)", topic, segment, segment[i], "*")
+			}
+		}
+	}
+	return nil
+}
+
+// isValidSegmentChar reports whether b is allowed in a literal topic segment:
+// [a-zA-Z0-9_-]. Notably excludes ":" (keeps developer topics disjoint from
+// the reserved lvt: namespace) and "*" (a wildcard is a whole segment, never a
+// partial one — "ro*m" is invalid).
+func isValidSegmentChar(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z':
+		return true
+	case b >= 'A' && b <= 'Z':
+		return true
+	case b >= '0' && b <= '9':
+		return true
+	case b == '_' || b == '-':
+		return true
+	default:
+		return false
+	}
+}
+
+// segmentMatch reports whether a subscription pattern matches a concrete
+// (publishable, "*"-free) topic.
+//
+// CONTRACT (proposal §2 "Matcher" / "Grammar"):
+//   - Split both arguments on "/" into segments.
+//   - The pattern matches ONLY IF both have the SAME segment count. Unequal
+//     counts never match — this is what makes "*" mean "exactly one segment,
+//     never zero, never across '/'": e.g. "room/*" (2) matches "room/42" (2)
+//     but NOT "room/42/log" (3) and NOT "room" (1).
+//   - For equal counts, the pattern matches iff EVERY pattern segment either
+//     is the literal "*" or is byte-equal to the concrete segment at the same
+//     index. Multiple "*" segments are independent ("a/*/b/*", "*/alice").
+//   - "*" matches exactly one NON-EMPTY segment: "*" must NOT match an empty
+//     concrete segment (the upstream grammar validator already rejects empty
+//     segments, but this matcher must be total and stay correct if a degenerate
+//     concrete is ever passed directly — decide how defensive to be here).
+//   - An all-literal pattern (no "*") is just exact equality, segment-wise.
+//   - No regexp, no trie/radix — a flat O(P) segment scan, by design.
+//
+// This is the GENERAL-case matcher (multi-"*": "a/*/b/*", "*/alice"), never
+// trailing-"*"-only — Phase 3's risk valve narrows only validateDeveloperTopic,
+// never this function. Split-and-compare is chosen over a manual two-cursor
+// walk: topics are short, so the two-slice allocation is negligible against the
+// readability of an explicit positional scan in a topic-isolation boundary.
+func segmentMatch(pattern, concrete string) bool {
+	patternSegs := strings.Split(pattern, "/")
+	concreteSegs := strings.Split(concrete, "/")
+	if len(patternSegs) != len(concreteSegs) {
+		// Unequal counts never match. This single check is what bounds "*" to
+		// exactly one segment — never zero, never spanning "/".
+		return false
+	}
+	for i, seg := range patternSegs {
+		if seg == "*" {
+			if concreteSegs[i] == "" {
+				return false // "*" matches exactly one NON-empty segment
+			}
+			continue
+		}
+		if seg != concreteSegs[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/topics.go
+++ b/topics.go
@@ -90,29 +90,15 @@ func isValidSegmentChar(b byte) bool {
 }
 
 // segmentMatch reports whether a subscription pattern matches a concrete
-// (publishable, "*"-free) topic.
+// ("*"-free) topic. Two load-bearing invariants (proposal §2); TestSegmentMatch
+// is the exhaustive executable spec:
+//   - Equal segment count is required — this is what bounds "*" to exactly one
+//     segment, never zero, never across "/". It is a topic-isolation boundary.
+//   - "*" matches one NON-EMPTY segment; guarded explicitly so the matcher is
+//     total even if a degenerate concrete bypasses validateDeveloperTopic.
 //
-// CONTRACT (proposal §2 "Matcher" / "Grammar"):
-//   - Split both arguments on "/" into segments.
-//   - The pattern matches ONLY IF both have the SAME segment count. Unequal
-//     counts never match — this is what makes "*" mean "exactly one segment,
-//     never zero, never across '/'": e.g. "room/*" (2) matches "room/42" (2)
-//     but NOT "room/42/log" (3) and NOT "room" (1).
-//   - For equal counts, the pattern matches iff EVERY pattern segment either
-//     is the literal "*" or is byte-equal to the concrete segment at the same
-//     index. Multiple "*" segments are independent ("a/*/b/*", "*/alice").
-//   - "*" matches exactly one NON-EMPTY segment: "*" must NOT match an empty
-//     concrete segment (the upstream grammar validator already rejects empty
-//     segments, but this matcher must be total and stay correct if a degenerate
-//     concrete is ever passed directly — decide how defensive to be here).
-//   - An all-literal pattern (no "*") is just exact equality, segment-wise.
-//   - No regexp, no trie/radix — a flat O(P) segment scan, by design.
-//
-// This is the GENERAL-case matcher (multi-"*": "a/*/b/*", "*/alice"), never
-// trailing-"*"-only — Phase 3's risk valve narrows only validateDeveloperTopic,
-// never this function. Split-and-compare is chosen over a manual two-cursor
-// walk: topics are short, so the two-slice allocation is negligible against the
-// readability of an explicit positional scan in a topic-isolation boundary.
+// General-case (multi-"*"): Phase 3's risk valve narrows validateDeveloperTopic,
+// never this function.
 func segmentMatch(pattern, concrete string) bool {
 	patternSegs := strings.Split(pattern, "/")
 	concreteSegs := strings.Split(concrete, "/")

--- a/topics.go
+++ b/topics.go
@@ -70,10 +70,9 @@ func validateDeveloperTopic(topic string) error {
 	return nil
 }
 
-// isValidSegmentChar reports whether b is allowed in a literal topic segment:
-// [a-zA-Z0-9_-]. Notably excludes ":" (keeps developer topics disjoint from
-// the reserved lvt: namespace) and "*" (a wildcard is a whole segment, never a
-// partial one — "ro*m" is invalid).
+// isValidSegmentChar's exclusions carry the non-obvious WHY: ":" keeps
+// developer topics disjoint from the reserved lvt: namespace; "*" is rejected
+// inside a segment because a wildcard is a whole segment ("ro*m" is invalid).
 func isValidSegmentChar(b byte) bool {
 	switch {
 	case b >= 'a' && b <= 'z':

--- a/topics_test.go
+++ b/topics_test.go
@@ -1,0 +1,133 @@
+package livetemplate
+
+import "testing"
+
+func TestUserTopic(t *testing.T) {
+	if got := UserTopic("alice"); got != "lvt:user:alice" {
+		t.Errorf("UserTopic(alice) = %q, want lvt:user:alice", got)
+	}
+	if got := UserTopic(""); got != "lvt:user:" {
+		t.Errorf("UserTopic(\"\") = %q, want lvt:user:", got)
+	}
+	if !isReservedTopic(UserTopic("bob")) {
+		t.Errorf("UserTopic output must be in the reserved namespace")
+	}
+}
+
+func TestIsReservedTopic(t *testing.T) {
+	tests := []struct {
+		topic string
+		want  bool
+	}{
+		{"lvt:user:alice", true},
+		{"lvt:session:abc123", true},
+		{"lvt:", true},
+		{"room/42", false},
+		{"announcements", false},
+		{"lvtx:foo", false}, // prefix is exactly "lvt:", not "lvt"
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isReservedTopic(tt.topic); got != tt.want {
+			t.Errorf("isReservedTopic(%q) = %v, want %v", tt.topic, got, tt.want)
+		}
+	}
+}
+
+func TestValidateDeveloperTopic(t *testing.T) {
+	valid := []string{
+		"room/42",
+		"room/*",
+		"a/*/b/*",
+		"*/alice",
+		"org/*/room/*",
+		"public/feed",
+		"a",
+		"*",
+		"foo-bar_baz/9",
+	}
+	for _, topic := range valid {
+		if err := validateDeveloperTopic(topic); err != nil {
+			t.Errorf("validateDeveloperTopic(%q) = %v, want nil", topic, err)
+		}
+	}
+
+	invalid := []string{
+		"",               // empty
+		"lvt:user:alice", // reserved prefix — not a developer topic
+		"room/",          // trailing slash → empty segment
+		"/room",          // leading slash → empty segment
+		"room//x",        // double slash → empty segment
+		"ro*m",           // partial wildcard — "*" must be a whole segment
+		"room/4*2",       // "*" mixed into a literal segment
+		"room/4 2",       // space is not an allowed segment char
+		"a:b",            // ":" is excluded (keeps disjoint from lvt:)
+	}
+	for _, topic := range invalid {
+		if err := validateDeveloperTopic(topic); err == nil {
+			t.Errorf("validateDeveloperTopic(%q) = nil, want error", topic)
+		}
+	}
+}
+
+// TestSegmentMatch is the executable specification for the segmentMatch
+// learning-mode contribution. Every row encodes a rule from proposal §2
+// ("Matcher" / "Grammar"). The implementation in topics.go must make all rows
+// pass — do not change this table to fit an implementation; implement to fit
+// this table.
+func TestSegmentMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		concrete string
+		want     bool
+	}{
+		// Exact (all-literal pattern == segment-wise equality).
+		{"exact equal", "room/42", "room/42", true},
+		{"exact differ", "room/42", "room/43", false},
+		{"exact single seg", "a", "a", true},
+		{"exact single seg differ", "a", "b", false},
+
+		// Single "*": matches exactly one non-empty segment, never across "/".
+		{"star one segment", "*", "foo", true},
+		{"star not across slash", "*", "a/b", false},
+		{"star not empty", "*", "", false}, // "*" matches NON-empty only
+
+		// Trailing "*".
+		{"trailing star match", "room/*", "room/42", true},
+		{"trailing star count mismatch deeper", "room/*", "room/42/log", false},
+		{"trailing star count mismatch shallower", "room/*", "room", false},
+		{"trailing star literal differ", "room/*", "hall/42", false},
+
+		// Leading "*".
+		{"leading star match", "*/alice", "room/alice", true},
+		{"leading star literal differ", "*/alice", "room/bob", false},
+		{"leading star count mismatch", "*/alice", "a/b/alice", false},
+		{"leading star x match", "*/x", "a/x", true},
+		{"leading star x count mismatch", "*/x", "a/b/x", false},
+		{"leading star x literal differ", "*/x", "a/y", false},
+
+		// Multi-segment "*" (general case — Phase 3 valve depends on this).
+		{"multi star match", "a/*/b/*", "a/1/b/2", true},
+		{"multi star count mismatch", "a/*/b/*", "a/1/b", false},
+		{"multi star literal differ", "a/*/b/*", "a/1/c/2", false},
+		{"org room match", "org/*/room/*", "org/9/room/42", true},
+		{"org room literal differ", "org/*/room/*", "org/9/lobby/42", false},
+
+		// "*" never matches an empty interior segment.
+		{"mid star match", "a/*/c", "a/b/c", true},
+		{"mid star empty segment", "a/*/c", "a//c", false},
+
+		// All-"*" patterns.
+		{"all star two", "*/*", "a/b", true},
+		{"all star count low", "*/*", "a", false},
+		{"all star count high", "*/*", "a/b/c", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := segmentMatch(tt.pattern, tt.concrete); got != tt.want {
+				t.Errorf("segmentMatch(%q, %q) = %v, want %v", tt.pattern, tt.concrete, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

**Phase 0** of the BroadcastAction → pub/sub topic-model redesign
(`docs/proposals/broadcast-action-redesign-proposal.md`). The proposal is built
as 7 dependency-ordered phases, **one phase per implementation session**; each
phase carries its own close-out record. This PR contains Phase 0 plus its
`learnings/phase-0.md` (the durable handoff Phase 1's audit reads) and the
`progress.md` tracker update.

## What's here (pure additions — no behavior wired)

No existing dispatch/broadcast path is touched. `ctx.BroadcastAction` and its
group-dispatch path remain **fully functional**; removal is atomic with
migration in Phase 5.

- **`internal/session/registry.go`** — `byTopic` + `byTopicPattern` indexes;
  `Connection.subscribedTopics` membership set (the GC root `Unregister()`
  walks); `SubscribeConnectionToTopic` / `UnsubscribeConnectionFromTopic` /
  `GetByTopicExcept` (deduped exact∪pattern union, idempotent **set** semantics
  — deliberately *not* the Phase-2 Redis ref-count); topic-GC wired into the
  existing `Unregister()` cleanup. Reuses `removeConnection` and the
  `GetByGroupExcept` copy contract. Pattern scan is flat O(P) — no trie, by
  design (proposal §2 "Matcher").
- **`topics.go`** (new) — `UserTopic`, `isReservedTopic`,
  `validateDeveloperTopic`, `segmentMatch` (general-case multi-`*`; Phase 3's
  risk valve narrows only the validator, never the matcher).
- **Tests** — `registry_topic_test.go` (6 tests, `-race`-clean) and
  `topics_test.go` (`TestSegmentMatch` = a 27-row executable spec, plus the
  validators/constructor).

## Gate status

Pre-commit hook ran in full (never `--no-verify`): `go fmt` + `golangci-lint`
(`errcheck,govet,ineffassign,staticcheck,unparam,unused`) **0 issues** +
non-race `go test -v ./... -timeout=300s` (incl. the Redis testcontainers
suite) — all green. `internal/session` also passed standalone `-race` (the only
concurrency-relevant Phase 0 code).

## Known pre-existing — NOT introduced here

A *full* `go test -race ./...` fails one root-package test,
`TestRangeBuildLatency_PostPhase7` (`range_build_latency_test.go`): a hard
wall-clock latency ceiling (50 ms / 250 ms) with no `-race`/`-short` guard, in
unrelated prior streaming-range work. **Verified pre-existing** by reproducing
it identically on a clean `main` checkout (no Phase 0 changes):
`median 109 ms` vs the `50 ms` ceiling — i.e. the race detector's
instrumentation overhead, not a regression, with zero code path from
`topics.go`/the registry. The pre-commit gate is non-race and passes it.
Out of Phase 0's scope guard to fix; recorded in the Ledger as a candidate
standalone follow-up (guard the latency test with `testing.Short()`/race-skip).

## Intentional handoffs to Phase 1 (recorded in `phase-0.md`, not omissions)

- **⚠ Latent subscribe-after-`Unregister` race.**
  `SubscribeConnectionToTopic` has no connection-liveness guard — *none is
  needed in Phase 0 (no caller)*. Phase 1's `ctx.Subscribe` exposes it; Phase 1
  must pick policy (a) registry `<-conn.done` short-circuit (mirrors
  `EnqueueDispatch`) or (b) `ctx.Subscribe` error return.
- **`DispatchRequest.Kind` deferred** — the proposal lists it *optional*; a
  zero-valued field with no consumer is dead code until Phase 1's dispatch path
  branches on it.
- **`GetByTopicExcept` takes an injected `match` parameter** — `internal/session`
  cannot import the root package's `segmentMatch` (import cycle), so the matcher
  is dependency-injected; Phase 1's `dispatchToTopic` passes `segmentMatch`.

## Scope

Phase 0 only (registry/topics substrate). Phases 1–6 land as separate PRs per
the proposal's protocol. `segmentMatch` was authored by the assistant at the
maintainer's explicit request (the learning-mode contribution was offered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
