### PR TITLE
fix(pubsub): synchronize the reconnectHook test seam (data race, #420)

### DIFF
--- a/pubsub/redis.go
+++ b/pubsub/redis.go
@@ -361,7 +361,32 @@ var subscribeHook func()
 // It allows tests to deterministically wait for reconnect() to enter its
 // no-lock window without relying on time-based synchronization.
 // Production code leaves this nil.
-var reconnectHook func()
+//
+// Access is mutex-guarded: reconnect() (running on the processMessages
+// goroutine) reads it while a test installs/restores it from the test
+// goroutine, so a bare package global would data-race under -race. Use
+// currentReconnectHook / setReconnectHook, never the variable directly.
+var (
+	reconnectHookMu sync.Mutex
+	reconnectHook   func()
+)
+
+// currentReconnectHook returns the installed test hook (nil in production).
+func currentReconnectHook() func() {
+	reconnectHookMu.Lock()
+	defer reconnectHookMu.Unlock()
+	return reconnectHook
+}
+
+// setReconnectHook installs h and returns the previously installed hook, so a
+// test can restore it: prev := setReconnectHook(fn); defer setReconnectHook(prev).
+func setReconnectHook(h func()) (prev func()) {
+	reconnectHookMu.Lock()
+	defer reconnectHookMu.Unlock()
+	prev = reconnectHook
+	reconnectHook = h
+	return prev
+}
 
 // errPubsubNotReady is a sentinel signaling that pubsub is currently nil
 // because reconnect() is in progress. It's distinct from "broadcaster is
@@ -824,8 +849,8 @@ func (b *RedisBroadcaster) reconnect() error {
 		b.mu.Unlock()
 	}()
 
-	if reconnectHook != nil {
-		reconnectHook()
+	if h := currentReconnectHook(); h != nil {
+		h()
 	}
 
 	// Wait before reconnecting (interruptible so Close() doesn't block for delay)

--- a/pubsub/redis_test.go
+++ b/pubsub/redis_test.go
@@ -1180,15 +1180,14 @@ func TestReconnect_DoesNotBlockConcurrentPublish(t *testing.T) {
 	// to enter the sleep window. Use it to deterministically time the publish
 	// rather than guessing with time.Sleep.
 	hookEntered := make(chan struct{})
-	prevHook := reconnectHook
-	reconnectHook = func() {
+	prevHook := setReconnectHook(func() {
 		select {
 		case <-hookEntered:
 		default:
 			close(hookEntered)
 		}
-	}
-	defer func() { reconnectHook = prevHook }()
+	})
+	defer setReconnectHook(prevHook)
 
 	// Trigger a reconnect from a goroutine.
 	reconnectDone := make(chan error, 1)
@@ -1247,15 +1246,14 @@ func TestReconnect_InterruptibleByContextCancel(t *testing.T) {
 	}
 
 	hookEntered := make(chan struct{})
-	prevHook := reconnectHook
-	reconnectHook = func() {
+	prevHook := setReconnectHook(func() {
 		select {
 		case <-hookEntered:
 		default:
 			close(hookEntered)
 		}
-	}
-	defer func() { reconnectHook = prevHook }()
+	})
+	defer setReconnectHook(prevHook)
 
 	reconnectDone := make(chan error, 1)
 	go func() {
@@ -1322,15 +1320,14 @@ func TestSubscribeTo_SucceedsDuringReconnectWindow(t *testing.T) {
 	}
 
 	hookEntered := make(chan struct{})
-	prevHook := reconnectHook
-	reconnectHook = func() {
+	prevHook := setReconnectHook(func() {
 		select {
 		case <-hookEntered:
 		default:
 			close(hookEntered)
 		}
-	}
-	defer func() { reconnectHook = prevHook }()
+	})
+	defer setReconnectHook(prevHook)
 
 	// Start reconnect; pubsub is nilled inside the lock then released before
 	// the hook fires.

--- a/pubsub/redis_test.go
+++ b/pubsub/redis_test.go
@@ -1180,12 +1180,12 @@ func TestReconnect_DoesNotBlockConcurrentPublish(t *testing.T) {
 	// to enter the sleep window. Use it to deterministically time the publish
 	// rather than guessing with time.Sleep.
 	hookEntered := make(chan struct{})
+	var hookOnce sync.Once
 	prevHook := setReconnectHook(func() {
-		select {
-		case <-hookEntered:
-		default:
-			close(hookEntered)
-		}
+		// reconnect() can run concurrently from the processMessages loop and
+		// the test's explicit goroutine, so the close must be exactly-once
+		// (a select/default guard is not atomic across goroutines).
+		hookOnce.Do(func() { close(hookEntered) })
 	})
 	defer setReconnectHook(prevHook)
 
@@ -1246,12 +1246,12 @@ func TestReconnect_InterruptibleByContextCancel(t *testing.T) {
 	}
 
 	hookEntered := make(chan struct{})
+	var hookOnce sync.Once
 	prevHook := setReconnectHook(func() {
-		select {
-		case <-hookEntered:
-		default:
-			close(hookEntered)
-		}
+		// reconnect() can run concurrently from the processMessages loop and
+		// the test's explicit goroutine, so the close must be exactly-once
+		// (a select/default guard is not atomic across goroutines).
+		hookOnce.Do(func() { close(hookEntered) })
 	})
 	defer setReconnectHook(prevHook)
 
@@ -1320,12 +1320,12 @@ func TestSubscribeTo_SucceedsDuringReconnectWindow(t *testing.T) {
 	}
 
 	hookEntered := make(chan struct{})
+	var hookOnce sync.Once
 	prevHook := setReconnectHook(func() {
-		select {
-		case <-hookEntered:
-		default:
-			close(hookEntered)
-		}
+		// reconnect() can run concurrently from the processMessages loop and
+		// the test's explicit goroutine, so the close must be exactly-once
+		// (a select/default guard is not atomic across goroutines).
+		hookOnce.Do(func() { close(hookEntered) })
 	})
 	defer setReconnectHook(prevHook)
 


### PR DESCRIPTION
Closes #420.

## Problem

`go test -race ./...` (the cross-repo "Test LVT against Core Changes" CI job) reliably reports a real `WARNING: DATA RACE` → `--- FAIL: TestReconnect_DoesNotBlockConcurrentPublish` (`pubsub`). It is **pre-existing on `main`** and surfaces on any PR whose CI runs `-race ./...` (e.g. #419), independent of that PR's content.

## Root cause

`reconnectHook` was a bare package-global test seam:

- **Production read** — `redis.go` `reconnect()`: `if reconnectHook != nil { reconnectHook() }`, executed on the `processMessages` goroutine.
- **Test write** — the three `TestReconnect*` tests install a hook and `defer` restoring it from the test goroutine.

Nothing synchronized the two. Under CI's full-suite `-race ./...` contention (a live `processMessages→reconnect()` goroutine concurrent with a test's deferred hook restore) the detector catches the unsynchronized global. It does not reproduce in isolated local runs (green 15× under `-race`) because the race window only widens under whole-suite contention.

## Fix

Replace the bare `var reconnectHook func()` with a mutex-guarded accessor pair:

- `currentReconnectHook() func()` — production reads via this.
- `setReconnectHook(h) (prev func())` — tests install via this; returns the previous hook for deferred restore.

The variable is now only ever read/written under `reconnectHookMu`, so the race is eliminated by construction. No reconnect-logic change; purely synchronizes the existing test seam.

## Verification

- `TestReconnect*` pass `go test -race -count=10 ./pubsub/`.
- `go build ./...`, `go vet ./pubsub/`, and the full pre-commit gate (`go fmt` + `golangci-lint` enable-only set 0 issues + full `go test -v ./... -timeout=300s` incl. Redis testcontainers) all green.

Standalone fix off `main`, deliberately scoped to the `reconnectHook` seam only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)