### PR TITLE
ci: collapse 5 per-docs-recipe jobs into one test-docs-examples job

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -177,16 +177,9 @@ jobs:
         CGO_ENABLED: 1
         LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
 
-  # All docs-side recipe + example tests are exercised in a single
-  # job that runs `go test ./examples/...` from the docs checkout.
-  # Before the docs examples/-as-canonical refactor (livetemplate/docs
-  # PR #35), this was 5 separate jobs (test-docs, test-docs-todos,
-  # test-docs-progressive-enhancement, test-docs-login,
-  # test-docs-shared-notepad), one per recipe with its own checkout +
-  # replace-directive setup. The refactor moved every example to
-  # docs/examples/<slug>/ with co-located tests and dissolved the
-  # docs/e2e separate Go module, so one `./examples/...` test target
-  # now covers them all. Adding a new example requires zero CI edits.
+  # Replaces 5 per-recipe jobs dissolved by livetemplate/docs PR #35,
+  # which moved all examples to docs/examples/<slug>/ with co-located
+  # tests. New examples are picked up automatically — no CI edits needed.
   test-docs-examples:
     name: Test Docs Examples against Core Changes
     runs-on: ubuntu-latest
@@ -267,7 +260,11 @@ jobs:
       # patterns app's flash handling. Skip applies to the patterns
       # subset only — go test -skip uses test-name regexes that don't
       # match anything in the other example suites.
-      run: go test -v -count=1 -timeout=20m -skip "Submit_With_No_Changes" ./examples/...
+      #
+      # 30m timeout chosen empirically: the largest suite (patterns)
+      # ran ~8min in the first green run; 30m leaves comfortable
+      # headroom for slow CI runners + chromedp cold-start variance.
+      run: go test -v -count=1 -timeout=30m -skip "Submit_With_No_Changes" ./examples/...
       env:
         CGO_ENABLED: 1
         LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js

--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -177,13 +177,18 @@ jobs:
         CGO_ENABLED: 1
         LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
 
-  # The patterns app (formerly examples/patterns) was folded into the
-  # docs repo at content/recipes/patterns/_app/ with its tests
-  # relocated to docs/e2e/patterns/. This job preserves the
-  # "patterns runs against core changes" coverage that test-examples
-  # provided before the deletion.
-  test-docs:
-    name: Test Docs Patterns against Core Changes
+  # All docs-side recipe + example tests are exercised in a single
+  # job that runs `go test ./examples/...` from the docs checkout.
+  # Before the docs examples/-as-canonical refactor (livetemplate/docs
+  # PR #35), this was 5 separate jobs (test-docs, test-docs-todos,
+  # test-docs-progressive-enhancement, test-docs-login,
+  # test-docs-shared-notepad), one per recipe with its own checkout +
+  # replace-directive setup. The refactor moved every example to
+  # docs/examples/<slug>/ with co-located tests and dissolved the
+  # docs/e2e separate Go module, so one `./examples/...` test target
+  # now covers them all. Adding a new example requires zero CI edits.
+  test-docs-examples:
+    name: Test Docs Examples against Core Changes
     runs-on: ubuntu-latest
 
     steps:
@@ -245,7 +250,7 @@ jobs:
         echo "OK: Client library built successfully"
         ls -la dist/
 
-    - name: Add replace directives to docs (parent module)
+    - name: Add replace directives to docs
       working-directory: docs
       run: |
         echo "Adding replace directives to docs..."
@@ -254,378 +259,15 @@ jobs:
         go mod tidy
         echo "OK: Replace directives added"
 
-    - name: Add replace directives to docs/e2e (separate module)
-      working-directory: docs/e2e
-      run: |
-        echo "Adding replace directives to docs/e2e..."
-        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
-        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
-        go mod edit -replace=github.com/livetemplate/docs=../
-        go mod tidy
-        echo "OK: Replace directives added"
-
-    - name: Run patterns e2e against core
-      working-directory: docs/e2e/patterns
-      # Submit_With_No_Changes is a pre-existing flash-state flake that
-      # fails identically in upstream examples/patterns; tracked as a
-      # follow-up to fix in the patterns app's flash handling.
-      run: go test -v -count=1 -timeout=15m -skip "Submit_With_No_Changes" ./...
-      env:
-        CGO_ENABLED: 1
-        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
-
-  test-docs-todos:
-    name: Test Docs Todos against Core Changes
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout core library (this PR/branch)
-      uses: actions/checkout@v4
-      with:
-        path: livetemplate
-
-    - name: Checkout LVT (for testing package)
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/lvt
-        path: lvt
-
-    - name: Checkout docs
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/docs
-        path: docs
-
-    - name: Use matching docs branch if available
+    - name: Run all docs example e2e tests against core
       working-directory: docs
