### PR TITLE
chore(scripts): bump release.sh test timeout to 300s to match pre-commit

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -159,7 +159,7 @@ Related repositories:
 # Build and test
 build_and_test() {
     log_step "Running Go tests..."
-    GOWORK=off go test ./... -timeout=120s || {
+    GOWORK=off go test ./... -timeout=300s || {
         log_error "Tests failed, aborting release"
         exit 1
     }


### PR DESCRIPTION
The release script's `go test ./... -timeout=120s` sits right at the boundary of the root `livetemplate` package's runtime (`phase-0.md` recorded *`ok 109.3s`* for the same suite). The Phase 4 v0.9.2 release attempt hit a 2-minute timeout panic — even though the same suite passes cleanly under the pre-commit hook ([`scripts/pre-commit.sh:154`](scripts/pre-commit.sh#L154)) which uses **`-timeout=300s`**.

Aligning the release script to the same 300s the pre-commit hook already uses for the same `go test ./...` invocation.

## Change

```diff
-    GOWORK=off go test ./... -timeout=120s || {
+    GOWORK=off go test ./... -timeout=300s || {
```

No test selection or behavior change — just removing a flaky boundary in the release path that's been there since before Phase 4.

## Verified

Pre-commit hook clean (lint 0 issues + full `go test ./...` incl. Redis testcontainers green in ~100s with plenty of headroom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)