### PR TITLE
feat(context): support relative redirects so recipes can redirect-to-self under StripPrefix

### DIFF
--- a/action.go
+++ b/action.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"unicode"
@@ -30,7 +31,7 @@ var (
 
 	// ErrInvalidRedirectURL is returned when Redirect is called with a potentially
 	// unsafe URL that could lead to open redirect vulnerabilities.
-	ErrInvalidRedirectURL = errors.New("invalid redirect URL (must be relative path starting with /)")
+	ErrInvalidRedirectURL = errors.New("invalid redirect URL (must be a relative reference with no scheme or host)")
 )
 
 // message is an alias for internal/send.ActionMessage for backward compatibility
@@ -341,18 +342,32 @@ func (a *ActionData) Get(key string) interface{} {
 	return a.raw[key]
 }
 
-// isValidRedirectURL checks if a URL is safe for redirects.
-// Only allows relative paths starting with "/" to prevent open redirects.
-func isValidRedirectURL(url string) bool {
-	// Must start with / (relative path)
-	if !strings.HasPrefix(url, "/") {
+// isValidRedirectURL reports whether rawURL is safe as a redirect target.
+// It permits absolute-path references ("/dashboard") and relative references
+// ("", ".", "./settings", "../list") so recipes mounted behind
+// http.StripPrefix can redirect to their own mount via a relative Location the
+// browser resolves against the un-stripped request URL.
+//
+// It rejects anything that could escape the current origin: protocol-relative
+// URLs ("//evil.com"), backslash variants browsers fold to "//" ("/\evil.com",
+// "\\evil.com"), and any URL carrying a scheme or host ("https://evil.com",
+// "javascript:...", "mailto:..."). url.Parse treats a leading "scheme:" in a
+// relative path (e.g. "foo:bar") as a scheme, so such targets are rejected;
+// write "./foo:bar" to keep the colon in a path segment.
+func isValidRedirectURL(rawURL string) bool {
+	// Guard "//host" and the backslash variants ("/\host", "\\host", "\/host")
+	// before parsing — url.Parse alone treats them as host-less relative paths,
+	// but browsers fold the backslashes to "//" and follow them cross-origin.
+	if len(rawURL) >= 2 {
+		if c0, c1 := rawURL[0], rawURL[1]; (c0 == '/' || c0 == '\\') && (c1 == '/' || c1 == '\\') {
+			return false
+		}
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
 		return false
 	}
-	// Reject protocol-relative URLs like "//evil.com"
-	if strings.HasPrefix(url, "//") {
-		return false
-	}
-	return true
+	return u.Scheme == "" && u.Host == ""
 }
 
 // FieldError represents a validation error for a specific field

--- a/action.go
+++ b/action.go
@@ -31,7 +31,7 @@ var (
 
 	// ErrInvalidRedirectURL is returned when Redirect is called with a potentially
 	// unsafe URL that could lead to open redirect vulnerabilities.
-	ErrInvalidRedirectURL = errors.New("invalid redirect URL (must be a relative reference with no scheme or host)")
+	ErrInvalidRedirectURL = errors.New("invalid redirect URL (must be a path or relative reference with no scheme or host)")
 )
 
 // message is an alias for internal/send.ActionMessage for backward compatibility

--- a/context.go
+++ b/context.go
@@ -354,7 +354,10 @@ func (c *Context) Redirect(url string, code int) error {
 		// (the action / PRG path), unless the caller already set a Content-Type.
 		h := c.w.Header()
 		_, hadCT := h["Content-Type"]
-		h.Set("Location", target)
+		// Percent-encode non-ASCII bytes so the Location stays within HTTP's
+		// ASCII header constraint — http.Redirect does this for the absolute
+		// branch via its own (unexported) helper.
+		h.Set("Location", hexEscapeNonASCII(target))
 		if !hadCT && (c.r.Method == http.MethodGet || c.r.Method == http.MethodHead) {
 			h.Set("Content-Type", "text/html; charset=utf-8")
 		}
@@ -372,6 +375,34 @@ func (c *Context) Redirect(url string, code int) error {
 		*c.redirected = true
 	}
 	return nil
+}
+
+// hexEscapeNonASCII percent-encodes bytes >= 0x80 so a relative Location value
+// stays within HTTP's ASCII header constraint. It mirrors the unexported
+// net/http helper http.Redirect applies to the absolute-path branch, and only
+// touches non-ASCII bytes — ASCII path delimiters ("/", ".", "?") are preserved,
+// unlike url.PathEscape which would mangle them.
+func hexEscapeNonASCII(s string) string {
+	const upperhex = "0123456789ABCDEF"
+	hasNonASCII := false
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			hasNonASCII = true
+			break
+		}
+	}
+	if !hasNonASCII {
+		return s
+	}
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c >= 0x80 {
+			b = append(b, '%', upperhex[c>>4], upperhex[c&0x0f])
+		} else {
+			b = append(b, c)
+		}
+	}
+	return string(b)
 }
 
 // WithHTTP returns a new Context with HTTP request/response.