-      env:
-        DOCS_REF: ${{ github.head_ref || github.ref_name }}
-      run: |
-        if git ls-remote --exit-code --heads origin "$DOCS_REF" >/dev/null 2>&1; then
-          echo "Using livetemplate/docs branch: $DOCS_REF"
-          git fetch origin "$DOCS_REF" --depth=1
-          git checkout FETCH_HEAD
-        else
-          echo "No matching livetemplate/docs branch for $DOCS_REF; using default branch"
-        fi
-
-    - name: Checkout client library
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/client
-        path: livetemplate/client
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.26'
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: livetemplate/client/package-lock.json
-
-    - name: Build client library
-      working-directory: livetemplate/client
-      run: |
-        echo "Installing client dependencies..."
-        npm ci
-        echo "Building client library..."
-        npm run build
-        echo "OK: Client library built successfully"
-        ls -la dist/
-
-    - name: Add replace directives to docs (parent module)
-      working-directory: docs
-      run: |
-        echo "Adding replace directives to docs..."
-        go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
-        go mod edit -replace=github.com/livetemplate/lvt=../lvt
-        go mod tidy
-        echo "OK: Replace directives added"
-
-    - name: Add replace directives to docs/e2e (separate module)
-      working-directory: docs/e2e
-      run: |
-        echo "Adding replace directives to docs/e2e..."
-        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
-        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
-        go mod edit -replace=github.com/livetemplate/docs=../
-        go mod tidy
-        echo "OK: Replace directives added"
-
-    - name: Run todos e2e against core
-      working-directory: docs/e2e/todos
-      run: go test -v -count=1 -timeout=15m ./...
-      env:
-        CGO_ENABLED: 1
-        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
-
-  test-docs-progressive-enhancement:
-    name: Test Docs Progressive Enhancement against Core Changes
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout core library (this PR/branch)
-      uses: actions/checkout@v4
-      with:
-        path: livetemplate
-
-    - name: Checkout LVT (for testing package)
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/lvt
-        path: lvt
-
-    - name: Checkout docs
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/docs
-        path: docs
-
-    - name: Use matching docs branch if available
-      working-directory: docs
-      env:
-        DOCS_REF: ${{ github.head_ref || github.ref_name }}
-      run: |
-        if git ls-remote --exit-code --heads origin "$DOCS_REF" >/dev/null 2>&1; then
-          echo "Using livetemplate/docs branch: $DOCS_REF"
-          git fetch origin "$DOCS_REF" --depth=1
-          git checkout FETCH_HEAD
-        else
-          echo "No matching livetemplate/docs branch for $DOCS_REF; using default branch"
-        fi
-
-    - name: Checkout client library
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/client
-        path: livetemplate/client
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.26'
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: livetemplate/client/package-lock.json
-
-    - name: Build client library
-      working-directory: livetemplate/client
-      run: |
-        echo "Installing client dependencies..."
-        npm ci
-        echo "Building client library..."
-        npm run build
-        echo "OK: Client library built successfully"
-        ls -la dist/
-
-    - name: Add replace directives to docs (parent module)
-      working-directory: docs
-      run: |
-        echo "Adding replace directives to docs..."
-        go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
-        go mod edit -replace=github.com/livetemplate/lvt=../lvt
-        go mod tidy
-        echo "OK: Replace directives added"
-
-    - name: Add replace directives to docs/e2e (separate module)
-      working-directory: docs/e2e
-      run: |
-        echo "Adding replace directives to docs/e2e..."
-        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
-        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
-        go mod edit -replace=github.com/livetemplate/docs=../
-        go mod tidy
-        echo "OK: Replace directives added"
-
-    - name: Run progressive-enhancement e2e against core
-      working-directory: docs/e2e/progressive-enhancement
-      run: go test -v -count=1 -timeout=15m ./...
-      env:
-        CGO_ENABLED: 1
-        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
-
-  test-docs-login:
-    name: Test Docs Login against Core Changes
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout core library (this PR/branch)
-      uses: actions/checkout@v4
-      with:
-        path: livetemplate
-
-    - name: Checkout LVT (for testing package)
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/lvt
-        path: lvt
-
-    - name: Checkout docs
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/docs
-        path: docs
-
-    - name: Use matching docs branch if available
-      working-directory: docs
-      env:
-        DOCS_REF: ${{ github.head_ref || github.ref_name }}
-      run: |
-        if git ls-remote --exit-code --heads origin "$DOCS_REF" >/dev/null 2>&1; then
-          echo "Using livetemplate/docs branch: $DOCS_REF"
-          git fetch origin "$DOCS_REF" --depth=1
-          git checkout FETCH_HEAD
-        else
-          echo "No matching livetemplate/docs branch for $DOCS_REF; using default branch"
-        fi
-
-    - name: Checkout client library
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/client
-        path: livetemplate/client
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.26'
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: livetemplate/client/package-lock.json
-
-    - name: Build client library
-      working-directory: livetemplate/client
-      run: |
-        echo "Installing client dependencies..."
-        npm ci
-        echo "Building client library..."
-        npm run build
-        echo "OK: Client library built successfully"
-        ls -la dist/
-
-    - name: Add replace directives to docs (parent module)
-      working-directory: docs
-      run: |
-        echo "Adding replace directives to docs..."
-        go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
-        go mod edit -replace=github.com/livetemplate/lvt=../lvt
-        go mod tidy
-        echo "OK: Replace directives added"
-
-    - name: Add replace directives to docs/e2e (separate module)
-      working-directory: docs/e2e
-      run: |
-        echo "Adding replace directives to docs/e2e..."
-        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
-        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
-        go mod edit -replace=github.com/livetemplate/docs=../
-        go mod tidy
-        echo "OK: Replace directives added"
-
-    - name: Run login e2e against core
-      working-directory: docs/e2e/login
-      run: go test -v -count=1 -timeout=15m ./...
-      env:
-        CGO_ENABLED: 1
-        LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js
-
-  test-docs-shared-notepad:
-    name: Test Docs Shared Notepad against Core Changes
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout core library (this PR/branch)
-      uses: actions/checkout@v4
-      with:
-        path: livetemplate
-
-    - name: Checkout LVT (for testing package)
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/lvt
-        path: lvt
-
-    - name: Checkout docs
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/docs
-        path: docs
-
-    - name: Use matching docs branch if available
-      working-directory: docs
-      env:
-        DOCS_REF: ${{ github.head_ref || github.ref_name }}
-      run: |
-        if git ls-remote --exit-code --heads origin "$DOCS_REF" >/dev/null 2>&1; then
-          echo "Using livetemplate/docs branch: $DOCS_REF"
-          git fetch origin "$DOCS_REF" --depth=1
-          git checkout FETCH_HEAD
-        else
-          echo "No matching livetemplate/docs branch for $DOCS_REF; using default branch"
-        fi
-
-    - name: Checkout client library
-      uses: actions/checkout@v4
-      with:
-        repository: livetemplate/client
-        path: livetemplate/client
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.26'
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: livetemplate/client/package-lock.json
-
-    - name: Build client library
-      working-directory: livetemplate/client
-      run: |
-        echo "Installing client dependencies..."
-        npm ci
-        echo "Building client library..."
-        npm run build
-        echo "OK: Client library built successfully"
-        ls -la dist/
-
-    - name: Add replace directives to docs (parent module)
-      working-directory: docs
-      run: |
-        echo "Adding replace directives to docs..."
-        go mod edit -replace=github.com/livetemplate/livetemplate=../livetemplate
-        go mod edit -replace=github.com/livetemplate/lvt=../lvt
-        go mod tidy
-        echo "OK: Replace directives added"
-
-    - name: Add replace directives to docs/e2e (separate module)
-      working-directory: docs/e2e
-      run: |
-        echo "Adding replace directives to docs/e2e..."
-        go mod edit -replace=github.com/livetemplate/livetemplate=../../livetemplate
-        go mod edit -replace=github.com/livetemplate/lvt=../../lvt
-        go mod edit -replace=github.com/livetemplate/docs=../
-        go mod tidy
-        echo "OK: Replace directives added"
-
-    - name: Run shared-notepad e2e against core
-      working-directory: docs/e2e/shared-notepad
-      run: go test -v -count=1 -timeout=15m ./...
+      # Submit_With_No_Changes is a pre-existing flash-state flake in
+      # examples/patterns that fails identically in upstream
+      # examples/patterns; tracked as a follow-up to fix in the
+      # patterns app's flash handling. Skip applies to the patterns
+      # subset only — go test -skip uses test-name regexes that don't
+      # match anything in the other example suites.
+      run: go test -v -count=1 -timeout=20m -skip "Submit_With_No_Changes" ./examples/...
       env:
         CGO_ENABLED: 1
         LVT_LOCAL_CLIENT: ${{ github.workspace }}/livetemplate/client/dist/livetemplate-client.browser.js


