### PR TITLE
fix(#413): cache range-item statics across full content swaps

### DIFF
--- a/internal/diff/prepare.go
+++ b/internal/diff/prepare.go
@@ -24,8 +24,10 @@ func PrepareTreeForClient(node interface{}, clientHasStatics bool) interface{} {
 	// Client has statics - remove them to reduce wire size
 	switch v := node.(type) {
 	case *TreeNode:
-		// Create new TreeNode without statics or fingerprint
-		result := &TreeNode{}
+		// Create new TreeNode without statics or fingerprint. AutoKey must
+		// be preserved because it is the "_k" identifier the client uses to
+		// track range items by key (issue #413).
+		result := &TreeNode{AutoKey: v.AutoKey}
 		// Pre-allocate to avoid repeated growth in SetDynamic
 		result.GrowDynamics(len(v.Dynamics))
 		// Recursively prepare dynamics, filtering out empty values while preserving static-only conditional blocks

--- a/internal/diff/prepare.go
+++ b/internal/diff/prepare.go
@@ -24,9 +24,7 @@ func PrepareTreeForClient(node interface{}, clientHasStatics bool) interface{} {
 	// Client has statics - remove them to reduce wire size
 	switch v := node.(type) {
 	case *TreeNode:
-		// Create new TreeNode without statics or fingerprint. AutoKey must
-		// be preserved because it is the "_k" identifier the client uses to
-		// track range items by key (issue #413).
+		// AutoKey is the "_k" identifier the client uses to track range items by key.
 		result := &TreeNode{AutoKey: v.AutoKey}
 		// Pre-allocate to avoid repeated growth in SetDynamic
 		result.GrowDynamics(len(v.Dynamics))

--- a/internal/diff/range_insert_strip_test.go
+++ b/internal/diff/range_insert_strip_test.go
@@ -1,0 +1,175 @@
+package diff
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/livetemplate/internal/build"
+)
+
+// TestStreamInsert_StripsNestedDynamicBranchStatics — issue #413.
+//
+// The stream-mode update path (`dynamicsToUpdatePayload`) already strips
+// nested statics via `PrepareTreeForClient(v, true)` because the §5b
+// homogeneity check guarantees the client has them. Insertions were
+// inconsistent: they kept all nested statics via `PrepareTreeForClient(item,
+// false)`, re-emitting per-row scaffolding the client had cached.
+//
+// After the fix in #413, stream-mode insertions also pass the
+// homogeneity-guaranteed flag, so nested branches containing dynamics drop
+// their statics on the wire. Static-only branches (whose entire content is
+// HTML, no dynamics) still retain statics — the special case in
+// `PrepareTreeForClient` preserves branch identity for those, since the
+// client otherwise has no way to distinguish two static-only branches at the
+// same item position.
+func TestStreamInsert_StripsNestedDynamicBranchStatics(t *testing.T) {
+	// Build a homogeneous range "old side" with items shaped like:
+	//   {data-key, marker-branch-with-dynamic}
+	// where the marker is `{{if .HasMarker}}<m>{{.MarkerText}}</m>{{end}}`.
+	// All items share the same statics-fingerprint shape, so
+	// TransitionToStreamMode succeeds.
+	itemStatics := []string{`<li data-key="`, `">`, `</li>`}
+	makeItem := func(key, markerText string) *TreeNode {
+		marker := &TreeNode{
+			Statics:  []string{"<m>", "</m>"},
+			Dynamics: []interface{}{markerText},
+		}
+		return &TreeNode{
+			Statics:  itemStatics, // before extractItemDynamics, item carries statics
+			Dynamics: []interface{}{key, marker},
+		}
+	}
+
+	oldItems := []interface{}{
+		extractDynamics(makeItem("k1", "old-marker-1")),
+		extractDynamics(makeItem("k2", "old-marker-2")),
+	}
+	oldTree := &TreeNode{
+		Statics: itemStatics,
+		Range:   &build.RangeData{Items: oldItems, Statics: itemStatics},
+	}
+	TransitionToStreamMode(oldTree)
+	if oldTree.Range.StreamState == nil {
+		t.Fatalf("TransitionToStreamMode left StreamState nil — fixture lost homogeneity?")
+	}
+
+	// New side: all items replaced with new keys (full content swap).
+	// Items have the SAME structure (marker with dynamic), but different
+	// dynamic values.
+	newItems := []interface{}{
+		extractDynamics(makeItem("n1", "new-marker-1")),
+		extractDynamics(makeItem("n2", "new-marker-2")),
+	}
+	newTree := &TreeNode{
+		Statics: itemStatics,
+		Range:   &build.RangeData{Items: newItems, Statics: itemStatics},
+	}
+
+	// Drive the dispatch path so stripStatics == true (fingerprint match).
+	changes := &TreeNode{}
+	if !handleStreamModeRange(oldTree, newTree, changes) {
+		t.Fatalf("handleStreamModeRange did not dispatch to stream mode")
+	}
+
+	if changes.Range == nil {
+		t.Fatalf("expected changes.Range to be populated; got: %+v", changes)
+	}
+
+	payload, err := json.Marshal(changes.Range.Items)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	// The marker's `<m>` static SHOULD be absent — the client has it cached
+	// from the homogeneity guarantee.
+	if strings.Contains(string(payload), `<m>`) {
+		t.Errorf("nested marker statics leaked into stream-mode insert payload (issue #413)\n  payload=%s", payload)
+	}
+
+	// The new dynamic content MUST still arrive.
+	if !strings.Contains(string(payload), "new-marker-1") || !strings.Contains(string(payload), "new-marker-2") {
+		t.Errorf("new-side dynamic content missing from insert payload\n  payload=%s", payload)
+	}
+}
+
+// TestStreamInsert_PreservesStaticOnlyBranchIdentity — companion to the
+// previous test. For static-only conditional branches (e.g.
+// `{{if .Add}}+{{end}}`) the branch's statics ARE the branch identity, and
+// stripping them would make `{s:["+"]}` and `{s:["-"]}` indistinguishable on
+// the wire. The special case in `PrepareTreeForClient` retains those, so the
+// fix in #413 must not regress this case.
+func TestStreamInsert_PreservesStaticOnlyBranchIdentity(t *testing.T) {
+	itemStatics := []string{`<li data-key="`, `">`, `</li>`}
+	// Build items where position 1 is a static-only nested *TreeNode (e.g.
+	// the {{else}} branch of a multi-branch conditional rendered with no
+	// dynamics).
+	makeItem := func(key, branchStatic string) *TreeNode {
+		branch := &TreeNode{Statics: []string{branchStatic}}
+		return &TreeNode{
+			Statics:  itemStatics,
+			Dynamics: []interface{}{key, branch},
+		}
+	}
+
+	// Need homogeneous old side to enter stream mode. All items use the same
+	// branch shape (static-only), but they may differ in what static text
+	// fills the branch — that's a STATICS difference, not a structure
+	// difference, so the staticsFingerprint matches.
+	oldItems := []interface{}{
+		extractDynamics(makeItem("k1", "+")),
+		extractDynamics(makeItem("k2", "+")),
+	}
+	oldTree := &TreeNode{
+		Statics: itemStatics,
+		Range:   &build.RangeData{Items: oldItems, Statics: itemStatics},
+	}
+	TransitionToStreamMode(oldTree)
+	if oldTree.Range.StreamState == nil {
+		t.Fatalf("TransitionToStreamMode left StreamState nil — fixture lost homogeneity?")
+	}
+
+	newItems := []interface{}{
+		extractDynamics(makeItem("n1", "+")),
+		extractDynamics(makeItem("n2", "+")),
+	}
+	newTree := &TreeNode{
+		Statics: itemStatics,
+		Range:   &build.RangeData{Items: newItems, Statics: itemStatics},
+	}
+
+	changes := &TreeNode{}
+	if !handleStreamModeRange(oldTree, newTree, changes) {
+		t.Fatalf("handleStreamModeRange did not dispatch to stream mode")
+	}
+
+	if changes.Range == nil {
+		t.Fatalf("expected changes.Range; got: %+v", changes)
+	}
+
+	payload, err := json.Marshal(changes.Range.Items)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	// The static-only branch's content MUST remain — it carries the branch
+	// identity. Stripping it would make two static-only branches at the same
+	// position indistinguishable.
+	if !strings.Contains(string(payload), `"+"`) {
+		t.Errorf("static-only branch statics were stripped, losing branch identity (regression vs PrepareTreeForClient special case)\n  payload=%s", payload)
+	}
+}
+
+// extractDynamics mirrors parse.extractItemDynamics for test fixtures: items
+// in a range carry their statics on the parent Range.Statics, not on each
+// item TreeNode. Without this, the homogeneity check would compare two items
+// with embedded Statics arrays as if they were the wire shape, which the
+// diff path never sees in production.
+func extractDynamics(item *TreeNode) *TreeNode {
+	result := &TreeNode{AutoKey: item.AutoKey}
+	if len(item.Dynamics) > 0 {
+		result.Dynamics = make([]interface{}, len(item.Dynamics))
+		copy(result.Dynamics, item.Dynamics)
+	}
+	return result
+}

--- a/internal/diff/range_insert_strip_test.go
+++ b/internal/diff/range_insert_strip_test.go
@@ -8,20 +8,7 @@ import (
 	"github.com/livetemplate/livetemplate/internal/build"
 )
 
-// TestStreamInsert_PreservesNestedDynamicBranchStatics — issue #413.
-//
-// The original symmetry attempt (stripping nested item statics in stream-mode
-// INSERTs to mirror the UPDATE path) broke client rendering. Updates patch
-// existing DOM in place, so the client only needs new dynamic values. Inserts
-// have to RENDER new DOM, and the client has no per-position branch-statics
-// cache — when it sees an item like {"0": {"0": "marker text"}} with no "s"
-// on the nested object, it joins values with empty string and loses the
-// HTML wrapper (`<span class="marker">…</span>`). Downstream regressions:
-// examples/flash-messages and tinkerdown auto-tables.
-//
-// This test locks in the contract that stream-mode INSERT payloads carry
-// the full per-item nested branch statics so the client can reconstruct
-// every new row's HTML structure.
+// Stream-mode INSERTs must carry full nested statics; client renders new rows without a branch-statics cache.
 func TestStreamInsert_PreservesNestedDynamicBranchStatics(t *testing.T) {
 	itemStatics := []string{`<li data-key="`, `">`, `</li>`}
 	makeItem := func(key, markerText string) *TreeNode {
@@ -75,7 +62,7 @@ func TestStreamInsert_PreservesNestedDynamicBranchStatics(t *testing.T) {
 	// default. Check the "s":[...] envelope (proves the nested statics
 	// were not stripped) and the actual on-wire marker content.
 	if !strings.Contains(string(payload), `"s":[`) {
-		t.Errorf("nested marker statics missing from insert payload; client cannot render new rows (issue #413)\n  payload=%s", payload)
+		t.Errorf("nested marker statics missing from insert payload; client cannot render new rows\n  payload=%s", payload)
 	}
 	if !strings.Contains(string(payload), `\u003cm\u003e`) {
 		t.Errorf("nested marker static content (<m>) missing from insert payload\n  payload=%s", payload)
@@ -92,12 +79,7 @@ func TestStreamInsert_PreservesNestedDynamicBranchStatics(t *testing.T) {
 	}
 }
 
-// TestStreamInsert_PreservesStaticOnlyBranchIdentity — companion test. For
-// static-only conditional branches (e.g. `{{if .Add}}+{{end}}`) the branch's
-// statics ARE the branch identity. The PrepareTreeForClient special case for
-// static-only branches preserved this even when the (now-reverted) strip-on-
-// insert path was active. Keeping the test guards against future regressions
-// in that special case.
+// Static-only conditional branches ({{if .Add}}+{{end}}) carry identity in their statics — never strip them.
 func TestStreamInsert_PreservesStaticOnlyBranchIdentity(t *testing.T) {
 	itemStatics := []string{`<li data-key="`, `">`, `</li>`}
 	makeItem := func(key, branchStatic string) *TreeNode {
@@ -149,12 +131,7 @@ func TestStreamInsert_PreservesStaticOnlyBranchIdentity(t *testing.T) {
 	}
 }
 
-// TestStreamInsert_PreservesAutoKey — regression test for the
-// examples/flash-messages bug. Items in a `{{range}}` without an explicit
-// data-key get an auto-generated `_k` field via build.TreeNode.AutoKey.
-// PrepareTreeForClient was dropping AutoKey when stripping statics, so
-// stream-mode inserts arrived at the client without `_k` and the client
-// could not track the new row by key.
+// PrepareTreeForClient must preserve AutoKey when stripping statics so the client can track new rows by key.
 func TestStreamInsert_PreservesAutoKey(t *testing.T) {
 	makeItem := func(autoKey, val string) *TreeNode {
 		return &TreeNode{
@@ -200,15 +177,11 @@ func TestStreamInsert_PreservesAutoKey(t *testing.T) {
 	}
 
 	if !strings.Contains(string(payload), `"_k":"hash-c"`) {
-		t.Errorf("auto-key (_k) missing from stream-mode insert; client cannot track new row (issue #413)\n  payload=%s", payload)
+		t.Errorf("auto-key (_k) missing from stream-mode insert; client cannot track new row\n  payload=%s", payload)
 	}
 }
 
-// extractDynamics mirrors parse.extractItemDynamics for test fixtures: items
-// in a range carry their statics on the parent Range.Statics, not on each
-// item TreeNode. Without this, the homogeneity check would compare two items
-// with embedded Statics arrays as if they were the wire shape, which the
-// diff path never sees in production.
+// extractDynamics mirrors parse.extractItemDynamics: range items carry statics on parent Range.Statics, not per-item.
 func extractDynamics(item *TreeNode) *TreeNode {
 	result := &TreeNode{AutoKey: item.AutoKey}
 	if len(item.Dynamics) > 0 {

--- a/internal/diff/range_insert_strip_test.go
+++ b/internal/diff/range_insert_strip_test.go
@@ -8,27 +8,21 @@ import (
 	"github.com/livetemplate/livetemplate/internal/build"
 )
 
-// TestStreamInsert_StripsNestedDynamicBranchStatics — issue #413.
+// TestStreamInsert_PreservesNestedDynamicBranchStatics — issue #413.
 //
-// The stream-mode update path (`dynamicsToUpdatePayload`) already strips
-// nested statics via `PrepareTreeForClient(v, true)` because the §5b
-// homogeneity check guarantees the client has them. Insertions were
-// inconsistent: they kept all nested statics via `PrepareTreeForClient(item,
-// false)`, re-emitting per-row scaffolding the client had cached.
+// The original symmetry attempt (stripping nested item statics in stream-mode
+// INSERTs to mirror the UPDATE path) broke client rendering. Updates patch
+// existing DOM in place, so the client only needs new dynamic values. Inserts
+// have to RENDER new DOM, and the client has no per-position branch-statics
+// cache — when it sees an item like {"0": {"0": "marker text"}} with no "s"
+// on the nested object, it joins values with empty string and loses the
+// HTML wrapper (`<span class="marker">…</span>`). Downstream regressions:
+// examples/flash-messages and tinkerdown auto-tables.
 //
-// After the fix in #413, stream-mode insertions also pass the
-// homogeneity-guaranteed flag, so nested branches containing dynamics drop
-// their statics on the wire. Static-only branches (whose entire content is
-// HTML, no dynamics) still retain statics — the special case in
-// `PrepareTreeForClient` preserves branch identity for those, since the
-// client otherwise has no way to distinguish two static-only branches at the
-// same item position.
-func TestStreamInsert_StripsNestedDynamicBranchStatics(t *testing.T) {
-	// Build a homogeneous range "old side" with items shaped like:
-	//   {data-key, marker-branch-with-dynamic}
-	// where the marker is `{{if .HasMarker}}<m>{{.MarkerText}}</m>{{end}}`.
-	// All items share the same statics-fingerprint shape, so
-	// TransitionToStreamMode succeeds.
+// This test locks in the contract that stream-mode INSERT payloads carry
+// the full per-item nested branch statics so the client can reconstruct
+// every new row's HTML structure.
+func TestStreamInsert_PreservesNestedDynamicBranchStatics(t *testing.T) {
 	itemStatics := []string{`<li data-key="`, `">`, `</li>`}
 	makeItem := func(key, markerText string) *TreeNode {
 		marker := &TreeNode{
@@ -36,7 +30,7 @@ func TestStreamInsert_StripsNestedDynamicBranchStatics(t *testing.T) {
 			Dynamics: []interface{}{markerText},
 		}
 		return &TreeNode{
-			Statics:  itemStatics, // before extractItemDynamics, item carries statics
+			Statics:  itemStatics,
 			Dynamics: []interface{}{key, marker},
 		}
 	}
@@ -54,9 +48,6 @@ func TestStreamInsert_StripsNestedDynamicBranchStatics(t *testing.T) {
 		t.Fatalf("TransitionToStreamMode left StreamState nil — fixture lost homogeneity?")
 	}
 
-	// New side: all items replaced with new keys (full content swap).
-	// Items have the SAME structure (marker with dynamic), but different
-	// dynamic values.
 	newItems := []interface{}{
 		extractDynamics(makeItem("n1", "new-marker-1")),
 		extractDynamics(makeItem("n2", "new-marker-2")),
@@ -66,7 +57,6 @@ func TestStreamInsert_StripsNestedDynamicBranchStatics(t *testing.T) {
 		Range:   &build.RangeData{Items: newItems, Statics: itemStatics},
 	}
 
-	// Drive the dispatch path so stripStatics == true (fingerprint match).
 	changes := &TreeNode{}
 	if !handleStreamModeRange(oldTree, newTree, changes) {
 		t.Fatalf("handleStreamModeRange did not dispatch to stream mode")
@@ -81,29 +71,35 @@ func TestStreamInsert_StripsNestedDynamicBranchStatics(t *testing.T) {
 		t.Fatalf("json.Marshal failed: %v", err)
 	}
 
-	// The marker's `<m>` static SHOULD be absent — the client has it cached
-	// from the homogeneity guarantee.
-	if strings.Contains(string(payload), `<m>`) {
-		t.Errorf("nested marker statics leaked into stream-mode insert payload (issue #413)\n  payload=%s", payload)
+	// json.Marshal HTML-escapes `<` to `<` and `>` to `>` by
+	// default. Check the "s":[...] envelope (proves the nested statics
+	// were not stripped) and the actual on-wire marker content.
+	if !strings.Contains(string(payload), `"s":[`) {
+		t.Errorf("nested marker statics missing from insert payload; client cannot render new rows (issue #413)\n  payload=%s", payload)
+	}
+	if !strings.Contains(string(payload), `\u003cm\u003e`) {
+		t.Errorf("nested marker static content (<m>) missing from insert payload\n  payload=%s", payload)
 	}
 
 	// The new dynamic content MUST still arrive.
 	if !strings.Contains(string(payload), "new-marker-1") || !strings.Contains(string(payload), "new-marker-2") {
 		t.Errorf("new-side dynamic content missing from insert payload\n  payload=%s", payload)
 	}
+
+	// Item keys must arrive so the client can track the new rows.
+	if !strings.Contains(string(payload), `"n1"`) || !strings.Contains(string(payload), `"n2"`) {
+		t.Errorf("new-side item keys missing from insert payload\n  payload=%s", payload)
+	}
 }
 
-// TestStreamInsert_PreservesStaticOnlyBranchIdentity — companion to the
-// previous test. For static-only conditional branches (e.g.
-// `{{if .Add}}+{{end}}`) the branch's statics ARE the branch identity, and
-// stripping them would make `{s:["+"]}` and `{s:["-"]}` indistinguishable on
-// the wire. The special case in `PrepareTreeForClient` retains those, so the
-// fix in #413 must not regress this case.
+// TestStreamInsert_PreservesStaticOnlyBranchIdentity — companion test. For
+// static-only conditional branches (e.g. `{{if .Add}}+{{end}}`) the branch's
+// statics ARE the branch identity. The PrepareTreeForClient special case for
+// static-only branches preserved this even when the (now-reverted) strip-on-
+// insert path was active. Keeping the test guards against future regressions
+// in that special case.
 func TestStreamInsert_PreservesStaticOnlyBranchIdentity(t *testing.T) {
 	itemStatics := []string{`<li data-key="`, `">`, `</li>`}
-	// Build items where position 1 is a static-only nested *TreeNode (e.g.
-	// the {{else}} branch of a multi-branch conditional rendered with no
-	// dynamics).
 	makeItem := func(key, branchStatic string) *TreeNode {
 		branch := &TreeNode{Statics: []string{branchStatic}}
 		return &TreeNode{
@@ -112,10 +108,6 @@ func TestStreamInsert_PreservesStaticOnlyBranchIdentity(t *testing.T) {
 		}
 	}
 
-	// Need homogeneous old side to enter stream mode. All items use the same
-	// branch shape (static-only), but they may differ in what static text
-	// fills the branch — that's a STATICS difference, not a structure
-	// difference, so the staticsFingerprint matches.
 	oldItems := []interface{}{
 		extractDynamics(makeItem("k1", "+")),
 		extractDynamics(makeItem("k2", "+")),
@@ -152,11 +144,63 @@ func TestStreamInsert_PreservesStaticOnlyBranchIdentity(t *testing.T) {
 		t.Fatalf("json.Marshal failed: %v", err)
 	}
 
-	// The static-only branch's content MUST remain — it carries the branch
-	// identity. Stripping it would make two static-only branches at the same
-	// position indistinguishable.
 	if !strings.Contains(string(payload), `"+"`) {
 		t.Errorf("static-only branch statics were stripped, losing branch identity (regression vs PrepareTreeForClient special case)\n  payload=%s", payload)
+	}
+}
+
+// TestStreamInsert_PreservesAutoKey — regression test for the
+// examples/flash-messages bug. Items in a `{{range}}` without an explicit
+// data-key get an auto-generated `_k` field via build.TreeNode.AutoKey.
+// PrepareTreeForClient was dropping AutoKey when stripping statics, so
+// stream-mode inserts arrived at the client without `_k` and the client
+// could not track the new row by key.
+func TestStreamInsert_PreservesAutoKey(t *testing.T) {
+	makeItem := func(autoKey, val string) *TreeNode {
+		return &TreeNode{
+			AutoKey:  autoKey,
+			Dynamics: []interface{}{val},
+		}
+	}
+
+	itemStatics := []string{"<li>", "</li>"}
+	oldItems := []interface{}{
+		makeItem("hash-a", "Apple"),
+		makeItem("hash-b", "Banana"),
+	}
+	oldTree := &TreeNode{
+		Statics:  itemStatics,
+		Range:    &build.RangeData{Items: oldItems, Statics: itemStatics},
+		Metadata: &build.TreeMetadata{IDKey: "_k"},
+	}
+	TransitionToStreamMode(oldTree)
+	if oldTree.Range.StreamState == nil {
+		t.Fatalf("TransitionToStreamMode left StreamState nil — fixture lost homogeneity?")
+	}
+
+	newItems := []interface{}{
+		makeItem("hash-a", "Apple"),
+		makeItem("hash-b", "Banana"),
+		makeItem("hash-c", "Cherry"),
+	}
+	newTree := &TreeNode{
+		Statics:  itemStatics,
+		Range:    &build.RangeData{Items: newItems, Statics: itemStatics},
+		Metadata: &build.TreeMetadata{IDKey: "_k"},
+	}
+
+	changes := &TreeNode{}
+	if !handleStreamModeRange(oldTree, newTree, changes) {
+		t.Fatalf("handleStreamModeRange did not dispatch to stream mode")
+	}
+
+	payload, err := json.Marshal(changes.Range.Items)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"_k":"hash-c"`) {
+		t.Errorf("auto-key (_k) missing from stream-mode insert; client cannot track new row (issue #413)\n  payload=%s", payload)
 	}
 }
 

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -138,7 +138,10 @@ func GenerateRangeDifferentialOperations(oldValue, newValue interface{}, stripSt
 
 	operations := make([]interface{}, 0, 4)
 	operations = generateRemovalOps(ctx, operations)
-	operations = generateInsertionOps(ctx, operations)
+	// Legacy path: no per-item homogeneity guarantee, so retain nested item
+	// statics on new inserts. Stream-mode path (below) does carry the
+	// guarantee and may strip them.
+	operations = generateInsertionOps(ctx, operations, false)
 
 	if sameKeySet(ctx.oldKeys, ctx.newKeys) && HasReordering(ctx.oldKeys, ctx.newKeys) {
 		operations = append(operations, []interface{}{"o", ctx.newKeys})
@@ -229,7 +232,13 @@ func GenerateRangeStreamOperations(
 	operations := make([]interface{}, 0, 4)
 	operations = generateStreamRemovalOps(streamState.Keys, ctx.newByKey, operations)
 	operations = generateStreamUpdateOps(newItems, newKeys, newHashes, oldHashByKey, ctx.keyPos, operations)
-	operations = generateInsertionOps(ctx, operations)
+	// Stream-mode inserts: the §5b homogeneity check at the top of this
+	// function guarantees every new item shares streamState.Fingerprint, so
+	// the client has the item's nested statics cached from the previous
+	// render. Pass stripStatics through so per-item nested statics get the
+	// same treatment as the op-envelope statics (consistent with the
+	// stream-mode update path's PrepareTreeForClient(v, true) call). Issue #413.
+	operations = generateInsertionOps(ctx, operations, stripStatics)
 
 	if hasReorder {
 		operations = append(operations, []interface{}{"o", newKeys})
@@ -480,30 +489,39 @@ func hasKeptItemChanged(ctx *rangeContext) bool {
 	return false
 }
 
-func generateInsertionOps(ctx *rangeContext, operations []interface{}) []interface{} {
+// generateInsertionOps emits insert operations for items newly added in the
+// new render. `clientHasItemStatics` says whether the client already has the
+// per-item nested statics cached — true in stream mode (the §5b homogeneity
+// check guarantees every new item shares the previously-rendered statics
+// shape) and false on the legacy path (no such guarantee).
+func generateInsertionOps(ctx *rangeContext, operations []interface{}, clientHasItemStatics bool) []interface{} {
 	if len(ctx.addedKeys) == 0 {
 		return operations
 	}
 
 	if len(ctx.oldKeySet) == 0 {
-		return handleEmptyToItemsTransition(ctx.newItems, ctx.statics, ctx.metadata, operations)
+		return handleEmptyToItemsTransition(ctx.newItems, ctx.statics, ctx.metadata, operations, clientHasItemStatics)
 	}
 
-	return handleIncrementalInsertionsCtx(ctx, operations)
+	return handleIncrementalInsertionsCtx(ctx, operations, clientHasItemStatics)
 }
 
 // handleEmptyToItemsTransition handles the transition from empty range to items.
+// When clientHasItemStatics is true (stream-mode insert with homogeneity
+// guarantee), nested per-item statics that the client already has cached are
+// stripped via PrepareTreeForClient. The static-only conditional-branch case
+// in PrepareTreeForClient still retains those statics so branch identity is
+// preserved on the wire.
 func handleEmptyToItemsTransition(
 	newItems []interface{},
 	statics interface{},
 	metadata map[string]interface{},
 	operations []interface{},
+	clientHasItemStatics bool,
 ) []interface{} {
-	// Build array of items to append, KEEPING nested statics
-	// The client hasn't seen these items before, so they need full structure
 	itemsToAppend := make([]interface{}, 0, len(newItems))
 	for _, item := range newItems {
-		itemsToAppend = append(itemsToAppend, PrepareTreeForClient(item, false))
+		itemsToAppend = append(itemsToAppend, PrepareTreeForClient(item, clientHasItemStatics))
 	}
 
 	// Use 'a' operation with statics and metadata so client can initialize range state
@@ -517,16 +535,16 @@ func handleEmptyToItemsTransition(
 	return operations
 }
 
-func handleIncrementalInsertionsCtx(ctx *rangeContext, operations []interface{}) []interface{} {
+func handleIncrementalInsertionsCtx(ctx *rangeContext, operations []interface{}, clientHasItemStatics bool) []interface{} {
 	if areAllItemsAtStartCtx(ctx) {
-		return handlePrependOperation(ctx.addedKeys, ctx.newByKey, ctx.statics, operations)
+		return handlePrependOperation(ctx.addedKeys, ctx.newByKey, ctx.statics, operations, clientHasItemStatics)
 	}
 
 	if areAllItemsAtEndCtx(ctx) {
-		return handleAppendOperation(ctx.addedKeys, ctx.newByKey, ctx.statics, operations)
+		return handleAppendOperation(ctx.addedKeys, ctx.newByKey, ctx.statics, operations, clientHasItemStatics)
 	}
 
-	return handleIndividualInsertionsCtx(ctx, operations)
+	return handleIndividualInsertionsCtx(ctx, operations, clientHasItemStatics)
 }
 
 // handlePrependOperation generates prepend operations for items at the start.
@@ -535,13 +553,12 @@ func handlePrependOperation(
 	newItemsByKey map[string]interface{},
 	statics interface{},
 	operations []interface{},
+	clientHasItemStatics bool,
 ) []interface{} {
 	itemsToPrepend := make([]interface{}, 0, len(addedKeys))
 	for _, key := range addedKeys {
 		if item, exists := newItemsByKey[key]; exists {
-			// Keep nested statics for new items - client hasn't seen these items before
-			// so nested TreeNode structures (like conditionals) need their statics.
-			itemsToPrepend = append(itemsToPrepend, PrepareTreeForClient(item, false))
+			itemsToPrepend = append(itemsToPrepend, PrepareTreeForClient(item, clientHasItemStatics))
 		}
 	}
 	// Use 'p' operation for prepending (O(1) on client)
@@ -556,13 +573,12 @@ func handleAppendOperation(
 	newItemsByKey map[string]interface{},
 	statics interface{},
 	operations []interface{},
+	clientHasItemStatics bool,
 ) []interface{} {
 	itemsToAppend := make([]interface{}, 0, len(addedKeys))
 	for _, key := range addedKeys {
 		if item, exists := newItemsByKey[key]; exists {
-			// Keep nested statics for new items - client hasn't seen these items before
-			// so nested TreeNode structures (like conditionals) need their statics.
-			itemsToAppend = append(itemsToAppend, PrepareTreeForClient(item, false))
+			itemsToAppend = append(itemsToAppend, PrepareTreeForClient(item, clientHasItemStatics))
 		}
 	}
 	// Use 'a' operation for appending (O(1) on client)
@@ -571,17 +587,17 @@ func handleAppendOperation(
 	return operations
 }
 
-func handleIndividualInsertionsCtx(ctx *rangeContext, operations []interface{}) []interface{} {
+func handleIndividualInsertionsCtx(ctx *rangeContext, operations []interface{}, clientHasItemStatics bool) []interface{} {
 	for _, key := range ctx.addedKeys {
 		if newItem, exists := ctx.newByKey[key]; exists {
 			for i, item := range ctx.newItems {
 				if itemKey, ok := ctx.getItemKey(item); ok && itemKey == key {
 					if i == 0 {
-						preparedItem := PrepareTreeForClient(newItem, false)
+						preparedItem := PrepareTreeForClient(newItem, clientHasItemStatics)
 						operations = append(operations, []interface{}{"p", []interface{}{preparedItem}, ctx.statics})
 					} else {
 						if prevKey, ok := ctx.getItemKey(ctx.newItems[i-1]); ok {
-							preparedItem := PrepareTreeForClient(newItem, false)
+							preparedItem := PrepareTreeForClient(newItem, clientHasItemStatics)
 							operations = append(operations, []interface{}{"i", prevKey, preparedItem})
 						}
 					}

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -138,10 +138,7 @@ func GenerateRangeDifferentialOperations(oldValue, newValue interface{}, stripSt
 
 	operations := make([]interface{}, 0, 4)
 	operations = generateRemovalOps(ctx, operations)
-	// Legacy path: no per-item homogeneity guarantee, so retain nested item
-	// statics on new inserts. Stream-mode path (below) does carry the
-	// guarantee and may strip them.
-	operations = generateInsertionOps(ctx, operations, false)
+	operations = generateInsertionOps(ctx, operations)
 
 	if sameKeySet(ctx.oldKeys, ctx.newKeys) && HasReordering(ctx.oldKeys, ctx.newKeys) {
 		operations = append(operations, []interface{}{"o", ctx.newKeys})
@@ -232,13 +229,13 @@ func GenerateRangeStreamOperations(
 	operations := make([]interface{}, 0, 4)
 	operations = generateStreamRemovalOps(streamState.Keys, ctx.newByKey, operations)
 	operations = generateStreamUpdateOps(newItems, newKeys, newHashes, oldHashByKey, ctx.keyPos, operations)
-	// Stream-mode inserts: the §5b homogeneity check at the top of this
-	// function guarantees every new item shares streamState.Fingerprint, so
-	// the client has the item's nested statics cached from the previous
-	// render. Pass stripStatics through so per-item nested statics get the
-	// same treatment as the op-envelope statics (consistent with the
-	// stream-mode update path's PrepareTreeForClient(v, true) call). Issue #413.
-	operations = generateInsertionOps(ctx, operations, stripStatics)
+	// Inserts keep nested item statics: even under the §5b homogeneity
+	// guarantee, the client renders new rows from data and has no per-position
+	// branch statics cache. Stripping breaks rendering for any item containing
+	// nested *TreeNode dynamics (conditional branches with dynamics). The
+	// stream-mode UPDATE path strips because it patches existing DOM in
+	// place — INSERT can't. Op-envelope statics are still stripped below.
+	operations = generateInsertionOps(ctx, operations)
 
 	if hasReorder {
 		operations = append(operations, []interface{}{"o", newKeys})
@@ -490,38 +487,31 @@ func hasKeptItemChanged(ctx *rangeContext) bool {
 }
 
 // generateInsertionOps emits insert operations for items newly added in the
-// new render. `clientHasItemStatics` says whether the client already has the
-// per-item nested statics cached — true in stream mode (the §5b homogeneity
-// check guarantees every new item shares the previously-rendered statics
-// shape) and false on the legacy path (no such guarantee).
-func generateInsertionOps(ctx *rangeContext, operations []interface{}, clientHasItemStatics bool) []interface{} {
+// new render. Items are kept intact (PrepareTreeForClient with strip=false)
+// because the client renders new rows from data and has no cache for
+// per-item nested branch statics — stripping them would lose the HTML
+// structure the client needs (issue #413).
+func generateInsertionOps(ctx *rangeContext, operations []interface{}) []interface{} {
 	if len(ctx.addedKeys) == 0 {
 		return operations
 	}
 
 	if len(ctx.oldKeySet) == 0 {
-		return handleEmptyToItemsTransition(ctx.newItems, ctx.statics, ctx.metadata, operations, clientHasItemStatics)
+		return handleEmptyToItemsTransition(ctx.newItems, ctx.statics, ctx.metadata, operations)
 	}
 
-	return handleIncrementalInsertionsCtx(ctx, operations, clientHasItemStatics)
+	return handleIncrementalInsertionsCtx(ctx, operations)
 }
 
-// handleEmptyToItemsTransition handles the transition from empty range to items.
-// When clientHasItemStatics is true (stream-mode insert with homogeneity
-// guarantee), nested per-item statics that the client already has cached are
-// stripped via PrepareTreeForClient. The static-only conditional-branch case
-// in PrepareTreeForClient still retains those statics so branch identity is
-// preserved on the wire.
 func handleEmptyToItemsTransition(
 	newItems []interface{},
 	statics interface{},
 	metadata map[string]interface{},
 	operations []interface{},
-	clientHasItemStatics bool,
 ) []interface{} {
 	itemsToAppend := make([]interface{}, 0, len(newItems))
 	for _, item := range newItems {
-		itemsToAppend = append(itemsToAppend, PrepareTreeForClient(item, clientHasItemStatics))
+		itemsToAppend = append(itemsToAppend, PrepareTreeForClient(item, false))
 	}
 
 	// Use 'a' operation with statics and metadata so client can initialize range state
@@ -535,16 +525,16 @@ func handleEmptyToItemsTransition(
 	return operations
 }
 
-func handleIncrementalInsertionsCtx(ctx *rangeContext, operations []interface{}, clientHasItemStatics bool) []interface{} {
+func handleIncrementalInsertionsCtx(ctx *rangeContext, operations []interface{}) []interface{} {
 	if areAllItemsAtStartCtx(ctx) {
-		return handlePrependOperation(ctx.addedKeys, ctx.newByKey, ctx.statics, operations, clientHasItemStatics)
+		return handlePrependOperation(ctx.addedKeys, ctx.newByKey, ctx.statics, operations)
 	}
 
 	if areAllItemsAtEndCtx(ctx) {
-		return handleAppendOperation(ctx.addedKeys, ctx.newByKey, ctx.statics, operations, clientHasItemStatics)
+		return handleAppendOperation(ctx.addedKeys, ctx.newByKey, ctx.statics, operations)
 	}
 
-	return handleIndividualInsertionsCtx(ctx, operations, clientHasItemStatics)
+	return handleIndividualInsertionsCtx(ctx, operations)
 }
 
 // handlePrependOperation generates prepend operations for items at the start.
@@ -553,12 +543,11 @@ func handlePrependOperation(
 	newItemsByKey map[string]interface{},
 	statics interface{},
 	operations []interface{},
-	clientHasItemStatics bool,
 ) []interface{} {
 	itemsToPrepend := make([]interface{}, 0, len(addedKeys))
 	for _, key := range addedKeys {
 		if item, exists := newItemsByKey[key]; exists {
-			itemsToPrepend = append(itemsToPrepend, PrepareTreeForClient(item, clientHasItemStatics))
+			itemsToPrepend = append(itemsToPrepend, PrepareTreeForClient(item, false))
 		}
 	}
 	// Use 'p' operation for prepending (O(1) on client)
@@ -573,12 +562,11 @@ func handleAppendOperation(
 	newItemsByKey map[string]interface{},
 	statics interface{},
 	operations []interface{},
-	clientHasItemStatics bool,
 ) []interface{} {
 	itemsToAppend := make([]interface{}, 0, len(addedKeys))
 	for _, key := range addedKeys {
 		if item, exists := newItemsByKey[key]; exists {
-			itemsToAppend = append(itemsToAppend, PrepareTreeForClient(item, clientHasItemStatics))
+			itemsToAppend = append(itemsToAppend, PrepareTreeForClient(item, false))
 		}
 	}
 	// Use 'a' operation for appending (O(1) on client)
@@ -587,17 +575,17 @@ func handleAppendOperation(
 	return operations
 }
 
-func handleIndividualInsertionsCtx(ctx *rangeContext, operations []interface{}, clientHasItemStatics bool) []interface{} {
+func handleIndividualInsertionsCtx(ctx *rangeContext, operations []interface{}) []interface{} {
 	for _, key := range ctx.addedKeys {
 		if newItem, exists := ctx.newByKey[key]; exists {
 			for i, item := range ctx.newItems {
 				if itemKey, ok := ctx.getItemKey(item); ok && itemKey == key {
 					if i == 0 {
-						preparedItem := PrepareTreeForClient(newItem, clientHasItemStatics)
+						preparedItem := PrepareTreeForClient(newItem, false)
 						operations = append(operations, []interface{}{"p", []interface{}{preparedItem}, ctx.statics})
 					} else {
 						if prevKey, ok := ctx.getItemKey(ctx.newItems[i-1]); ok {
-							preparedItem := PrepareTreeForClient(newItem, clientHasItemStatics)
+							preparedItem := PrepareTreeForClient(newItem, false)
 							operations = append(operations, []interface{}{"i", prevKey, preparedItem})
 						}
 					}

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -229,12 +229,7 @@ func GenerateRangeStreamOperations(
 	operations := make([]interface{}, 0, 4)
 	operations = generateStreamRemovalOps(streamState.Keys, ctx.newByKey, operations)
 	operations = generateStreamUpdateOps(newItems, newKeys, newHashes, oldHashByKey, ctx.keyPos, operations)
-	// Inserts keep nested item statics: even under the §5b homogeneity
-	// guarantee, the client renders new rows from data and has no per-position
-	// branch statics cache. Stripping breaks rendering for any item containing
-	// nested *TreeNode dynamics (conditional branches with dynamics). The
-	// stream-mode UPDATE path strips because it patches existing DOM in
-	// place — INSERT can't. Op-envelope statics are still stripped below.
+	// Inserts keep nested statics: client renders new DOM without a per-position branch-statics cache.
 	operations = generateInsertionOps(ctx, operations)
 
 	if hasReorder {
@@ -486,11 +481,7 @@ func hasKeptItemChanged(ctx *rangeContext) bool {
 	return false
 }
 
-// generateInsertionOps emits insert operations for items newly added in the
-// new render. Items are kept intact (PrepareTreeForClient with strip=false)
-// because the client renders new rows from data and has no cache for
-// per-item nested branch statics — stripping them would lose the HTML
-// structure the client needs (issue #413).
+// generateInsertionOps emits insert ops for newly-added items, keeping nested statics intact.
 func generateInsertionOps(ctx *rangeContext, operations []interface{}) []interface{} {
 	if len(ctx.addedKeys) == 0 {
 		return operations

--- a/internal/diff/range_ops_test.go
+++ b/internal/diff/range_ops_test.go
@@ -482,7 +482,7 @@ func TestGenerateInsertionOperations_Prepend(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	operations := []interface{}{}
 
-	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations)
+	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations, false)
 
 	// Should generate prepend operation
 	found := false
@@ -513,7 +513,7 @@ func TestGenerateInsertionOperations_Append(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	operations := []interface{}{}
 
-	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations)
+	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations, false)
 
 	// Should generate append operation
 	found := false
@@ -546,7 +546,7 @@ func TestGenerateInsertionOperations_Complex(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	operations := []interface{}{}
 
-	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations)
+	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations, false)
 
 	// Should generate individual insert operation
 	found := false

--- a/internal/diff/range_ops_test.go
+++ b/internal/diff/range_ops_test.go
@@ -482,7 +482,7 @@ func TestGenerateInsertionOperations_Prepend(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	operations := []interface{}{}
 
-	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations, false)
+	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations)
 
 	// Should generate prepend operation
 	found := false
@@ -513,7 +513,7 @@ func TestGenerateInsertionOperations_Append(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	operations := []interface{}{}
 
-	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations, false)
+	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations)
 
 	// Should generate append operation
 	found := false
@@ -546,7 +546,7 @@ func TestGenerateInsertionOperations_Complex(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	operations := []interface{}{}
 
-	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations, false)
+	ops := generateInsertionOps(newRangeContext(oldItems, newItems, statics, nil), operations)
 
 	// Should generate individual insert operation
 	found := false

--- a/range_statics_swap_bench_test.go
+++ b/range_statics_swap_bench_test.go
@@ -8,23 +8,7 @@ import (
 	"testing"
 )
 
-// Benchmarks for issue #413: measure the WIRE PAYLOAD size of a full content
-// swap of a {{range}} at varying row counts. We measure the JSON length, not
-// allocator bytes, because the issue is about transmitted bytes.
-//
-// Two shapes:
-//   1. "Simple": homogeneous range with primitive dynamics — the case from
-//      the issue. After the fingerprint-based op-envelope strip, this
-//      scales near-linearly in dynamic content size with zero per-row static
-//      overhead.
-//   2. "DynamicBranch": homogeneous range whose item template contains an
-//      {{if}}…{{else}}{{end}} branch with a dynamic inside the if-arm. The
-//      branch's statics MUST remain in the insert payload — the client has
-//      no per-position branch-statics cache and would otherwise render the
-//      new row without its HTML wrapper. See the regression tests in
-//      `range_statics_swap_test.go` (NestedBranch_AppendIncludesBranchStatics).
-//
-// Reported metric: bytes/op = wire JSON bytes per update.
+// Measures wire-payload bytes per full content swap. DynamicBranch bytes/op are intentionally higher than Simple — nested branch statics MUST stay in the insert payload (no client-side branch-statics cache).
 
 const benchSimpleTemplate = `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
 
@@ -51,12 +35,7 @@ func benchMakeLines(n int, prefix string) []benchLine {
 			Kind:               []string{"add", "rem", "ctx"}[i%3],
 			LineNo:             i + 1,
 			HighlightedContent: template.HTML(fmt.Sprintf("<span>%s line %d %s</span>", prefix, i, strings.Repeat("x", 16))),
-			// HasMarker is uniform across items so the range stays
-			// homogeneous and TransitionToStreamMode succeeds — the
-			// improvement in #413 is in the stream-mode insert path.
-			// Heterogeneous ranges (some items with markers, some without)
-			// fall back to the legacy diff path which conservatively keeps
-			// nested statics.
+			// Uniform HasMarker keeps the range homogeneous so TransitionToStreamMode succeeds.
 			HasMarker:  true,
 			MarkerText: fmt.Sprintf("M%d", i),
 		}
@@ -73,8 +52,7 @@ func benchmarkFullContentSwapPayload(b *testing.B, tmplStr string, n int) {
 	d1 := benchState{Lines: benchMakeLines(n, "A")}
 	d2 := benchState{Lines: benchMakeLines(n, "B")}
 
-	// Prime the template once with the initial render so subsequent
-	// iterations exercise the update (stream-mode) path.
+	// Prime with initial render so subsequent iterations exercise the update path.
 	if err := tmpl.ExecuteUpdates(&bytes.Buffer{}, d1); err != nil {
 		b.Fatalf("initial render failed: %v", err)
 	}
@@ -84,8 +62,7 @@ func benchmarkFullContentSwapPayload(b *testing.B, tmplStr string, n int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
-		// Alternate between two payloads so each iteration is a real swap
-		// (not a no-op repeat).
+		// Alternate payloads so each iteration is a real swap.
 		d := d1
 		if i%2 == 0 {
 			d = d2
@@ -99,9 +76,7 @@ func benchmarkFullContentSwapPayload(b *testing.B, tmplStr string, n int) {
 	b.ReportMetric(float64(totalBytes)/float64(b.N), "bytes/op")
 }
 
-// Simple (no nested conditionals) — the "premise" case from issue #413.
-// Expected: zero per-row statics; bytes/op proportional to per-row dynamic
-// content size.
+// Simple range: zero per-row statics; bytes/op scales with dynamic content size.
 func BenchmarkRangeFullSwap_Simple_N10(b *testing.B) {
 	benchmarkFullContentSwapPayload(b, benchSimpleTemplate, 10)
 }
@@ -112,10 +87,7 @@ func BenchmarkRangeFullSwap_Simple_N1000(b *testing.B) {
 	benchmarkFullContentSwapPayload(b, benchSimpleTemplate, 1000)
 }
 
-// DynamicBranch (nested {{if}} with dynamic inside the if-arm) — exercises
-// the stream-mode insert path. Branch statics MUST remain in the wire so
-// the client can render new rows; bytes/op here is the cost of that
-// per-row scaffolding.
+// DynamicBranch: nested {{if}} with dynamic. Branch statics MUST stay in the wire — bytes/op reflects that cost.
 func BenchmarkRangeFullSwap_DynamicBranch_N10(b *testing.B) {
 	benchmarkFullContentSwapPayload(b, benchDynamicBranchTemplate, 10)
 }

--- a/range_statics_swap_bench_test.go
+++ b/range_statics_swap_bench_test.go
@@ -14,15 +14,15 @@ import (
 //
 // Two shapes:
 //   1. "Simple": homogeneous range with primitive dynamics — the case from
-//      the issue. After the existing fingerprint-based strip, this should
-//      scale near-linearly in dynamic content size with zero per-row static
+//      the issue. After the fingerprint-based op-envelope strip, this
+//      scales near-linearly in dynamic content size with zero per-row static
 //      overhead.
 //   2. "DynamicBranch": homogeneous range whose item template contains an
-//      {{if}}…{{else}}{{end}} branch with a dynamic inside the if-arm. Before
-//      the fix in #413 the stream-mode insert path re-emitted those branch
-//      statics; after the fix they are stripped under the §5b homogeneity
-//      guarantee. Static-only branches still retain statics (the special
-//      case in PrepareTreeForClient preserves branch identity).
+//      {{if}}…{{else}}{{end}} branch with a dynamic inside the if-arm. The
+//      branch's statics MUST remain in the insert payload — the client has
+//      no per-position branch-statics cache and would otherwise render the
+//      new row without its HTML wrapper. See the regression tests in
+//      `range_statics_swap_test.go` (NestedBranch_AppendIncludesBranchStatics).
 //
 // Reported metric: bytes/op = wire JSON bytes per update.
 
@@ -113,9 +113,9 @@ func BenchmarkRangeFullSwap_Simple_N1000(b *testing.B) {
 }
 
 // DynamicBranch (nested {{if}} with dynamic inside the if-arm) — exercises
-// the stream-mode insert path that previously re-emitted nested branch
-// statics. After the fix in #413, the if-arm statics are stripped under the
-// §5b homogeneity guarantee.
+// the stream-mode insert path. Branch statics MUST remain in the wire so
+// the client can render new rows; bytes/op here is the cost of that
+// per-row scaffolding.
 func BenchmarkRangeFullSwap_DynamicBranch_N10(b *testing.B) {
 	benchmarkFullContentSwapPayload(b, benchDynamicBranchTemplate, 10)
 }

--- a/range_statics_swap_bench_test.go
+++ b/range_statics_swap_bench_test.go
@@ -1,0 +1,127 @@
+package livetemplate
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"strings"
+	"testing"
+)
+
+// Benchmarks for issue #413: measure the WIRE PAYLOAD size of a full content
+// swap of a {{range}} at varying row counts. We measure the JSON length, not
+// allocator bytes, because the issue is about transmitted bytes.
+//
+// Two shapes:
+//   1. "Simple": homogeneous range with primitive dynamics — the case from
+//      the issue. After the existing fingerprint-based strip, this should
+//      scale near-linearly in dynamic content size with zero per-row static
+//      overhead.
+//   2. "DynamicBranch": homogeneous range whose item template contains an
+//      {{if}}…{{else}}{{end}} branch with a dynamic inside the if-arm. Before
+//      the fix in #413 the stream-mode insert path re-emitted those branch
+//      statics; after the fix they are stripped under the §5b homogeneity
+//      guarantee. Static-only branches still retain statics (the special
+//      case in PrepareTreeForClient preserves branch identity).
+//
+// Reported metric: bytes/op = wire JSON bytes per update.
+
+const benchSimpleTemplate = `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
+
+const benchDynamicBranchTemplate = `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span>{{if .HasMarker}}<span class="marker">{{.MarkerText}}</span>{{end}}<span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
+
+type benchLine struct {
+	ID                 string
+	Kind               string
+	LineNo             int
+	HighlightedContent template.HTML
+	HasMarker          bool
+	MarkerText         string
+}
+
+type benchState struct {
+	Lines []benchLine
+}
+
+func benchMakeLines(n int, prefix string) []benchLine {
+	out := make([]benchLine, n)
+	for i := 0; i < n; i++ {
+		out[i] = benchLine{
+			ID:                 fmt.Sprintf("%s-%d", prefix, i),
+			Kind:               []string{"add", "rem", "ctx"}[i%3],
+			LineNo:             i + 1,
+			HighlightedContent: template.HTML(fmt.Sprintf("<span>%s line %d %s</span>", prefix, i, strings.Repeat("x", 16))),
+			// HasMarker is uniform across items so the range stays
+			// homogeneous and TransitionToStreamMode succeeds — the
+			// improvement in #413 is in the stream-mode insert path.
+			// Heterogeneous ranges (some items with markers, some without)
+			// fall back to the legacy diff path which conservatively keeps
+			// nested statics.
+			HasMarker:  true,
+			MarkerText: fmt.Sprintf("M%d", i),
+		}
+	}
+	return out
+}
+
+func benchmarkFullContentSwapPayload(b *testing.B, tmplStr string, n int) {
+	tmpl := Must(New("test"))
+	if _, err := tmpl.Parse(tmplStr); err != nil {
+		b.Fatalf("Parse failed: %v", err)
+	}
+
+	d1 := benchState{Lines: benchMakeLines(n, "A")}
+	d2 := benchState{Lines: benchMakeLines(n, "B")}
+
+	// Prime the template once with the initial render so subsequent
+	// iterations exercise the update (stream-mode) path.
+	if err := tmpl.ExecuteUpdates(&bytes.Buffer{}, d1); err != nil {
+		b.Fatalf("initial render failed: %v", err)
+	}
+
+	var totalBytes int64
+	var buf bytes.Buffer
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		// Alternate between two payloads so each iteration is a real swap
+		// (not a no-op repeat).
+		d := d1
+		if i%2 == 0 {
+			d = d2
+		}
+		if err := tmpl.ExecuteUpdates(&buf, d); err != nil {
+			b.Fatalf("ExecuteUpdates failed: %v", err)
+		}
+		totalBytes += int64(buf.Len())
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(totalBytes)/float64(b.N), "bytes/op")
+}
+
+// Simple (no nested conditionals) — the "premise" case from issue #413.
+// Expected: zero per-row statics; bytes/op proportional to per-row dynamic
+// content size.
+func BenchmarkRangeFullSwap_Simple_N10(b *testing.B) {
+	benchmarkFullContentSwapPayload(b, benchSimpleTemplate, 10)
+}
+func BenchmarkRangeFullSwap_Simple_N100(b *testing.B) {
+	benchmarkFullContentSwapPayload(b, benchSimpleTemplate, 100)
+}
+func BenchmarkRangeFullSwap_Simple_N1000(b *testing.B) {
+	benchmarkFullContentSwapPayload(b, benchSimpleTemplate, 1000)
+}
+
+// DynamicBranch (nested {{if}} with dynamic inside the if-arm) — exercises
+// the stream-mode insert path that previously re-emitted nested branch
+// statics. After the fix in #413, the if-arm statics are stripped under the
+// §5b homogeneity guarantee.
+func BenchmarkRangeFullSwap_DynamicBranch_N10(b *testing.B) {
+	benchmarkFullContentSwapPayload(b, benchDynamicBranchTemplate, 10)
+}
+func BenchmarkRangeFullSwap_DynamicBranch_N100(b *testing.B) {
+	benchmarkFullContentSwapPayload(b, benchDynamicBranchTemplate, 100)
+}
+func BenchmarkRangeFullSwap_DynamicBranch_N1000(b *testing.B) {
+	benchmarkFullContentSwapPayload(b, benchDynamicBranchTemplate, 1000)
+}

--- a/range_statics_swap_test.go
+++ b/range_statics_swap_test.go
@@ -9,17 +9,8 @@ import (
 	"testing"
 )
 
-// Tests in this file cover issue #413:
-// "{{range}} statics not cached across full content swap — resends per-row scaffolding".
-//
-// Goal: lock in the contract that per-row static scaffolding is NOT re-emitted
-// across full content swaps of the same {{range}} (matching the
-// tree-update-specification §3.4 "stripped from operations" rule for stripped
-// statics when the structure fingerprint is unchanged).
+// Per-row static scaffolding must not be re-emitted across full content swaps of the same {{range}}.
 
-// rangeFileLine mirrors the per-row shape used by the prereview app from
-// issue #413: kind, line number, and a (template-safe) highlighted-content
-// blob. Keeping the shape ASCII-simple makes wire-byte assertions stable.
 type rangeFileLine struct {
 	ID                 string
 	Kind               string
@@ -32,9 +23,6 @@ type rangeFileState struct {
 	Lines    []rangeFileLine
 }
 
-// makeRangeLines builds N homogeneous lines whose content varies with `i`,
-// so a swap from set A to set B produces fully different dynamic values
-// (matching the file-switch scenario from issue #413).
 func makeRangeLines(n int, prefix string) []rangeFileLine {
 	out := make([]rangeFileLine, n)
 	for i := 0; i < n; i++ {
@@ -48,16 +36,12 @@ func makeRangeLines(n int, prefix string) []rangeFileLine {
 	return out
 }
 
-// countStaticsKey returns how many times "s":[ appears in the wire payload.
-// (Counts the JSON key, not the bytes inside any literal strings — payloads
-// here don't embed `"s":[` inside content.)
+// countStaticsKey counts occurrences of the statics key. Matches the `[` suffix to skip the rare false positive of `"s":` appearing inside a string value.
 func countStaticsKey(payload []byte) int {
-	return bytes.Count(payload, []byte(`"s":`))
+	return bytes.Count(payload, []byte(`"s":[`))
 }
 
-// renderUpdate renders d1 to prime the template (initial render) and returns
-// the wire payload of the subsequent ExecuteUpdates(d2) — the update path
-// these tests care about.
+// renderUpdate primes the template with d1 then returns the wire payload of ExecuteUpdates(d2).
 func renderUpdate(t *testing.T, tmplStr string, d1, d2 interface{}) []byte {
 	t.Helper()
 	tmpl := Must(New("test"))
@@ -74,9 +58,7 @@ func renderUpdate(t *testing.T, tmplStr string, d1, d2 interface{}) []byte {
 	return update.Bytes()
 }
 
-// TestRangeStatics_InitialRender_IncludesStatics is the baseline: the initial
-// render of a {{range}} MUST include the item template under "s" so the client
-// can cache the scaffold. Spec §5.1.
+// Initial render of a {{range}} must include the item template under "s" so the client can cache it.
 func TestRangeStatics_InitialRender_IncludesStatics(t *testing.T) {
 	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
 
@@ -101,11 +83,7 @@ func TestRangeStatics_InitialRender_IncludesStatics(t *testing.T) {
 	}
 }
 
-// TestRangeStatics_FullContentSwap_NoPerRowStatics is the core assertion from
-// issue #413: when the {{range}}'s backing slice is fully replaced with a new
-// set of items (different keys, same range item template), the update payload
-// MUST NOT re-emit per-row static scaffolding. The client has the item
-// template cached from the initial render.
+// Full slice replacement on the same range template must not re-emit per-row statics; client has them cached.
 func TestRangeStatics_FullContentSwap_NoPerRowStatics(t *testing.T) {
 	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
 
@@ -125,11 +103,7 @@ func TestRangeStatics_FullContentSwap_NoPerRowStatics(t *testing.T) {
 	}
 }
 
-// TestRangeStatics_GrowCountDelta_NoPerRowStatics: growing the list (e.g.,
-// switching from a 5-row file to a 50-row file) must not re-emit per-row
-// statics. The 'p'/'a' insertion op may carry the item template once at
-// the op envelope, but it gets stripped when the structure fingerprint
-// matches the previous render — so the wire must not contain ANY "s":[.
+// Growing the list must not re-emit per-row statics. n == 0: this template has only string dynamics, so PrepareTreeForClient strips nothing at the item level; op-envelope statics get stripped separately by fingerprint match.
 func TestRangeStatics_GrowCountDelta_NoPerRowStatics(t *testing.T) {
 	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
 
@@ -142,8 +116,7 @@ func TestRangeStatics_GrowCountDelta_NoPerRowStatics(t *testing.T) {
 	}
 }
 
-// TestRangeStatics_ShrinkCountDelta_NoPerRowStatics: shrinking the list must
-// not re-emit per-row statics either.
+// Shrinking the list must not re-emit per-row statics.
 func TestRangeStatics_ShrinkCountDelta_NoPerRowStatics(t *testing.T) {
 	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
 
@@ -156,11 +129,7 @@ func TestRangeStatics_ShrinkCountDelta_NoPerRowStatics(t *testing.T) {
 	}
 }
 
-// TestRangeStatics_EmptyToNonEmpty_IncludesItemTemplateOnce: empty → items
-// is the only update path where the item template can legitimately appear on
-// the wire (the client received an empty range on first render and never saw
-// the per-row scaffold). The item template must appear in the append op's
-// statics slot ONCE — not N times.
+// Empty → items is the only update path where the item template legitimately appears on the wire — exactly once.
 func TestRangeStatics_EmptyToNonEmpty_IncludesItemTemplateOnce(t *testing.T) {
 	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span></div>{{end}}</div>`
 
@@ -174,8 +143,7 @@ func TestRangeStatics_EmptyToNonEmpty_IncludesItemTemplateOnce(t *testing.T) {
 	}
 }
 
-// TestRangeStatics_NonEmptyToEmpty: populated → empty must clear/remove items
-// but not include any per-row statics on the wire.
+// Populated → empty must remove items without emitting any per-row statics.
 func TestRangeStatics_NonEmptyToEmpty(t *testing.T) {
 	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span></div>{{end}}</div>`
 
@@ -188,8 +156,7 @@ func TestRangeStatics_NonEmptyToEmpty(t *testing.T) {
 	}
 }
 
-// TestRangeStatics_SingleItemSwap: a single-item range whose only item is
-// replaced (different key, same template) must not re-emit the item template.
+// Single-item swap (different key, same template) must not re-emit the item template.
 func TestRangeStatics_SingleItemSwap(t *testing.T) {
 	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span></div>{{end}}</div>`
 
@@ -202,9 +169,7 @@ func TestRangeStatics_SingleItemSwap(t *testing.T) {
 	}
 }
 
-// TestRangeStatics_RepeatedSwap_PayloadStable: repeated A→B→A→B swaps must
-// produce comparable payload sizes (no growth from accumulated static-resends).
-// The third swap's payload size should be within a small factor of the first.
+// Repeated swaps of equal-sized lists must produce stable payload sizes (no accumulated static-resend growth).
 func TestRangeStatics_RepeatedSwap_PayloadStable(t *testing.T) {
 	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span></div>{{end}}</div>`
 
@@ -232,8 +197,6 @@ func TestRangeStatics_RepeatedSwap_PayloadStable(t *testing.T) {
 		}
 	}
 
-	// Sanity-check sizes are within ~20% of each other — they should be near-
-	// identical for homogeneous swaps of equal-sized lists.
 	min, max := sizes[0], sizes[0]
 	for _, s := range sizes[1:] {
 		if s < min {
@@ -243,15 +206,13 @@ func TestRangeStatics_RepeatedSwap_PayloadStable(t *testing.T) {
 			max = s
 		}
 	}
+	// Allow up to 20% size drift across repeated same-size swaps.
 	if max > min*12/10 {
 		t.Errorf("repeated swap payload sizes drifted: %v (min=%d max=%d)", sizes, min, max)
 	}
 }
 
-// TestRangeStatics_FullSwap_DynamicsPreserved sanity-checks that the swap
-// payload — while omitting statics — still carries enough new-side data to
-// rebuild every row. This is the wire-format contract: dynamics + op
-// envelope + cached statics must be sufficient.
+// Swap payload omits statics but must still carry every new row's dynamic content.
 func TestRangeStatics_FullSwap_DynamicsPreserved(t *testing.T) {
 	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
 
@@ -281,13 +242,7 @@ func truncate(b []byte, n int) string {
 	return string(b[:n]) + "...(truncated)"
 }
 
-// TestRangeStatics_AutoKey_AppendIncludesAutoKey is the flash-messages
-// regression test for issue #413: a `{{range}}` over a slice of strings has
-// no explicit data-key, so each item gets an auto-generated `_k` hash.
-// Stream-mode inserts must carry the `_k` field so the client can track the
-// new row for later remove/update operations. The earlier strip-on-insert
-// attempt dropped AutoKey via PrepareTreeForClient and broke remove flow in
-// examples/flash-messages.
+// Stream-mode insert must carry auto-generated _k so the client can later remove/update the new row.
 func TestRangeStatics_AutoKey_AppendIncludesAutoKey(t *testing.T) {
 	tmplStr := `<ul>{{range .Items}}<li>{{.}}</li>{{end}}</ul>`
 
@@ -313,14 +268,7 @@ func TestRangeStatics_AutoKey_AppendIncludesAutoKey(t *testing.T) {
 	}
 }
 
-// TestRangeStatics_NestedBranch_AppendIncludesBranchStatics is the
-// tinkerdown auto-tables regression test for issue #413: a `{{range}}` whose
-// item template contains a nested `{{if}}` branch with dynamics must keep
-// the branch's statics on insert. The client has no per-position branch
-// statics cache — when it receives an item with stripped nested statics
-// (numeric keys only on the nested object), it joins values without the
-// HTML wrapper, losing the row's structure (`<span class="marker">…</span>`
-// becomes just the dynamic text).
+// Range items with a nested {{if}} branch carrying dynamics must keep their branch statics on insert.
 func TestRangeStatics_NestedBranch_AppendIncludesBranchStatics(t *testing.T) {
 	tmplStr := `<ul>{{range .Items}}<li>{{if .HasMarker}}<span class="marker">{{.MarkerText}}</span>{{end}}{{.Name}}</li>{{end}}</ul>`
 

--- a/range_statics_swap_test.go
+++ b/range_statics_swap_test.go
@@ -280,3 +280,81 @@ func truncate(b []byte, n int) string {
 	}
 	return string(b[:n]) + "...(truncated)"
 }
+
+// TestRangeStatics_AutoKey_AppendIncludesAutoKey is the flash-messages
+// regression test for issue #413: a `{{range}}` over a slice of strings has
+// no explicit data-key, so each item gets an auto-generated `_k` hash.
+// Stream-mode inserts must carry the `_k` field so the client can track the
+// new row for later remove/update operations. The earlier strip-on-insert
+// attempt dropped AutoKey via PrepareTreeForClient and broke remove flow in
+// examples/flash-messages.
+func TestRangeStatics_AutoKey_AppendIncludesAutoKey(t *testing.T) {
+	tmplStr := `<ul>{{range .Items}}<li>{{.}}</li>{{end}}</ul>`
+
+	tmpl := Must(New("test"))
+	if _, err := tmpl.Parse(tmplStr); err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	d1 := map[string]interface{}{"Items": []string{"Apple", "Banana", "Cherry"}}
+	if err := tmpl.ExecuteUpdates(&bytes.Buffer{}, d1); err != nil {
+		t.Fatalf("initial render failed: %v", err)
+	}
+
+	d2 := map[string]interface{}{"Items": []string{"Apple", "Banana", "Cherry", "Date"}}
+	var update bytes.Buffer
+	if err := tmpl.ExecuteUpdates(&update, d2); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	payload := update.String()
+	if !strings.Contains(payload, `"_k"`) {
+		t.Errorf("append payload missing auto-key (_k); client cannot track new row\n  payload=%s", payload)
+	}
+}
+
+// TestRangeStatics_NestedBranch_AppendIncludesBranchStatics is the
+// tinkerdown auto-tables regression test for issue #413: a `{{range}}` whose
+// item template contains a nested `{{if}}` branch with dynamics must keep
+// the branch's statics on insert. The client has no per-position branch
+// statics cache — when it receives an item with stripped nested statics
+// (numeric keys only on the nested object), it joins values without the
+// HTML wrapper, losing the row's structure (`<span class="marker">…</span>`
+// becomes just the dynamic text).
+func TestRangeStatics_NestedBranch_AppendIncludesBranchStatics(t *testing.T) {
+	tmplStr := `<ul>{{range .Items}}<li>{{if .HasMarker}}<span class="marker">{{.MarkerText}}</span>{{end}}{{.Name}}</li>{{end}}</ul>`
+
+	type item struct {
+		Name       string
+		HasMarker  bool
+		MarkerText string
+	}
+
+	tmpl := Must(New("test"))
+	if _, err := tmpl.Parse(tmplStr); err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	d1 := map[string]interface{}{"Items": []item{
+		{Name: "Apple", HasMarker: true, MarkerText: "A"},
+		{Name: "Banana", HasMarker: true, MarkerText: "B"},
+	}}
+	if err := tmpl.ExecuteUpdates(&bytes.Buffer{}, d1); err != nil {
+		t.Fatalf("initial render failed: %v", err)
+	}
+
+	d2 := map[string]interface{}{"Items": []item{
+		{Name: "Apple", HasMarker: true, MarkerText: "A"},
+		{Name: "Banana", HasMarker: true, MarkerText: "B"},
+		{Name: "Cherry", HasMarker: true, MarkerText: "C"},
+	}}
+	var update bytes.Buffer
+	if err := tmpl.ExecuteUpdates(&update, d2); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	payload := update.String()
+	if !strings.Contains(payload, "marker") {
+		t.Errorf("append payload missing nested branch statics (class=\"marker\"); client cannot render new row\n  payload=%s", payload)
+	}
+}

--- a/range_statics_swap_test.go
+++ b/range_statics_swap_test.go
@@ -1,0 +1,282 @@
+package livetemplate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"strings"
+	"testing"
+)
+
+// Tests in this file cover issue #413:
+// "{{range}} statics not cached across full content swap — resends per-row scaffolding".
+//
+// Goal: lock in the contract that per-row static scaffolding is NOT re-emitted
+// across full content swaps of the same {{range}} (matching the
+// tree-update-specification §3.4 "stripped from operations" rule for stripped
+// statics when the structure fingerprint is unchanged).
+
+// rangeFileLine mirrors the per-row shape used by the prereview app from
+// issue #413: kind, line number, and a (template-safe) highlighted-content
+// blob. Keeping the shape ASCII-simple makes wire-byte assertions stable.
+type rangeFileLine struct {
+	ID                 string
+	Kind               string
+	LineNo             int
+	HighlightedContent template.HTML
+}
+
+type rangeFileState struct {
+	Filename string
+	Lines    []rangeFileLine
+}
+
+// makeRangeLines builds N homogeneous lines whose content varies with `i`,
+// so a swap from set A to set B produces fully different dynamic values
+// (matching the file-switch scenario from issue #413).
+func makeRangeLines(n int, prefix string) []rangeFileLine {
+	out := make([]rangeFileLine, n)
+	for i := 0; i < n; i++ {
+		out[i] = rangeFileLine{
+			ID:                 fmt.Sprintf("%s-%d", prefix, i),
+			Kind:               []string{"add", "rem", "ctx"}[i%3],
+			LineNo:             i + 1,
+			HighlightedContent: template.HTML(fmt.Sprintf("<span>%s line %d %s</span>", prefix, i, strings.Repeat("x", 16))),
+		}
+	}
+	return out
+}
+
+// countStaticsKey returns how many times "s":[ appears in the wire payload.
+// (Counts the JSON key, not the bytes inside any literal strings — payloads
+// here don't embed `"s":[` inside content.)
+func countStaticsKey(payload []byte) int {
+	return bytes.Count(payload, []byte(`"s":`))
+}
+
+// renderUpdate renders d1 to prime the template (initial render) and returns
+// the wire payload of the subsequent ExecuteUpdates(d2) — the update path
+// these tests care about.
+func renderUpdate(t *testing.T, tmplStr string, d1, d2 interface{}) []byte {
+	t.Helper()
+	tmpl := Must(New("test"))
+	if _, err := tmpl.Parse(tmplStr); err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if err := tmpl.ExecuteUpdates(&bytes.Buffer{}, d1); err != nil {
+		t.Fatalf("Initial ExecuteUpdates failed: %v", err)
+	}
+	var update bytes.Buffer
+	if err := tmpl.ExecuteUpdates(&update, d2); err != nil {
+		t.Fatalf("Update ExecuteUpdates failed: %v", err)
+	}
+	return update.Bytes()
+}
+
+// TestRangeStatics_InitialRender_IncludesStatics is the baseline: the initial
+// render of a {{range}} MUST include the item template under "s" so the client
+// can cache the scaffold. Spec §5.1.
+func TestRangeStatics_InitialRender_IncludesStatics(t *testing.T) {
+	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
+
+	tmpl := Must(New("test"))
+	if _, err := tmpl.Parse(tmplStr); err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	d := rangeFileState{Filename: "a.go", Lines: makeRangeLines(5, "A")}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteUpdates(&buf, d); err != nil {
+		t.Fatalf("ExecuteUpdates failed: %v", err)
+	}
+
+	if !bytes.Contains(buf.Bytes(), []byte(`"s":`)) {
+		t.Errorf("initial render MUST include statics; payload=%s", buf.String())
+	}
+
+	// The item template ("line-row") must appear (this is the per-row scaffold).
+	if !bytes.Contains(buf.Bytes(), []byte(`line-row`)) {
+		t.Errorf("initial render missing the per-row template scaffold; payload=%s", buf.String())
+	}
+}
+
+// TestRangeStatics_FullContentSwap_NoPerRowStatics is the core assertion from
+// issue #413: when the {{range}}'s backing slice is fully replaced with a new
+// set of items (different keys, same range item template), the update payload
+// MUST NOT re-emit per-row static scaffolding. The client has the item
+// template cached from the initial render.
+func TestRangeStatics_FullContentSwap_NoPerRowStatics(t *testing.T) {
+	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
+
+	d1 := rangeFileState{Filename: "a.go", Lines: makeRangeLines(8, "A")}
+	d2 := rangeFileState{Filename: "b.go", Lines: makeRangeLines(8, "B")}
+	update := renderUpdate(t, tmplStr, d1, d2)
+
+	// The wire payload must NOT contain any "s":[ — the item template is
+	// cached on the client from the initial render.
+	if n := countStaticsKey(update); n != 0 {
+		t.Errorf("full content swap MUST NOT re-emit per-row statics; got %d \"s\":[ occurrences\n  payload=%s", n, update)
+	}
+
+	// The update should still contain the new line content under dynamics.
+	if !bytes.Contains(update, []byte(`B line 0`)) {
+		t.Errorf("update missing new dynamic content (B line 0); payload=%s", update)
+	}
+}
+
+// TestRangeStatics_GrowCountDelta_NoPerRowStatics: growing the list (e.g.,
+// switching from a 5-row file to a 50-row file) must not re-emit per-row
+// statics. The 'p'/'a' insertion op may carry the item template once at
+// the op envelope, but it gets stripped when the structure fingerprint
+// matches the previous render — so the wire must not contain ANY "s":[.
+func TestRangeStatics_GrowCountDelta_NoPerRowStatics(t *testing.T) {
+	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
+
+	d1 := rangeFileState{Filename: "a.go", Lines: makeRangeLines(5, "A")}
+	d2 := rangeFileState{Filename: "b.go", Lines: makeRangeLines(50, "B")}
+	update := renderUpdate(t, tmplStr, d1, d2)
+
+	if n := countStaticsKey(update); n != 0 {
+		t.Errorf("count-delta GROW MUST NOT re-emit per-row statics; got %d \"s\":[ occurrences\n  first 600 bytes=%s", n, truncate(update, 600))
+	}
+}
+
+// TestRangeStatics_ShrinkCountDelta_NoPerRowStatics: shrinking the list must
+// not re-emit per-row statics either.
+func TestRangeStatics_ShrinkCountDelta_NoPerRowStatics(t *testing.T) {
+	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
+
+	d1 := rangeFileState{Filename: "a.go", Lines: makeRangeLines(50, "A")}
+	d2 := rangeFileState{Filename: "b.go", Lines: makeRangeLines(5, "B")}
+	update := renderUpdate(t, tmplStr, d1, d2)
+
+	if n := countStaticsKey(update); n != 0 {
+		t.Errorf("count-delta SHRINK MUST NOT re-emit per-row statics; got %d \"s\":[ occurrences\n  payload=%s", n, update)
+	}
+}
+
+// TestRangeStatics_EmptyToNonEmpty_IncludesItemTemplateOnce: empty → items
+// is the only update path where the item template can legitimately appear on
+// the wire (the client received an empty range on first render and never saw
+// the per-row scaffold). The item template must appear in the append op's
+// statics slot ONCE — not N times.
+func TestRangeStatics_EmptyToNonEmpty_IncludesItemTemplateOnce(t *testing.T) {
+	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span></div>{{end}}</div>`
+
+	d1 := rangeFileState{Filename: "empty.go", Lines: nil}
+	d2 := rangeFileState{Filename: "a.go", Lines: makeRangeLines(10, "A")}
+	update := renderUpdate(t, tmplStr, d1, d2)
+
+	// The item template ("line-row") must appear once (the op-level statics).
+	if count := bytes.Count(update, []byte(`line-row`)); count != 1 {
+		t.Errorf("empty→items MUST include item template exactly ONCE (op-level statics), got %d occurrences\n  payload=%s", count, update)
+	}
+}
+
+// TestRangeStatics_NonEmptyToEmpty: populated → empty must clear/remove items
+// but not include any per-row statics on the wire.
+func TestRangeStatics_NonEmptyToEmpty(t *testing.T) {
+	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span></div>{{end}}</div>`
+
+	d1 := rangeFileState{Filename: "a.go", Lines: makeRangeLines(10, "A")}
+	d2 := rangeFileState{Filename: "empty.go", Lines: nil}
+	update := renderUpdate(t, tmplStr, d1, d2)
+
+	if n := countStaticsKey(update); n != 0 {
+		t.Errorf("non-empty→empty MUST NOT emit any per-row statics; got %d \"s\":[\n  payload=%s", n, update)
+	}
+}
+
+// TestRangeStatics_SingleItemSwap: a single-item range whose only item is
+// replaced (different key, same template) must not re-emit the item template.
+func TestRangeStatics_SingleItemSwap(t *testing.T) {
+	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span></div>{{end}}</div>`
+
+	d1 := rangeFileState{Filename: "a.go", Lines: makeRangeLines(1, "A")}
+	d2 := rangeFileState{Filename: "b.go", Lines: makeRangeLines(1, "B")}
+	update := renderUpdate(t, tmplStr, d1, d2)
+
+	if n := countStaticsKey(update); n != 0 {
+		t.Errorf("single-item swap MUST NOT re-emit per-row statics; got %d \"s\":[\n  payload=%s", n, update)
+	}
+}
+
+// TestRangeStatics_RepeatedSwap_PayloadStable: repeated A→B→A→B swaps must
+// produce comparable payload sizes (no growth from accumulated static-resends).
+// The third swap's payload size should be within a small factor of the first.
+func TestRangeStatics_RepeatedSwap_PayloadStable(t *testing.T) {
+	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span></div>{{end}}</div>`
+
+	tmpl := Must(New("test"))
+	if _, err := tmpl.Parse(tmplStr); err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	// Prime with A.
+	if err := tmpl.ExecuteUpdates(&bytes.Buffer{}, rangeFileState{Lines: makeRangeLines(50, "A1")}); err != nil {
+		t.Fatalf("initial render failed: %v", err)
+	}
+
+	// Three full content swaps.
+	var sizes [3]int
+	prefixes := []string{"B", "A2", "B2"}
+	for i, p := range prefixes {
+		var buf bytes.Buffer
+		if err := tmpl.ExecuteUpdates(&buf, rangeFileState{Lines: makeRangeLines(50, p)}); err != nil {
+			t.Fatalf("swap %d failed: %v", i, err)
+		}
+		sizes[i] = buf.Len()
+		if n := countStaticsKey(buf.Bytes()); n != 0 {
+			t.Errorf("swap %d (%s) re-emitted statics %d times; payload=%s", i, p, n, buf.String())
+		}
+	}
+
+	// Sanity-check sizes are within ~20% of each other — they should be near-
+	// identical for homogeneous swaps of equal-sized lists.
+	min, max := sizes[0], sizes[0]
+	for _, s := range sizes[1:] {
+		if s < min {
+			min = s
+		}
+		if s > max {
+			max = s
+		}
+	}
+	if max > min*12/10 {
+		t.Errorf("repeated swap payload sizes drifted: %v (min=%d max=%d)", sizes, min, max)
+	}
+}
+
+// TestRangeStatics_FullSwap_DynamicsPreserved sanity-checks that the swap
+// payload — while omitting statics — still carries enough new-side data to
+// rebuild every row. This is the wire-format contract: dynamics + op
+// envelope + cached statics must be sufficient.
+func TestRangeStatics_FullSwap_DynamicsPreserved(t *testing.T) {
+	tmplStr := `<div class="diff">{{range .Lines}}<div class="line-row" data-key="{{.ID}}"><span class="kind">{{.Kind}}</span><span class="ln">{{.LineNo}}</span><span class="content">{{.HighlightedContent}}</span></div>{{end}}</div>`
+
+	d1 := rangeFileState{Lines: makeRangeLines(20, "A")}
+	d2 := rangeFileState{Lines: makeRangeLines(20, "B")}
+	update := renderUpdate(t, tmplStr, d1, d2)
+
+	// Every new line's content must appear in the wire.
+	for i := 0; i < 20; i++ {
+		marker := fmt.Sprintf("B line %d ", i)
+		if !bytes.Contains(update, []byte(marker)) {
+			t.Errorf("update missing new row content for line %d (marker=%q)\n  payload=%s", i, marker, update)
+		}
+	}
+
+	// JSON must parse.
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(update, &parsed); err != nil {
+		t.Errorf("update payload is not valid JSON: %v", err)
+	}
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "...(truncated)"
+}


### PR DESCRIPTION
Fixes #413.

## Summary

The reported symptom was "per-row static scaffolding re-emitted on `{{range}}` full content swaps." Investigation found:

1. **For the simple template shape in the issue body, per-row statics are already correctly stripped** by the existing fingerprint-based op-envelope path. Verified across full content swap, grow, shrink, single-item swap, empty↔non-empty, and repeated A↔B swaps. The 434KB / 61KB payloads cited in the issue are dominated by per-row *dynamic* content (highlighted source), not redundant statics.

2. **The real bug is narrower**: `PrepareTreeForClient` was dropping `AutoKey` (the `_k` field) when stripping statics. Auto-keyed ranges (slices without an explicit `data-key`) hit this on stream-mode inserts — the new row arrived without `_k`, so the client couldn't track it for later remove/update operations. This was the root cause of the downstream regressions in `examples/flash-messages` (remove-by-id failed) and tinkerdown auto-tables (new rows never appeared).

## The fix

One-line preservation of `AutoKey` in `PrepareTreeForClient`'s strip path:

```go
case *TreeNode:
    result := &TreeNode{AutoKey: v.AutoKey}
```

`Metadata` is preserved by existing code further down the same function.

## What this does NOT do

An earlier attempt at this PR threaded `clientHasItemStatics` through the insertion helpers to also strip nested item statics on stream-mode inserts (mirroring the update path). That was **reverted**: unlike updates (which patch existing DOM in place), inserts render new DOM and the client has no per-position branch-statics cache. Stripping nested statics on insert lost the HTML wrapper for any item containing a nested `{{if}}` with dynamics. The reverted approach is now locked out by regression tests; do not re-introduce it without solving the client-side cache problem.

## Tests added

- `range_statics_swap_test.go` (11 tests, public API via `ExecuteUpdates`) — locks in the no-per-row-statics contract for the simple-template case and the must-carry-statics contract for auto-key + nested-branch inserts.
- `internal/diff/range_insert_strip_test.go` (3 tests) — exercises the dispatch directly:
  - `TestStreamInsert_PreservesNestedDynamicBranchStatics` — locks out the reverted approach
  - `TestStreamInsert_PreservesStaticOnlyBranchIdentity` — non-regression for the `{s:["+"]}` / `{s:["-"]}` special case
  - `TestStreamInsert_PreservesAutoKey` — direct regression test for the landed fix

## Benchmarks

`range_statics_swap_bench_test.go` measures wire-payload bytes per full content swap across N = 10 / 100 / 1000 for two shapes:
- **Simple**: no nested conditionals — bytes/op scales with per-row dynamic content size (zero per-row statics).
- **DynamicBranch**: nested `{{if}}` with a dynamic. Branch statics MUST stay in the wire so the client can render new rows — bytes/op reflects that cost (intentional, not a regression to optimize away).

Run with `go test -bench=BenchmarkRangeFullSwap -benchtime=20x -run=^$ .`

## Risks & compatibility

- **No wire-format change.** `PrepareTreeForClient`'s output now includes `_k` for auto-keyed items on the strip path — clients already handle this field on the no-strip path.
- **No protocol additions, no schema change.**
- **Insertion path unchanged.** Nested statics still flow through on stream-mode inserts.

## Verification

- `go test ./... -timeout 300s`: all packages pass
- `go vet ./...`: clean
- Pre-commit hook (`scripts/pre-commit.sh`): passes

---
_Generated by [Claude Code](https://claude.ai/code/session_014nUsSxrv8yH7tYWRnmaqnY)_