--- a/context.go
+++ b/context.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -299,9 +301,19 @@ func (c *Context) GetCookie(name string) (*http.Cookie, error) {
 }
 
 // Redirect sends an HTTP redirect response.
+//
+// The target may be an absolute-path reference ("/dashboard") or a relative
+// reference ("", ".", "./settings", "../list"). Relative references are emitted
+// as-is in the Location header so the browser resolves them against its own
+// (un-stripped) request URL — this lets a recipe mounted behind
+// http.StripPrefix redirect back to its own mount without knowing the prefix.
+// The empty string means "reload self": Redirect("", http.StatusSeeOther) is
+// the canonical POST-Redirect-GET target for a recipe's own mount.
+//
 // Returns ErrNoHTTPContext if called from a WebSocket action.
 // Returns ErrInvalidRedirectCode if code is not 3xx.
-// Returns ErrInvalidRedirectURL if URL is not a valid relative path.
+// Returns ErrInvalidRedirectURL if the target carries a scheme or host, or is a
+// protocol-relative URL (open-redirect guards — see isValidRedirectURL).
 func (c *Context) Redirect(url string, code int) error {
 	if c.w == nil || c.r == nil {
 		return ErrNoHTTPContext
@@ -312,7 +324,27 @@ func (c *Context) Redirect(url string, code int) error {
 	if !isValidRedirectURL(url) {
 		return ErrInvalidRedirectURL
 	}
-	http.Redirect(c.w, c.r, url, code)
+
+	if strings.HasPrefix(url, "/") {
+		// Absolute-path target: unchanged behaviour. http.Redirect does not
+		// resolve absolute paths, so the stripped request path is irrelevant.
+		http.Redirect(c.w, c.r, url, code)
+	} else {
+		// Relative target: emit the reference RAW so the client resolves it
+		// against its effective (un-stripped) request URI. http.Redirect would
+		// resolve it server-side against the http.StripPrefix-stripped path —
+		// the bug we're avoiding. "" means "reload self": translate to
+		// "./<last-segment>" so the Location is non-empty (an empty Location
+		// breaks clients) and resolves back to the current URL.
+		target := url
+		if target == "" {
+			_, last := path.Split(c.r.URL.EscapedPath())
+			target = "./" + last
+		}
+		c.w.Header().Set("Location", target)
+		c.w.WriteHeader(code)
+	}
+
 	if c.redirected != nil {
 		*c.redirected = true
 	}

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package livetemplate
 import (
 	"context"
 	"fmt"
+	"html"
 	"log/slog"
 	"net/http"
 	"path"
@@ -341,8 +342,24 @@ func (c *Context) Redirect(url string, code int) error {
 			_, last := path.Split(c.r.URL.EscapedPath())
 			target = "./" + last
 		}
-		c.w.Header().Set("Location", target)
+		// Mirror http.Redirect's method-aware tail so the two branches behave
+		// identically apart from URL resolution: a short HTML body plus
+		// Content-Type for GET, Content-Type only for HEAD, neither for POST
+		// (the action / PRG path), unless the caller already set a Content-Type.
+		h := c.w.Header()
+		_, hadCT := h["Content-Type"]
+		h.Set("Location", target)
+		if !hadCT && (c.r.Method == http.MethodGet || c.r.Method == http.MethodHead) {
+			h.Set("Content-Type", "text/html; charset=utf-8")
+		}
 		c.w.WriteHeader(code)
+		if !hadCT && c.r.Method == http.MethodGet {
+			if _, err := fmt.Fprintf(c.w, "<a href=\"%s\">%s</a>.\n", html.EscapeString(target), http.StatusText(code)); err != nil {
+				slog.Warn("Failed to write redirect body",
+					slog.String("component", "context"),
+					slog.Any("error", err))
+			}
+		}
 	}
 
 	if c.redirected != nil {

--- a/context.go
+++ b/context.go
@@ -309,7 +309,12 @@ func (c *Context) GetCookie(name string) (*http.Cookie, error) {
 // (un-stripped) request URL — this lets a recipe mounted behind
 // http.StripPrefix redirect back to its own mount without knowing the prefix.
 // The empty string means "reload self": Redirect("", http.StatusSeeOther) is
-// the canonical POST-Redirect-GET target for a recipe's own mount.
+// the canonical POST-Redirect-GET target for a recipe's own mount. This assumes
+// a trailing-slash mount — the canonical http.StripPrefix("/apps/login/", …)
+// pattern — because "" resolves to "./", the current directory. An exact-match
+// mount without a trailing slash (http.StripPrefix("/apps/login", …) serving
+// /apps/login) would resolve "./" to the parent path; mount with a trailing
+// slash to use the reload-self form.
 //
 // Returns ErrNoHTTPContext if called from a WebSocket action.
 // Returns ErrInvalidRedirectCode if code is not 3xx.

--- a/context.go
+++ b/context.go
@@ -304,7 +304,8 @@ func (c *Context) GetCookie(name string) (*http.Cookie, error) {
 // Redirect sends an HTTP redirect response.
 //
 // The target may be an absolute-path reference ("/dashboard") or a relative
-// reference ("", ".", "./settings", "../list"). Relative references are emitted
+// reference — including a bare segment ("dashboard"), dot forms (".", "./settings",
+// "../list"), and the empty string. Relative references are emitted
 // as-is in the Location header so the browser resolves them against its own
 // (un-stripped) request URL — this lets a recipe mounted behind
 // http.StripPrefix redirect back to its own mount without knowing the prefix.

--- a/docs/references/authentication.md
+++ b/docs/references/authentication.md
@@ -245,7 +245,7 @@ var (
     ErrInvalidRedirectCode = errors.New("invalid redirect status code (must be 3xx)")
 
     // Returned when Redirect URL could cause open redirect vulnerability
-    ErrInvalidRedirectURL = errors.New("invalid redirect URL (must be a relative reference with no scheme or host)")
+    ErrInvalidRedirectURL = errors.New("invalid redirect URL (must be a path or relative reference with no scheme or host)")
 )
 ```
 

--- a/docs/references/authentication.md
+++ b/docs/references/authentication.md
@@ -193,16 +193,39 @@ ctx.DeleteCookie("session_token") // Sets MaxAge = -1
 ctx.Redirect("/dashboard", http.StatusSeeOther) // 303
 ```
 
-**Security:** Only relative paths starting with `/` are allowed. This prevents open redirect vulnerabilities:
+The target may be an **absolute-path reference** (`/dashboard`) or a **relative
+reference** (`""`, `.`, `./settings`, `../list`). Relative references are
+emitted as-is in the `Location` header, so the browser resolves them against
+its own request URL.
+
+**Redirecting to your own mount (recipes behind `http.StripPrefix`):** When a
+handler is mounted at a subpath via `http.StripPrefix("/apps/login/", handler)`,
+`r.URL.Path` is stripped before the handler sees it, so the handler can't
+reconstruct its own mount. Use the empty string — "reload self" — and let the
+browser resolve it against the full URL:
+
+```go
+// POST-Redirect-GET back to the recipe's own mount, wherever it's mounted.
+return state, ctx.Redirect("", http.StatusSeeOther)
+```
+
+This lands back at `/apps/login/` in production and at `/` under a root-mounted
+test server — no `mountPath` argument needs threading through the handler.
+
+**Security:** Relative references are origin-confined (RFC 3986 resolution
+keeps the current scheme+host), so they can't be open-redirect vectors. The
+guard rejects anything that could escape the current origin:
 
 ```go
 // Valid redirects
-ctx.Redirect("/dashboard", http.StatusSeeOther)     // OK
-ctx.Redirect("/users/profile", http.StatusFound)    // OK
+ctx.Redirect("/dashboard", http.StatusSeeOther)     // OK (absolute path)
+ctx.Redirect("", http.StatusSeeOther)               // OK (reload self)
+ctx.Redirect("./settings", http.StatusSeeOther)     // OK (relative)
 
 // Invalid redirects (rejected with ErrInvalidRedirectURL)
-ctx.Redirect("https://evil.com", http.StatusFound)  // Rejected
+ctx.Redirect("https://evil.com", http.StatusFound)  // Rejected (has scheme/host)
 ctx.Redirect("//evil.com", http.StatusFound)        // Rejected (protocol-relative)
+ctx.Redirect("/\\evil.com", http.StatusFound)       // Rejected (backslash bypass)
 ```
 
 ### Error Types
@@ -216,7 +239,7 @@ var (
     ErrInvalidRedirectCode = errors.New("invalid redirect status code (must be 3xx)")
 
     // Returned when Redirect URL could cause open redirect vulnerability
-    ErrInvalidRedirectURL = errors.New("invalid redirect URL (must be relative path starting with /)")
+    ErrInvalidRedirectURL = errors.New("invalid redirect URL (must be a relative reference with no scheme or host)")
 )
 ```
 

--- a/docs/references/authentication.md
+++ b/docs/references/authentication.md
@@ -212,6 +212,12 @@ return state, ctx.Redirect("", http.StatusSeeOther)
 This lands back at `/apps/login/` in production and at `/` under a root-mounted
 test server — no `mountPath` argument needs threading through the handler.
 
+> **Mount with a trailing slash.** The empty-string "reload self" form resolves
+> to `./` (the current directory), so it relies on the canonical trailing-slash
+> mount `http.StripPrefix("/apps/login/", …)`. An exact-match mount *without* a
+> trailing slash (`http.StripPrefix("/apps/login", …)` serving `/apps/login`)
+> would resolve `./` to the parent path.
+
 **Security:** Relative references are origin-confined (RFC 3986 resolution
 keeps the current scheme+host), so they can't be open-redirect vectors. The
 guard rejects anything that could escape the current origin:

--- a/handle_test.go
+++ b/handle_test.go
@@ -3279,7 +3279,7 @@ func TestRedirect_RelativeBranch(t *testing.T) {
 		return NewContext(req.Context(), "Act", nil).WithHTTP(rec, req), rec
 	}
 
-	t.Run("self reloads via ./<segment>", func(t *testing.T) {
+	t.Run("trailing-slash self reload yields ./", func(t *testing.T) {
 		ctx, rec := newCtx(http.MethodPost, "/apps/login/")
 		if err := ctx.Redirect("", http.StatusSeeOther); err != nil {
 			t.Fatalf("Redirect returned error: %v", err)
@@ -3330,6 +3330,17 @@ func TestRedirect_RelativeBranch(t *testing.T) {
 		}
 		if got := rec.Header().Get("Location"); got != "." {
 			t.Errorf("Location = %q, want %q", got, ".")
+		}
+	})
+
+	t.Run("non-ASCII target percent-encoded in Location", func(t *testing.T) {
+		ctx, rec := newCtx(http.MethodPost, "/apps/login/")
+		if err := ctx.Redirect("./résumé", http.StatusSeeOther); err != nil {
+			t.Fatalf("Redirect returned error: %v", err)
+		}
+		// é is U+00E9 → UTF-8 0xC3 0xA9; the header must stay ASCII.
+		if got := rec.Header().Get("Location"); got != "./r%C3%A9sum%C3%A9" {
+			t.Errorf("Location = %q, want %q", got, "./r%C3%A9sum%C3%A9")
 		}
 	})
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -3251,6 +3251,7 @@ func TestIsValidRedirectURL(t *testing.T) {
 		{"./settings", true},
 		{"../list", true},
 		{"dashboard", true},
+		{"./foo:bar", true}, // colon in a path segment, escaped with leading ./
 		// Reject: protocol-relative and the backslash bypass variants.
 		{"//evil.com", false},
 		{"/\\evil.com", false},
@@ -3272,14 +3273,14 @@ func TestIsValidRedirectURL(t *testing.T) {
 }
 
 func TestRedirect_RelativeBranch(t *testing.T) {
-	newCtx := func(reqPath string) (*Context, *httptest.ResponseRecorder) {
+	newCtx := func(method, reqPath string) (*Context, *httptest.ResponseRecorder) {
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest("POST", reqPath, nil)
+		req := httptest.NewRequest(method, reqPath, nil)
 		return NewContext(req.Context(), "Act", nil).WithHTTP(rec, req), rec
 	}
 
 	t.Run("self reloads via ./<segment>", func(t *testing.T) {
-		ctx, rec := newCtx("/apps/login/")
+		ctx, rec := newCtx(http.MethodPost, "/apps/login/")
 		if err := ctx.Redirect("", http.StatusSeeOther); err != nil {
 			t.Fatalf("Redirect returned error: %v", err)
 		}
@@ -3289,10 +3290,17 @@ func TestRedirect_RelativeBranch(t *testing.T) {
 		if rec.Code != http.StatusSeeOther {
 			t.Errorf("code = %d, want %d", rec.Code, http.StatusSeeOther)
 		}
+		// POST mirrors http.Redirect: no courtesy body, no Content-Type.
+		if rec.Body.Len() != 0 {
+			t.Errorf("POST redirect body = %q, want empty", rec.Body.String())
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "" {
+			t.Errorf("POST redirect Content-Type = %q, want empty", ct)
+		}
 	})
 
 	t.Run("self on a sub-path keeps the segment", func(t *testing.T) {
-		ctx, rec := newCtx("/foo")
+		ctx, rec := newCtx(http.MethodPost, "/foo")
 		if err := ctx.Redirect("", http.StatusSeeOther); err != nil {
 			t.Fatalf("Redirect returned error: %v", err)
 		}
@@ -3302,7 +3310,7 @@ func TestRedirect_RelativeBranch(t *testing.T) {
 	})
 
 	t.Run("relative target emitted raw", func(t *testing.T) {
-		ctx, rec := newCtx("/apps/login/")
+		ctx, rec := newCtx(http.MethodPost, "/apps/login/")
 		if err := ctx.Redirect("dashboard", http.StatusSeeOther); err != nil {
 			t.Fatalf("Redirect returned error: %v", err)
 		}
@@ -3311,8 +3319,21 @@ func TestRedirect_RelativeBranch(t *testing.T) {
 		}
 	})
 
+	t.Run("GET mirrors http.Redirect body and Content-Type", func(t *testing.T) {
+		ctx, rec := newCtx(http.MethodGet, "/apps/login/")
+		if err := ctx.Redirect("dashboard", http.StatusSeeOther); err != nil {
+			t.Fatalf("Redirect returned error: %v", err)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+			t.Errorf("GET redirect Content-Type = %q, want text/html; charset=utf-8", ct)
+		}
+		if body := rec.Body.String(); !strings.Contains(body, `<a href="dashboard">`) {
+			t.Errorf("GET redirect body = %q, want an <a href> courtesy link", body)
+		}
+	})
+
 	t.Run("cross-origin target rejected", func(t *testing.T) {
-		ctx, _ := newCtx("/apps/login/")
+		ctx, _ := newCtx(http.MethodPost, "/apps/login/")
 		if err := ctx.Redirect("https://evil.com", http.StatusSeeOther); !errors.Is(err, ErrInvalidRedirectURL) {
 			t.Errorf("Redirect error = %v, want ErrInvalidRedirectURL", err)
 		}

--- a/handle_test.go
+++ b/handle_test.go
@@ -3290,6 +3290,10 @@ func TestRedirect_RelativeBranch(t *testing.T) {
 		if rec.Code != http.StatusSeeOther {
 			t.Errorf("code = %d, want %d", rec.Code, http.StatusSeeOther)
 		}
+		// The redirected flag must be set so mount.go skips the PRG re-render.
+		if ctx.redirected == nil || !*ctx.redirected {
+			t.Error("redirected flag not set after relative redirect")
+		}
 		// POST mirrors http.Redirect: no courtesy body, no Content-Type.
 		if rec.Body.Len() != 0 {
 			t.Errorf("POST redirect body = %q, want empty", rec.Body.String())
@@ -3329,6 +3333,19 @@ func TestRedirect_RelativeBranch(t *testing.T) {
 		}
 		if body := rec.Body.String(); !strings.Contains(body, `<a href="dashboard">`) {
 			t.Errorf("GET redirect body = %q, want an <a href> courtesy link", body)
+		}
+	})
+
+	t.Run("HEAD sets Content-Type but writes no body", func(t *testing.T) {
+		ctx, rec := newCtx(http.MethodHead, "/apps/login/")
+		if err := ctx.Redirect("dashboard", http.StatusSeeOther); err != nil {
+			t.Fatalf("Redirect returned error: %v", err)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+			t.Errorf("HEAD redirect Content-Type = %q, want text/html; charset=utf-8", ct)
+		}
+		if rec.Body.Len() != 0 {
+			t.Errorf("HEAD redirect body = %q, want empty", rec.Body.String())
 		}
 	})
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -3251,7 +3251,7 @@ func TestIsValidRedirectURL(t *testing.T) {
 		{"./settings", true},
 		{"../list", true},
 		{"dashboard", true},
-		{"./foo:bar", true}, // colon in a path segment, escaped with leading ./
+		{"./foo:bar", true}, // colon in a path segment; leading ./ prevents scheme parsing
 		// Reject: protocol-relative and the backslash bypass variants.
 		{"//evil.com", false},
 		{"/\\evil.com", false},
@@ -3320,6 +3320,16 @@ func TestRedirect_RelativeBranch(t *testing.T) {
 		}
 		if got := rec.Header().Get("Location"); got != "dashboard" {
 			t.Errorf("Location = %q, want %q", got, "dashboard")
+		}
+	})
+
+	t.Run("dot target emitted raw", func(t *testing.T) {
+		ctx, rec := newCtx(http.MethodPost, "/apps/login/")
+		if err := ctx.Redirect(".", http.StatusSeeOther); err != nil {
+			t.Fatalf("Redirect returned error: %v", err)
+		}
+		if got := rec.Header().Get("Location"); got != "." {
+			t.Errorf("Location = %q, want %q", got, ".")
 		}
 	})
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -3162,3 +3162,159 @@ func TestIsReconnect_OnWSReconnect(t *testing.T) {
 		t.Errorf("WS reconnect: rc want true after state restored, got %q. Full msg: %s", v, string(reconnectMsg))
 	}
 }
+
+// ============================================================================
+// Relative redirect support (issue #434)
+// ============================================================================
+
+type reloadSelfController struct{}
+type reloadSelfState struct{ Hits int }
+
+func (reloadSelfController) Mount(s reloadSelfState, ctx *Context) (reloadSelfState, error) {
+	return s, nil
+}
+
+func (reloadSelfController) ReloadSelf(s reloadSelfState, ctx *Context) (reloadSelfState, error) {
+	s.Hits++
+	return s, ctx.Redirect("", http.StatusSeeOther)
+}
+
+// TestRedirect_RelativeSelf_UnderStripPrefix is the regression guard for
+// issue #434: a recipe mounted behind http.StripPrefix must be able to
+// redirect back to its own mount without being told the prefix. The recipe
+// calls ctx.Redirect("", 303); the framework emits a relative Location the
+// client resolves against the full (un-stripped) request URL, landing back at
+// the mount. Before the fix, "" failed validation, the action errored, and the
+// POST re-rendered in place with no redirect at all.
+func TestRedirect_RelativeSelf_UnderStripPrefix(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>hits {{.Hits}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	handler := tmpl.Handle(&reloadSelfController{}, AsState(&reloadSelfState{}))
+
+	const prefix = "/apps/login/"
+	mux := http.NewServeMux()
+	mux.Handle(prefix, http.StripPrefix(prefix, handler))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	var followed []*http.Request
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		followed = append(followed, req) // req.URL is the client-resolved Location
+		if len(via) >= 10 {
+			return errors.New("too many redirects")
+		}
+		return nil
+	}}
+
+	form := url.Values{}
+	form.Set("lvt-action", "ReloadSelf")
+	req, err := http.NewRequest("POST", ts.URL+prefix, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("NewRequest failed: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "text/html")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if len(followed) == 0 {
+		t.Fatal("expected a self-redirect, got none (relative Location not emitted)")
+	}
+	if got := followed[0].URL.Path; got != prefix {
+		t.Errorf("redirect resolved to %q, want %q", got, prefix)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("final status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestIsValidRedirectURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		// Accept: absolute-path and relative references (origin-confined).
+		{"/dashboard", true},
+		{"/", true},
+		{"", true},
+		{".", true},
+		{"./settings", true},
+		{"../list", true},
+		{"dashboard", true},
+		// Reject: protocol-relative and the backslash bypass variants.
+		{"//evil.com", false},
+		{"/\\evil.com", false},
+		{"\\\\evil.com", false},
+		{"\\/evil.com", false},
+		// Reject: anything carrying a scheme or host.
+		{"https://evil.com", false},
+		{"http://evil.com/path", false},
+		{"javascript:alert(1)", false},
+		{"mailto:x@example.com", false},
+		{"data:text/html,x", false},
+		{"foo:bar", false},
+	}
+	for _, tt := range tests {
+		if got := isValidRedirectURL(tt.url); got != tt.want {
+			t.Errorf("isValidRedirectURL(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestRedirect_RelativeBranch(t *testing.T) {
+	newCtx := func(reqPath string) (*Context, *httptest.ResponseRecorder) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", reqPath, nil)
+		return NewContext(req.Context(), "Act", nil).WithHTTP(rec, req), rec
+	}
+
+	t.Run("self reloads via ./<segment>", func(t *testing.T) {
+		ctx, rec := newCtx("/apps/login/")
+		if err := ctx.Redirect("", http.StatusSeeOther); err != nil {
+			t.Fatalf("Redirect returned error: %v", err)
+		}
+		if got := rec.Header().Get("Location"); got != "./" {
+			t.Errorf("Location = %q, want %q", got, "./")
+		}
+		if rec.Code != http.StatusSeeOther {
+			t.Errorf("code = %d, want %d", rec.Code, http.StatusSeeOther)
+		}
+	})
+
+	t.Run("self on a sub-path keeps the segment", func(t *testing.T) {
+		ctx, rec := newCtx("/foo")
+		if err := ctx.Redirect("", http.StatusSeeOther); err != nil {
+			t.Fatalf("Redirect returned error: %v", err)
+		}
+		if got := rec.Header().Get("Location"); got != "./foo" {
+			t.Errorf("Location = %q, want %q", got, "./foo")
+		}
+	})
+
+	t.Run("relative target emitted raw", func(t *testing.T) {
+		ctx, rec := newCtx("/apps/login/")
+		if err := ctx.Redirect("dashboard", http.StatusSeeOther); err != nil {
+			t.Fatalf("Redirect returned error: %v", err)
+		}
+		if got := rec.Header().Get("Location"); got != "dashboard" {
+			t.Errorf("Location = %q, want %q", got, "dashboard")
+		}
+	})
+
+	t.Run("cross-origin target rejected", func(t *testing.T) {
+		ctx, _ := newCtx("/apps/login/")
+		if err := ctx.Redirect("https://evil.com", http.StatusSeeOther); !errors.Is(err, ErrInvalidRedirectURL) {
+			t.Errorf("Redirect error = %v, want ErrInvalidRedirectURL", err)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

When a recipe handler is mounted at a non-root subpath via `http.StripPrefix("/apps/login/", handler)` — the standard pattern in `docs/cmd/site` and real apps — it cannot reliably redirect "back to its own mount." `http.StripPrefix` clones the request and rewrites `r.URL.Path` to the stripped value **outside** the framework, recording the trimmed prefix **nowhere** (no header, no `Pattern`). So the framework can't reconstruct the mount server-side, and `ctx.Redirect("/")` leaks past the StripPrefix boundary — login succeeds but the user lands on the wrong page.

The workaround in [docs#34](https://github.com/livetemplate/docs/pull/34) threads `mountPath` through `loginrecipe.Handler(mountPath, ...)` — caller-coupling for a recipe-internal concern.

## Fix (Option B from the issue)

The only entity that still knows the full mount URL is the **browser**, and a *relative* `Location` header is resolved by the client against its own effective request URI (`/apps/login/`), which never saw the strip.

- **`Context.Redirect`** now accepts relative references (`""`, `.`, `./x`, `../x`) in addition to absolute paths. Absolute paths keep flowing through `http.Redirect` **byte-for-byte unchanged**. Relative targets are emitted **raw** in the `Location` header (bypassing `http.Redirect`'s server-side resolution against the stripped path) so the browser resolves them against the full URL. The empty string is the canonical "reload self": it's translated to `"./<last-segment>"` so the `Location` is non-empty (an empty `Location` breaks clients) and resolves back to the current URL for both trailing-slash mounts and sub-paths.
- **`isValidRedirectURL`** is rewritten to parse with `net/url` and reject any target carrying a scheme or host, plus protocol-relative and **backslash-bypass** variants (`/\`, `\\`, `\/`) — closing a latent open-redirect the previous `//`-only check missed.

Recipes now one-line `return state, ctx.Redirect("", http.StatusSeeOther)` instead of threading a `mountPath` argument.

## Security & compatibility

- **No open-redirect risk.** Open-redirect safety hinges on the resolved *authority* (scheme+host), not the path. Per RFC 3986 §5.4, resolving any relative reference that doesn't begin with `//` keeps the base origin unchanged — relative paths are origin-confined by construction. The guard is strictly **stronger** than before (it now rejects the `\` bypass).
- **Non-breaking.** No existing caller passes a relative URL (they'd get `ErrInvalidRedirectURL` today), so the relative branch is purely additive. A relative `Location` is sanctioned by RFC 7231 §7.1.2.

## Tests

- `TestRedirect_RelativeSelf_UnderStripPrefix` — mounts a controller under `http.StripPrefix("/apps/login/", …)`, drives it with an `http.Client` that follows redirects (resolving the relative `Location` against the full URL, emulating a browser), and asserts the redirect lands back at `/apps/login/`. **Verified fail-before / pass-after.**
- `TestIsValidRedirectURL` — table covering accepted relative/absolute refs and rejected scheme/host/protocol-relative/backslash variants.
- `TestRedirect_RelativeBranch` — recorder-level unit tests for the `Location` header values.

## Out of scope

`mount.go`'s PRG fallback (~L1472) does `http.Redirect(w, r, r.URL.Path, 303)` with the stripped path — the same latent bug for non-JS progressive-enhancement clients. Tracked separately, not fixed here.

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)