### PR DESCRIPTION
## Summary

Replaces the 5 separate `test-docs-*` jobs in `.github/workflows/cross-repo-test.yml` with a single `test-docs-examples` job that runs `go test ./examples/...` from the docs checkout.

This is the cross-repo follow-up to **[livetemplate/docs#35](https://github.com/livetemplate/docs/pull/35)** (merged as `2bec46f`), which moved every runnable app to `docs/examples/<slug>/` with co-located `*_test.go` files and dissolved the `docs/e2e/go.mod` separate Go module. With that refactor in main, one `./examples/...` test target now covers every example — no need for per-recipe orchestration here.

## What changed

| Removed | Replaced by |
|---|---|
| `test-docs` (Patterns) | `test-docs-examples` (single job) |
| `test-docs-todos` | (same) |
| `test-docs-progressive-enhancement` | (same) |
| `test-docs-login` | (same) |
| `test-docs-shared-notepad` | (same) |

**Diff:** 1 file changed, 21 insertions(+), 379 deletions(-).

Preserved:

- Matching-docs-branch logic (a livetemplate PR named `xyz` uses docs branch `xyz` if it exists, else docs main).
- `Submit_With_No_Changes` skip — a pre-existing flash-state flake in the patterns recipe. `go test -skip` uses test-name regexes and other example suites have no test names that match it, so scope is unchanged.
- `docs` parent-module replace directive (the only remaining go.mod replace — `docs/e2e/go.mod` no longer exists, dropped that step entirely).

Bumped the test timeout from 15m (per recipe) to **30m** (whole suite). The largest suite (patterns) ran ~8min in the first green run; 30m gives comfortable headroom for slow CI runners and chromedp cold-start variance.

## Why now

Adding a new docs example used to require:

1. Create `content/recipes/<slug>/_app/` (the Go package)
2. Create `content/recipes/<slug>/index.md` (the recipe doc)
3. Edit `docs/cmd/site/main.go` (import + mount)
4. Create `docs/e2e/<slug>/main.go` (test wrapper)
5. Create `docs/e2e/<slug>/<slug>_test.go` (the test)
6. **Edit this workflow to add a new `test-docs-<slug>` job (~85 lines of YAML)**

After this PR, step 6 disappears — the new example is picked up by the `./examples/...` glob automatically.

## Dependency on docs hotfix

PR 437's first CI run surfaced a bug in livetemplate/docs PR #35: the per-example `cmd/main.go` files only enabled dev mode via the `--dev` flag, but `e2etest.StartTestServer` invokes `go run ./cmd` without passing flags, so the spawned server got the production origin allowlist and rejected Chrome's `host.docker.internal` WebSocket upgrades.

Fixed in [livetemplate/docs#37](https://github.com/livetemplate/docs/pull/37) (`3cb9f78`) — `cmd/main.go` now also honors `LVT_DEV_MODE=true` (which `e2etest.StartTestServer` already sets). The second Cross-Repository Tests run on this PR confirms all 4 jobs (`Test LVT`, `Test Examples`, `Test Docs Examples`, `Test Tinkerdown`) pass green.

## Test plan

- [x] YAML structure validated (4 jobs remain: `test-lvt`, `test-examples`, `test-docs-examples`, `test-tinkerdown`)
- [x] CI runs green on this PR (test-docs-examples completes the full chromedp suite for 12 examples in ~8 min)
- [ ] After merge: one routine livetemplate PR confirms the matching-docs-branch fallback still works

## Follow-up (not in this PR)

The `test-examples` job still tests `livetemplate/examples` repo. That repo will be archived in a separate follow-up after this PR bakes — at that point, `test-examples` can be removed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)