### PR TITLE
test: skip TestRangeBuildLatency_PostPhase7 under -race (pre-existing flake)

### DIFF
--- a/race_disabled_test.go
+++ b/race_disabled_test.go
@@ -1,0 +1,6 @@
+//go:build !race
+
+package livetemplate
+
+// raceEnabled is false in normal (non-race) builds. See race_enabled_test.go.
+const raceEnabled = false

--- a/race_enabled_test.go
+++ b/race_enabled_test.go
@@ -1,0 +1,9 @@
+//go:build race
+
+package livetemplate
+
+// raceEnabled is true when the binary is built with -race. Build-tagged
+// sentinel (the canonical Go idiom; stdlib has no runtime race query) used to
+// skip wall-clock latency assertions whose ceilings are meaningless under the
+// race detector's instrumentation overhead.
+const raceEnabled = true

--- a/range_build_latency_test.go
+++ b/range_build_latency_test.go
@@ -34,16 +34,20 @@ const latencyTemplate = `<table><tbody>{{range .Items}}<tr data-key="{{.ID}}"><t
 // regression that would silently undo the work if a future change reverted
 // the parallel dispatch or re-introduced JSON-marshal in the hash path.
 //
-// Skipped under -short and on CI runners (the wall-clock ceilings are
-// calibrated for an 8-core linux/arm64 dev box; shared CI runners have
-// variable performance and cause spurious failures). Run locally to
-// validate Phase 7+8 didn't regress.
+// Skipped under -short, on CI runners, and under -race (the wall-clock
+// ceilings are calibrated for an 8-core linux/arm64 dev box; shared CI runners
+// and the race detector's 2-10x instrumentation overhead both inflate the
+// medians and cause spurious failures). Run locally without -race to validate
+// Phase 7+8 didn't regress.
 func TestRangeBuildLatency_PostPhase7(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipped under -short; allocates ~90MB at N=10000")
 	}
 	if os.Getenv("CI") != "" {
 		t.Skip("skipped on CI; wall-clock ceilings are calibrated for 8-core dev hardware. Run locally to validate.")
+	}
+	if raceEnabled {
+		t.Skip("skipped under -race; the detector's instrumentation overhead inflates wall-clock medians past the latency ceilings (spurious failure). Run without -race to validate.")
 	}
 
 	cases := []struct {


### PR DESCRIPTION
## Context

Standalone test-hygiene fix, **unrelated to the pub/sub redesign** (#417). Surfaced while running a full `go test -race ./...` during Phase 0 review.

`TestRangeBuildLatency_PostPhase7` (`range_build_latency_test.go`) asserts hard wall-clock latency ceilings (N=1000 → 50 ms, N=10000 → 250 ms). The race detector's 2–10× instrumentation overhead inflates the medians to ~109 ms / ~1.04 s, so a full `go test -race ./...` **fails spuriously**. Verified **pre-existing on clean `main`** (identical failure, no relation to recent work). It is **not in any gate** — pre-commit and CI "Unit Tests" are non-race — so this only bites an explicit `-race ./...` sweep.

## Fix

A build-tagged `raceEnabled` sentinel (`race_enabled_test.go` `//go:build race` → true; `race_disabled_test.go` `//go:build !race` → false — the canonical Go idiom since stdlib has no runtime race query; test-only, nothing ships) plus a third skip guard alongside the existing `-short` and `CI` guards, in the same idiom.

- Non-race runs still **execute and enforce** the ceilings (the regression gate is intact).
- `-race` now **skips** with a clear message instead of failing.

## Verification

- `go test -race -run TestRangeBuildLatency_PostPhase7 .` → **SKIP** (was FAIL)
- Non-race run → still executes + passes (pre-commit ran the full non-race suite green)
- `golangci-lint` (errcheck,govet,ineffassign,staticcheck,unparam,unused) → **0 issues**; gofmt clean
- Full `go test -race ./... -timeout=600s` → green (confirmation in PR thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
