### PR TITLE
fix(build): tokenizer-based block-tag boundary detection (closes #436)

### DIFF
--- a/internal/build/html_segmentation.go
+++ b/internal/build/html_segmentation.go
@@ -15,13 +15,10 @@ var htmlBlockTags = map[string]struct{}{
 	"aside": {}, "nav": {}, "ul": {}, "ol": {}, "table": {},
 }
 
-// findBlockTagBoundaries walks htmlDoc once with html.Tokenizer and returns the
+// findBlockTagBoundaries walks htmlDoc once with html.Tokenizer and returns
 // ascending byte offsets of every StartTagToken whose tag name is in
-// htmlBlockTags. Unlike strings.Index, the tokenizer correctly skips "<div"
-// / "<article" / etc. substrings that appear inside HTML comments, RAWTEXT
-// (<script>/<style> content), RCDATA (<title>/<textarea> content), and
-// attribute values — closing the same class of substring-match hazard fixed
-// in wrapper.go's locateBodyAndFirstScript.
+// htmlBlockTags. The tokenizer correctly ignores block-tag-shaped substrings
+// inside comments, RAWTEXT, RCDATA, and attribute values.
 func findBlockTagBoundaries(htmlDoc string) []int {
 	var boundaries []int
 	z := html.NewTokenizer(strings.NewReader(htmlDoc))
@@ -53,10 +50,7 @@ func findBlockTagBoundaries(htmlDoc string) []int {
 // This is used as a fallback when template parsing fails or for initial tree generation
 // without template metadata.
 func CreateHTMLStructureBasedTree(html string) *TreeNode {
-	// Boundaries arrive in ascending byte order from a single forward
-	// tokenizer walk — no sort needed (the previous strings.Index
-	// implementation sorted because it scanned per-tag, interleaving
-	// offsets across tags).
+	// Boundaries are returned in document order by the single forward walk.
 	boundaries := findBlockTagBoundaries(html)
 
 	if len(boundaries) > 0 {

--- a/internal/build/html_segmentation.go
+++ b/internal/build/html_segmentation.go
@@ -49,14 +49,14 @@ func findBlockTagBoundaries(htmlDoc string) []int {
 //
 // This is used as a fallback when template parsing fails or for initial tree generation
 // without template metadata.
-func CreateHTMLStructureBasedTree(html string) *TreeNode {
+func CreateHTMLStructureBasedTree(htmlDoc string) *TreeNode {
 	// Boundaries are returned in document order by the single forward walk.
-	boundaries := findBlockTagBoundaries(html)
+	boundaries := findBlockTagBoundaries(htmlDoc)
 
 	if len(boundaries) > 0 {
 		// Create segments based on boundaries
 		const maxSegments = 8
-		segmentSize := len(html) / maxSegments
+		segmentSize := len(htmlDoc) / maxSegments
 
 		var statics []string
 		var dynamics []interface{}
@@ -67,20 +67,20 @@ func CreateHTMLStructureBasedTree(html string) *TreeNode {
 			if boundary-lastPos > segmentSize || i == len(boundaries)-1 {
 				if lastPos == 0 {
 					// First segment is typically more static (head, nav, etc)
-					statics = append(statics, html[lastPos:boundary])
+					statics = append(statics, htmlDoc[lastPos:boundary])
 				} else {
 					// Create a dynamic segment
 					statics = append(statics, "")
-					dynamics = append(dynamics, html[lastPos:boundary])
+					dynamics = append(dynamics, htmlDoc[lastPos:boundary])
 				}
 				lastPos = boundary
 			}
 		}
 
 		// Add the final segment
-		if lastPos < len(html) {
+		if lastPos < len(htmlDoc) {
 			statics = append(statics, "")
-			dynamics = append(dynamics, html[lastPos:])
+			dynamics = append(dynamics, htmlDoc[lastPos:])
 		}
 
 		// Build the tree
@@ -101,6 +101,6 @@ func CreateHTMLStructureBasedTree(html string) *TreeNode {
 
 	// Fallback to single segment strategy
 	fallback := NewTreeNodeWithStatics([]string{"", ""})
-	fallback.SetDynamic(0, render.MinifyHTML(html))
+	fallback.SetDynamic(0, render.MinifyHTML(htmlDoc))
 	return fallback
 }

--- a/internal/build/html_segmentation.go
+++ b/internal/build/html_segmentation.go
@@ -1,15 +1,46 @@
 package build
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/livetemplate/livetemplate/internal/render"
+	"golang.org/x/net/html"
 )
 
-// htmlBlockTags defines block-level HTML elements that create natural segment boundaries
-// for tree-based HTML structure analysis and segmentation.
-var htmlBlockTags = []string{"<div", "<article", "<section", "<main", "<aside", "<nav", "<ul", "<ol", "<table"}
+// htmlBlockTags defines block-level HTML tag names that create natural segment
+// boundaries for tree-based HTML structure analysis. Stored as bare tag names
+// (no leading "<") to match html.Tokenizer.TagName() output directly.
+var htmlBlockTags = map[string]struct{}{
+	"div": {}, "article": {}, "section": {}, "main": {},
+	"aside": {}, "nav": {}, "ul": {}, "ol": {}, "table": {},
+}
+
+// findBlockTagBoundaries walks htmlDoc once with html.Tokenizer and returns the
+// ascending byte offsets of every StartTagToken whose tag name is in
+// htmlBlockTags. Unlike strings.Index, the tokenizer correctly skips "<div"
+// / "<article" / etc. substrings that appear inside HTML comments, RAWTEXT
+// (<script>/<style> content), RCDATA (<title>/<textarea> content), and
+// attribute values — closing the same class of substring-match hazard fixed
+// in wrapper.go's locateBodyAndFirstScript.
+func findBlockTagBoundaries(htmlDoc string) []int {
+	var boundaries []int
+	z := html.NewTokenizer(strings.NewReader(htmlDoc))
+	offset := 0
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			return boundaries
+		}
+		raw := z.Raw()
+		if tt == html.StartTagToken {
+			name, _ := z.TagName()
+			if _, ok := htmlBlockTags[string(name)]; ok {
+				boundaries = append(boundaries, offset)
+			}
+		}
+		offset += len(raw)
+	}
+}
 
 // CreateHTMLStructureBasedTree implements deterministic segmentation strategies for HTML content.
 // It analyzes HTML structure and creates a tree representation with static and dynamic segments.
@@ -22,25 +53,13 @@ var htmlBlockTags = []string{"<div", "<article", "<section", "<main", "<aside", 
 // This is used as a fallback when template parsing fails or for initial tree generation
 // without template metadata.
 func CreateHTMLStructureBasedTree(html string) *TreeNode {
-	// Find the positions of block elements
-	var boundaries []int
-	for _, tag := range htmlBlockTags {
-		idx := 0
-		for {
-			pos := strings.Index(html[idx:], tag)
-			if pos == -1 {
-				break
-			}
-			boundaries = append(boundaries, idx+pos)
-			idx = idx + pos + len(tag)
-		}
-	}
+	// Boundaries arrive in ascending byte order from a single forward
+	// tokenizer walk — no sort needed (the previous strings.Index
+	// implementation sorted because it scanned per-tag, interleaving
+	// offsets across tags).
+	boundaries := findBlockTagBoundaries(html)
 
-	// Sort boundaries
 	if len(boundaries) > 0 {
-		// Sort boundaries using efficient stdlib sort
-		sort.Ints(boundaries)
-
 		// Create segments based on boundaries
 		const maxSegments = 8
 		segmentSize := len(html) / maxSegments

--- a/internal/build/html_segmentation_test.go
+++ b/internal/build/html_segmentation_test.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/html"
 )
 
 // blockTagDecoyCases enumerates fragments whose literal text contains block
@@ -150,9 +152,10 @@ func TestFindBlockTagBoundaries_PropertyDecoys(t *testing.T) {
 }
 
 // TestFindBlockTagBoundaries_OffsetCoverage proves the offset accounting
-// (sum(len(z.Raw())) == len(input)) holds across realistic inputs. If this
-// drifts, every offset returned by findBlockTagBoundaries is wrong by the
-// same delta. Mirrors the wrapper.go offset-coverage sanity test.
+// invariant the helper depends on: sum(len(z.Raw())) over a full tokenizer
+// walk equals len(input). If this ever drifts, every offset returned by
+// findBlockTagBoundaries is wrong by the same delta. Mirrors the wrapper.go
+// offset-coverage sanity test.
 func TestFindBlockTagBoundaries_OffsetCoverage(t *testing.T) {
 	inputs := []string{
 		`<div>x</div>`,
@@ -163,12 +166,26 @@ func TestFindBlockTagBoundaries_OffsetCoverage(t *testing.T) {
 	}
 	for i, in := range inputs {
 		t.Run(fmt.Sprintf("input_%d", i), func(t *testing.T) {
-			// Re-walk the tokens the same way findBlockTagBoundaries does
-			// and verify sum(len(raw)) == len(in).
-			boundaries := findBlockTagBoundaries(in)
-			// The boundaries themselves don't reveal the offset coverage,
-			// but every boundary must lie within [0, len(in)).
-			for _, b := range boundaries {
+			// Walk the same tokenizer findBlockTagBoundaries uses and sum
+			// the raw-byte lengths. If the sum diverges from len(in), the
+			// per-token offset accounting in findBlockTagBoundaries is
+			// also wrong.
+			z := html.NewTokenizer(strings.NewReader(in))
+			sum := 0
+			for {
+				tt := z.Next()
+				if tt == html.ErrorToken {
+					break
+				}
+				sum += len(z.Raw())
+			}
+			if sum != len(in) {
+				t.Errorf("offset coverage drift: sum=%d want=%d input=%q", sum, len(in), in)
+			}
+
+			// Belt-and-suspenders: returned boundaries must lie within the
+			// input range.
+			for _, b := range findBlockTagBoundaries(in) {
 				if b < 0 || b >= len(in) {
 					t.Errorf("boundary %d out of range [0, %d)", b, len(in))
 				}

--- a/internal/build/html_segmentation_test.go
+++ b/internal/build/html_segmentation_test.go
@@ -1,0 +1,200 @@
+package build
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// blockTagDecoyCases enumerates fragments whose literal text contains block
+// tag substrings ("<div", "<article", etc.) but where those substrings are
+// inside HTML comments, RAWTEXT (<script>/<style> content), RCDATA (<title>/
+// <textarea> content), or attribute values — i.e. NOT real start tags.
+// findBlockTagBoundaries must skip every one of these.
+var blockTagDecoyCases = []struct {
+	name string
+	html string
+}{
+	{
+		"<div inside <style> comment",
+		`<style>/* fake <div> note */ .x{}</style>`,
+	},
+	{
+		"<article inside inline JS string",
+		`<script>var s = "<article id='x'>";</script>`,
+	},
+	{
+		"<section inside HTML comment",
+		`<!-- <section> in a comment -->`,
+	},
+	{
+		"<nav inside meta content attribute",
+		`<meta property="og:description" content="<nav class='x'>">`,
+	},
+	{
+		"<table inside title text (RCDATA)",
+		`<title>About the <table> tag</title>`,
+	},
+	{
+		"<aside inside textarea text (RCDATA)",
+		`<textarea><aside></textarea>`,
+	},
+	{
+		"<main inside style+script decoys",
+		`<style>/* <main> note */</style><script>var x="<main>";</script>`,
+	},
+	{
+		"<ul inside HTML comment with multiple block tags",
+		`<!-- <ul><li><ol> all here --><!--end-->`,
+	},
+}
+
+// TestFindBlockTagBoundaries_DecoyImmunity confirms that block-tag substrings
+// inside comments / RAWTEXT / RCDATA / attribute values are NOT picked up as
+// segment boundaries. This is the canonical regression test for #436.
+func TestFindBlockTagBoundaries_DecoyImmunity(t *testing.T) {
+	for _, tc := range blockTagDecoyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			boundaries := findBlockTagBoundaries(tc.html)
+			if len(boundaries) != 0 {
+				t.Errorf("expected 0 boundaries for decoy-only input, got %d at offsets %v\ninput=%q",
+					len(boundaries), boundaries, tc.html)
+			}
+		})
+	}
+}
+
+// TestFindBlockTagBoundaries_RealTagsFound confirms genuine block-level start
+// tags are still found (the tokenizer migration didn't lose coverage).
+func TestFindBlockTagBoundaries_RealTagsFound(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want int // expected number of boundaries
+	}{
+		{"single div", `<div>x</div>`, 1},
+		{"three siblings", `<div>a</div><main>b</main><div>c</div>`, 3},
+		{"nested counts each", `<div><section><ul><li>x</li></ul></section></div>`, 3},
+		{"non-block tag ignored", `<span>x</span><p>y</p>`, 0},
+		{"mixed", `<div>a</div><span>b</span><article>c</article>`, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := len(findBlockTagBoundaries(tc.html))
+			if got != tc.want {
+				t.Errorf("findBlockTagBoundaries(%q) returned %d boundaries, want %d",
+					tc.html, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFindBlockTagBoundaries_OffsetsAreAscending confirms the single-walk
+// invariant: boundaries are returned in document order without needing a sort.
+func TestFindBlockTagBoundaries_OffsetsAreAscending(t *testing.T) {
+	input := `<div>a</div><section>b</section><main>c</main><article>d</article>`
+	boundaries := findBlockTagBoundaries(input)
+	for i := 1; i < len(boundaries); i++ {
+		if boundaries[i] <= boundaries[i-1] {
+			t.Errorf("boundaries not ascending at index %d: %v", i, boundaries)
+		}
+	}
+}
+
+// TestFindBlockTagBoundaries_PropertyDecoys is a randomized regression test:
+// no combination of block-tag-bearing decoy contexts in head/inline-script/
+// style/comment should ever produce a false boundary. Catches future
+// regressions toward naive strings.Index.
+func TestFindBlockTagBoundaries_PropertyDecoys(t *testing.T) {
+	const realMarker = `<div id="real">REAL</div>`
+	decoys := []string{
+		`<style>/* <div> */</style>`,
+		`<style>/* <article> */</style>`,
+		`<script>var s="<section>";</script>`,
+		`<script>// <main></main></script>`,
+		`<meta property="og:title" content="<nav>">`,
+		`<!-- <ul> -->`,
+		`<!-- <ol></ol> -->`,
+		`<title>About <table></title>`,
+		`<textarea><aside></textarea>`,
+	}
+
+	const seed = int64(0xb10c1abc)
+	rng := rand.New(rand.NewSource(seed))
+
+	const iterations = 1000
+	for i := 0; i < iterations; i++ {
+		n := rng.Intn(len(decoys) + 1)
+		perm := rng.Perm(len(decoys))
+		var head strings.Builder
+		for _, k := range perm[:n] {
+			head.WriteString(decoys[k])
+		}
+		input := head.String() + realMarker
+
+		boundaries := findBlockTagBoundaries(input)
+		if len(boundaries) != 1 {
+			t.Fatalf("iter %d (seed=%#x): expected exactly 1 boundary (for real <div>), got %d at %v\ninput=%q",
+				i, seed, len(boundaries), boundaries, input)
+		}
+		// The boundary must point at the real <div>, not anywhere in the
+		// decoy prefix.
+		wantOffset := strings.Index(input, realMarker)
+		if boundaries[0] != wantOffset {
+			t.Fatalf("iter %d (seed=%#x): boundary at %d, want %d (start of real <div>)\ninput=%q",
+				i, seed, boundaries[0], wantOffset, input)
+		}
+	}
+}
+
+// TestFindBlockTagBoundaries_OffsetCoverage proves the offset accounting
+// (sum(len(z.Raw())) == len(input)) holds across realistic inputs. If this
+// drifts, every offset returned by findBlockTagBoundaries is wrong by the
+// same delta. Mirrors the wrapper.go offset-coverage sanity test.
+func TestFindBlockTagBoundaries_OffsetCoverage(t *testing.T) {
+	inputs := []string{
+		`<div>x</div>`,
+		`<style>/* <div> */</style><div>real</div>`,
+		`<!doctype html><html><body><main>x</main></body></html>`,
+		``,
+		`plain text`,
+	}
+	for i, in := range inputs {
+		t.Run(fmt.Sprintf("input_%d", i), func(t *testing.T) {
+			// Re-walk the tokens the same way findBlockTagBoundaries does
+			// and verify sum(len(raw)) == len(in).
+			boundaries := findBlockTagBoundaries(in)
+			// The boundaries themselves don't reveal the offset coverage,
+			// but every boundary must lie within [0, len(in)).
+			for _, b := range boundaries {
+				if b < 0 || b >= len(in) {
+					t.Errorf("boundary %d out of range [0, %d)", b, len(in))
+				}
+			}
+		})
+	}
+}
+
+// TestCreateHTMLStructureBasedTree_DecoyInputDoesNotSegment confirms that an
+// input whose only "block tags" are inside decoy contexts produces the
+// fallback single-segment tree (because findBlockTagBoundaries returns
+// empty). Before the fix, decoys would have created false boundaries and
+// possibly an over-segmented tree.
+func TestCreateHTMLStructureBasedTree_DecoyInputDoesNotSegment(t *testing.T) {
+	input := `<style>/* <div> */</style><script>var x="<article>";</script>plain content with no real block tags`
+
+	tree := CreateHTMLStructureBasedTree(input)
+	if tree == nil {
+		t.Fatal("expected fallback tree, got nil")
+	}
+	// Fallback shape: 2 statics ("", ""), 1 dynamic (the whole content).
+	if len(tree.Statics) != 2 {
+		t.Errorf("expected fallback 2-statics tree, got %d statics: %#v",
+			len(tree.Statics), tree.Statics)
+	}
+	if tree.DynamicLen() != 1 {
+		t.Errorf("expected 1 dynamic in fallback tree, got %d", tree.DynamicLen())
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #436. `CreateHTMLStructureBasedTree`'s diff-time segmentation boundary scan used the same naive `strings.Index` pattern that caused #414 in `wrapper.go`. Block-tag substrings (`<div`, `<article`, `<section`, etc.) appearing inside HTML comments, RAWTEXT (`<script>`/`<style>`), RCDATA (`<title>`/`<textarea>`), or attribute values were mis-detected as real start tags, producing wrong segment boundaries.
- Migrate to a single `html.Tokenizer` walk via `findBlockTagBoundaries`, mirroring the `wrapper.go` `locateBodyAndFirstScript` design from #435.
- Single forward walk replaces the per-tag nested loop, so boundaries arrive pre-sorted — `sort.Ints` call disappears.
- `htmlBlockTags` becomes a `map[string]struct{}` of bare tag names (no leading `<`) to match `html.Tokenizer.TagName()` directly.

## No golden-snapshot drift

The existing behavior-pin test (`TestCreateHTMLStructureBasedTreeSegmentsBlockBoundaries`) passes unchanged. For clean HTML the tokenizer offsets match the old `strings.Index` offsets byte-for-byte — only inputs with decoy substrings in comments/RAWTEXT/RCDATA/attributes see different (and now correct) output. `pre-commit.sh` confirms no golden file drift across the suite.

## Test plan

- [x] `internal/build/html_segmentation_test.go` (new): 8 decoy-immunity fixtures (comment, RAWTEXT, RCDATA, meta-attribute), real-tag presence checks, ascending-offsets pin, 1000-iter property-decoy fuzz with deterministic seed, offset-range sanity, decoy-only fallback check.
- [x] Existing `TestCreateHTMLStructureBasedTreeSegmentsBlockBoundaries` passes (no regression for clean inputs).
- [x] `go test -race ./internal/build/...` PASS.
- [x] `scripts/pre-commit.sh` PASS (gofmt + golangci-lint with project linter set + full test suite at 300s).
- [x] No golden file shifts across `testdata/golden/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)