### PR TITLE
fix(pubsub): synchronize the subscribeHook test seam (data race, #422)

### DIFF
--- a/pubsub/redis.go
+++ b/pubsub/redis.go
@@ -354,7 +354,34 @@ func (b *RedisBroadcaster) SubscribeToGroupAction(groupID string) error {
 // before the Redis SUBSCRIBE network call (and outside any lock). It allows
 // tests to inject delay or block to verify that mu is not held across the
 // network call. Production code leaves this nil.
-var subscribeHook func()
+//
+// Access is mutex-guarded: trySubscribe runs on whatever goroutine called
+// SubscribeToGroup (a test or background goroutine) and is also reached from
+// reconnect()'s channel replay on the processMessages goroutine, while a test
+// installs/restores it from the test goroutine, so a bare package global would
+// data-race under -race. Use currentSubscribeHook / setSubscribeHook, never the
+// variable directly.
+var (
+	subscribeHookMu sync.Mutex
+	subscribeHook   func()
+)
+
+// currentSubscribeHook returns the installed test hook (nil in production).
+func currentSubscribeHook() func() {
+	subscribeHookMu.Lock()
+	defer subscribeHookMu.Unlock()
+	return subscribeHook
+}
+
+// setSubscribeHook installs h and returns the previously installed hook, so a
+// test can restore it: prev := setSubscribeHook(fn); defer setSubscribeHook(prev).
+func setSubscribeHook(h func()) (prev func()) {
+	subscribeHookMu.Lock()
+	defer subscribeHookMu.Unlock()
+	prev = subscribeHook
+	subscribeHook = h
+	return prev
+}
 
 // reconnectHook is a test-only hook invoked from reconnect() immediately
 // after the lock has been released and before the reconnect-delay sleep.
@@ -521,8 +548,8 @@ func (b *RedisBroadcaster) trySubscribe(channel, label string) error {
 	pubsub := b.pubsub
 	b.mu.Unlock()
 
-	if subscribeHook != nil {
-		subscribeHook()
+	if h := currentSubscribeHook(); h != nil {
+		h()
 	}
 
 	if err := pubsub.Subscribe(b.ctx, channel); err != nil {

--- a/pubsub/redis_test.go
+++ b/pubsub/redis_test.go
@@ -1081,16 +1081,16 @@ func TestSubscribeTo_DoesNotBlockConcurrentOperations(t *testing.T) {
 	// the Redis network call) until we explicitly release it.
 	release := make(chan struct{})
 	hookEntered := make(chan struct{})
-	prevHook := subscribeHook
-	subscribeHook = func() {
-		select {
-		case <-hookEntered:
-		default:
-			close(hookEntered)
-		}
+	var hookOnce sync.Once
+	prevHook := setSubscribeHook(func() {
+		// trySubscribe can run concurrently from reconnect()'s channel
+		// replay on the processMessages loop and the test's explicit
+		// goroutine, so the close must be exactly-once (a select/default
+		// guard is not atomic across goroutines).
+		hookOnce.Do(func() { close(hookEntered) })
 		<-release
-	}
-	defer func() { subscribeHook = prevHook }()
+	})
+	defer setSubscribeHook(prevHook)
 
 	// Start the slow subscribe in a goroutine.
 	slowDone := make(chan error, 1)


### PR DESCRIPTION
Fixes #422.

## What

`subscribeHook` was a bare package-global test seam — the **same class of
unsynchronized-global data race** fixed for `reconnectHook` in #421 (which closed
#420). Production `trySubscribe` read it (reachable off background goroutines and
from `reconnect()`'s channel replay on the `processMessages` loop) while a test
wrote/restored it from the test goroutine, with no synchronization → `WARNING:
DATA RACE` under `go test -race ./...` under full-suite contention (exactly how
#420 surfaced).

This is a deliberate **one-to-one mechanical port of #421** (the follow-up
`#421` itself scoped out and filed as #422):

- **`pubsub/redis.go`** — bare `var subscribeHook func()` → mutex-guarded
  `var (subscribeHookMu sync.Mutex; subscribeHook func())` + `currentSubscribeHook()`
  / `setSubscribeHook(h) (prev)` accessors, structurally identical to the adjacent
  `reconnectHook` block. `trySubscribe` reads via the getter
  (`if h := currentSubscribeHook(); h != nil { h() }`).
- **`pubsub/redis_test.go`** — test site → `prev := setSubscribeHook(fn); defer
  setSubscribeHook(prev)`, and the hook's non-atomic `select/default` channel
  close → `sync.Once`. This is the **second latent bug the mutex fix unmasks**
  (same as #421's `59436a50`): `trySubscribe` is reachable from `reconnect()`'s
  channel replay on the `processMessages` goroutine, so a non-atomic close could
  double-close → `panic: close of closed channel` under contention.

No new test: the existing `TestSubscribeTo_DoesNotBlockConcurrentOperations` is
the correct surface, exercised with the new primitives (#421 added none either).

## Verification

- `GOWORK=off go test -race ./pubsub/ -count=10` — green (~250s)
- `GOWORK=off go test -race ./... -count=1` — green (the full-suite contention
  path that caught #420; no DATA RACE, no panic, 16/16 `ok`)
- Full `scripts/pre-commit.sh` gate green (go fmt + golangci-lint
  errcheck/govet/ineffassign/staticcheck/unparam/unused + full suite incl. Redis
  testcontainers)

Per #422 / the issue body, the narrow window means `-race ./pubsub/` validates
the change is sound, not a before/after repro — the justification is structural
symmetry with the CI-proven #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)