### PR TITLE
feat(context): lvt.Redact template helper for Preview-mode field redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changes
+### Added
 
-- feat(context): lvt.Redact(name) template helper — renders a `[[name]]` placeholder
-  token for Preview-mode field redaction. Pairs with the client's `data-lvt-redact`
-  attribute: the server holds only the placeholder, the browser holds the real value.
-  Bracket grammar (not `<<name>>`) so the token survives both html/template's escaper
-  and the browser's innerHTML parser. Purely additive.
+- feat(context): lvt.Redact(name) template helper — emits an empty
+  `<span data-lvt-redact="name">` for Preview-mode field redaction. The client
+  fills it from browser localStorage; the server only ever holds the empty marked
+  element. The attribute is the trust signal (not a free text token), so
+  user-posted content can't trigger substitution. Purely additive.
 
 ## [v0.11.1] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to LiveTemplate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changes
+
+- feat(context): lvt.Redact(name) template helper — renders a `[[name]]` placeholder
+  token for Preview-mode field redaction. Pairs with the client's `data-lvt-redact`
+  attribute: the server holds only the placeholder, the browser holds the real value.
+  Bracket grammar (not `<<name>>`) so the token survives both html/template's escaper
+  and the browser's innerHTML parser. Purely additive.
+
 ## [v0.11.1] - 2026-05-23
 
 ### Changes

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -355,32 +355,21 @@ func (t *TemplateContext) UploadError(name string) string {
 	return errorResults[0].String()
 }
 
-// Redact returns the placeholder token for a redacted field as template.HTML.
+// Redact renders the "[[name]]" placeholder token for a Preview-mode redacted
+// field. The client substitutes the real value from localStorage before each
+// DOM patch, so the server only ever holds the placeholder. Use in HTML
+// *content* (e.g. {{.lvt.Redact "passport"}}); editable inputs use the
+// data-lvt-redact attribute instead, not this token in their value.
 //
-// Preview mode keeps sensitive values (passport numbers, SSNs, draft answers)
-// in the visitor's browser localStorage and never sends them to the server. The
-// server renders the placeholder token "[[name]]" wherever the real value would
-// appear; the TypeScript client substitutes the localStorage value for the token
-// before applying each DOM patch, so the user sees their own value and the server
-// only ever holds the placeholder.
+// The bracket grammar is deliberate: "<<name>>" is mangled by both
+// html/template's attribute escaper and the browser's innerHTML parser (which
+// reads "<name>" as a tag), whereas "[[name]]" survives every context.
 //
-// Use this in HTML *content* contexts to echo a redacted value back to the user —
-// e.g. <span>Passport on file: {{.lvt.Redact "passport"}}</span>.
-//
-// For the input the user edits, do NOT put the token in the value. Tag the
-// element instead so the client sets its .value *property* from localStorage
-// (which makes it a real, editable, submittable field) and swaps the outgoing
-// value for a redact sentinel:
-//
-//	<input name="passport" data-lvt-redact="passport">
-//
-// The "[[name]]" grammar is deliberately bracket-based, not "<<name>>": a token
-// containing angle brackets is mangled both by html/template's attribute escaper
-// and by the browser's innerHTML parser (it reads "<name>" as a tag). Brackets
-// survive every context — Go content, Go attribute, and client-side innerHTML —
-// so the client can scan text nodes for it reliably.
+// name is HTML-escaped (as ErrorTag/FlashTag do) since the template.HTML return
+// type bypasses the escaper — a non-literal name from user data would otherwise
+// be an injection vector.
 func (t *TemplateContext) Redact(name string) template.HTML {
-	return template.HTML("[[" + name + "]]")
+	return template.HTML("[[" + html.EscapeString(name) + "]]")
 }
 
 const (

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -355,13 +355,12 @@ func (t *TemplateContext) UploadError(name string) string {
 	return errorResults[0].String()
 }
 
-// Redact renders the "[[name]]" Preview-mode placeholder for content contexts
-// (the client substitutes the real value from localStorage; editable inputs use
-// the data-lvt-redact attribute instead). Bracket grammar, not "<<name>>":
-// angle brackets are mangled by html/template's escaper and the browser's
-// innerHTML parser, while brackets survive every context.
+// Redact emits a self-contained <span data-lvt-redact="name"> the client fills
+// from localStorage; the trust signal is the attribute, so no free-floating
+// token can be spoofed by user-posted content (editable inputs carry the same
+// attribute directly). Empty until the client hydrates it.
 func (t *TemplateContext) Redact(name string) template.HTML {
-	return template.HTML("[[" + html.EscapeString(name) + "]]")
+	return template.HTML(`<span data-lvt-redact="` + html.EscapeString(name) + `"></span>`)
 }
 
 const (

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -355,19 +355,11 @@ func (t *TemplateContext) UploadError(name string) string {
 	return errorResults[0].String()
 }
 
-// Redact renders the "[[name]]" placeholder token for a Preview-mode redacted
-// field. The client substitutes the real value from localStorage before each
-// DOM patch, so the server only ever holds the placeholder. Use in HTML
-// *content* (e.g. {{.lvt.Redact "passport"}}); editable inputs use the
-// data-lvt-redact attribute instead, not this token in their value.
-//
-// The bracket grammar is deliberate: "<<name>>" is mangled by both
-// html/template's attribute escaper and the browser's innerHTML parser (which
-// reads "<name>" as a tag), whereas "[[name]]" survives every context.
-//
-// name is HTML-escaped (as ErrorTag/FlashTag do) since the template.HTML return
-// type bypasses the escaper — a non-literal name from user data would otherwise
-// be an injection vector.
+// Redact renders the "[[name]]" Preview-mode placeholder for content contexts
+// (the client substitutes the real value from localStorage; editable inputs use
+// the data-lvt-redact attribute instead). Bracket grammar, not "<<name>>":
+// angle brackets are mangled by html/template's escaper and the browser's
+// innerHTML parser, while brackets survive every context.
 func (t *TemplateContext) Redact(name string) template.HTML {
 	return template.HTML("[[" + html.EscapeString(name) + "]]")
 }

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -355,6 +355,34 @@ func (t *TemplateContext) UploadError(name string) string {
 	return errorResults[0].String()
 }
 
+// Redact returns the placeholder token for a redacted field as template.HTML.
+//
+// Preview mode keeps sensitive values (passport numbers, SSNs, draft answers)
+// in the visitor's browser localStorage and never sends them to the server. The
+// server renders the placeholder token "[[name]]" wherever the real value would
+// appear; the TypeScript client substitutes the localStorage value for the token
+// before applying each DOM patch, so the user sees their own value and the server
+// only ever holds the placeholder.
+//
+// Use this in HTML *content* contexts to echo a redacted value back to the user —
+// e.g. <span>Passport on file: {{.lvt.Redact "passport"}}</span>.
+//
+// For the input the user edits, do NOT put the token in the value. Tag the
+// element instead so the client sets its .value *property* from localStorage
+// (which makes it a real, editable, submittable field) and swaps the outgoing
+// value for a redact sentinel:
+//
+//	<input name="passport" data-lvt-redact="passport">
+//
+// The "[[name]]" grammar is deliberately bracket-based, not "<<name>>": a token
+// containing angle brackets is mangled both by html/template's attribute escaper
+// and by the browser's innerHTML parser (it reads "<name>" as a tag). Brackets
+// survive every context — Go content, Go attribute, and client-side innerHTML —
+// so the client can scan text nodes for it reliably.
+func (t *TemplateContext) Redact(name string) template.HTML {
+	return template.HTML("[[" + name + "]]")
+}
+
 const (
 	// TemplateContextKey is the key used to access lvt context in templates
 	TemplateContextKey = "lvt"

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -255,28 +255,27 @@ func TestTemplateContext_Redact(t *testing.T) {
 		{
 			name:  "simple field",
 			field: "passport",
-			want:  "[[passport]]",
+			want:  `<span data-lvt-redact="passport"></span>`,
 		},
 		{
 			name:  "snake_case field",
 			field: "tax_id",
-			want:  "[[tax_id]]",
+			want:  `<span data-lvt-redact="tax_id"></span>`,
 		},
 		{
 			name:  "empty field name",
 			field: "",
-			want:  "[[]]",
+			want:  `<span data-lvt-redact=""></span>`,
 		},
 		{
 			name:  "HTML-special chars in name are escaped",
 			field: `x"><script>alert(1)</script>`,
-			want:  `[[x&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;]]`,
+			want:  `<span data-lvt-redact="x&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"></span>`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Redact is independent of messages; a zero context suffices.
 			ctx := NewTemplateContext(nil, false)
 			got := ctx.Redact(tt.field)
 			if got != tt.want {
@@ -286,33 +285,19 @@ func TestTemplateContext_Redact(t *testing.T) {
 	}
 }
 
-// TestTemplateContext_Redact_SurvivesEscaping guards the bracket grammar: the
-// "[[name]]" token must survive html/template's escaper in both content and
-// attribute contexts (the rejected "<<name>>" grammar did not).
-func TestTemplateContext_Redact_SurvivesEscaping(t *testing.T) {
+// TestTemplateContext_Redact_RendersAsElement guards that Redact emits a live
+// element in content context (not escaped to text), so the client can find it
+// by attribute. The name stays escaped inside the attribute.
+func TestTemplateContext_Redact_RendersAsElement(t *testing.T) {
 	ctx := NewTemplateContext(nil, false)
 	data := map[string]any{"lvt": ctx}
-
-	cases := []struct {
-		name string
-		tmpl string
-		want string
-	}{
-		{"content", `<span>{{.lvt.Redact "passport"}}</span>`, `<span>[[passport]]</span>`},
-		{"attribute", `<input value="{{.lvt.Redact "passport"}}">`, `<input value="[[passport]]">`},
+	tmpl := template.Must(template.New("c").Parse(`<p>{{.lvt.Redact "passport"}}</p>`))
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("execute: %v", err)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			tmpl := template.Must(template.New(tc.name).Parse(tc.tmpl))
-			var buf strings.Builder
-			if err := tmpl.Execute(&buf, data); err != nil {
-				t.Fatalf("execute: %v", err)
-			}
-			if buf.String() != tc.want {
-				t.Errorf("%s context: got %q, want %q — redact token must survive escaping",
-					tc.name, buf.String(), tc.want)
-			}
-		})
+	if got, want := buf.String(), `<p><span data-lvt-redact="passport"></span></p>`; got != want {
+		t.Errorf("got %q, want %q — Redact must render as a live element in content", got, want)
 	}
 }
 

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -246,6 +246,73 @@ func TestTemplateContext_ErrorTag(t *testing.T) {
 	}
 }
 
+func TestTemplateContext_Redact(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		want  template.HTML
+	}{
+		{
+			name:  "simple field",
+			field: "passport",
+			want:  "[[passport]]",
+		},
+		{
+			name:  "snake_case field",
+			field: "tax_id",
+			want:  "[[tax_id]]",
+		},
+		{
+			name:  "empty field name",
+			field: "",
+			want:  "[[]]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Redact is independent of messages; a zero context suffices.
+			ctx := NewTemplateContext(nil, false)
+			got := ctx.Redact(tt.field)
+			if got != tt.want {
+				t.Errorf("Redact(%q) = %q, want %q", tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTemplateContext_Redact_SurvivesEscaping locks in the property that drove
+// the bracket grammar: the "[[name]]" token must survive html/template's
+// context-aware escaper in BOTH content and attribute contexts. The earlier
+// "<<name>>" grammar failed here — angle brackets are escaped in attributes and
+// reparsed as a tag — which is why brackets were chosen. If a future Go release
+// changes bracket handling, this test flags it before it breaks Preview mode.
+func TestTemplateContext_Redact_SurvivesEscaping(t *testing.T) {
+	ctx := NewTemplateContext(nil, false)
+	data := map[string]any{"lvt": ctx}
+
+	cases := map[string]struct {
+		tmpl string
+		want string
+	}{
+		"content":   {`<span>{{.lvt.Redact "passport"}}</span>`, `<span>[[passport]]</span>`},
+		"attribute": {`<input value="{{.lvt.Redact "passport"}}">`, `<input value="[[passport]]">`},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tmpl := template.Must(template.New(name).Parse(tc.tmpl))
+			var buf strings.Builder
+			if err := tmpl.Execute(&buf, data); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if buf.String() != tc.want {
+				t.Errorf("%s context: got %q, want %q — redact token must survive escaping",
+					name, buf.String(), tc.want)
+			}
+		})
+	}
+}
+
 func TestTemplateContext_AriaInvalid(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -268,9 +268,6 @@ func TestTemplateContext_Redact(t *testing.T) {
 			want:  "[[]]",
 		},
 		{
-			// The template.HTML return type bypasses html/template's escaper,
-			// so a non-literal name from user data must be escaped here or it
-			// becomes an injection vector. Locks in the html.EscapeString call.
 			name:  "HTML-special chars in name are escaped",
 			field: `x"><script>alert(1)</script>`,
 			want:  `[[x&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;]]`,
@@ -289,33 +286,31 @@ func TestTemplateContext_Redact(t *testing.T) {
 	}
 }
 
-// TestTemplateContext_Redact_SurvivesEscaping locks in the property that drove
-// the bracket grammar: the "[[name]]" token must survive html/template's
-// context-aware escaper in BOTH content and attribute contexts. The earlier
-// "<<name>>" grammar failed here — angle brackets are escaped in attributes and
-// reparsed as a tag — which is why brackets were chosen. If a future Go release
-// changes bracket handling, this test flags it before it breaks Preview mode.
+// TestTemplateContext_Redact_SurvivesEscaping guards the bracket grammar: the
+// "[[name]]" token must survive html/template's escaper in both content and
+// attribute contexts (the rejected "<<name>>" grammar did not).
 func TestTemplateContext_Redact_SurvivesEscaping(t *testing.T) {
 	ctx := NewTemplateContext(nil, false)
 	data := map[string]any{"lvt": ctx}
 
-	cases := map[string]struct {
+	cases := []struct {
+		name string
 		tmpl string
 		want string
 	}{
-		"content":   {`<span>{{.lvt.Redact "passport"}}</span>`, `<span>[[passport]]</span>`},
-		"attribute": {`<input value="{{.lvt.Redact "passport"}}">`, `<input value="[[passport]]">`},
+		{"content", `<span>{{.lvt.Redact "passport"}}</span>`, `<span>[[passport]]</span>`},
+		{"attribute", `<input value="{{.lvt.Redact "passport"}}">`, `<input value="[[passport]]">`},
 	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			tmpl := template.Must(template.New(name).Parse(tc.tmpl))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := template.Must(template.New(tc.name).Parse(tc.tmpl))
 			var buf strings.Builder
 			if err := tmpl.Execute(&buf, data); err != nil {
 				t.Fatalf("execute: %v", err)
 			}
 			if buf.String() != tc.want {
 				t.Errorf("%s context: got %q, want %q — redact token must survive escaping",
-					name, buf.String(), tc.want)
+					tc.name, buf.String(), tc.want)
 			}
 		})
 	}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -267,6 +267,14 @@ func TestTemplateContext_Redact(t *testing.T) {
 			field: "",
 			want:  "[[]]",
 		},
+		{
+			// The template.HTML return type bypasses html/template's escaper,
+			// so a non-literal name from user data must be escaped here or it
+			// becomes an injection vector. Locks in the html.EscapeString call.
+			name:  "HTML-special chars in name are escaped",
+			field: `x"><script>alert(1)</script>`,
+			want:  `[[x&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;]]`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Adds `(*TemplateContext).Redact(name string) template.HTML`, callable in templates as `{{.lvt.Redact "field"}}`. It emits an empty `<span data-lvt-redact="name"></span>` that the livetemplate TypeScript client fills from browser `localStorage` before painting — so an app can keep sensitive field values (passport numbers, SSNs, draft answers) in the visitor's browser and never send them to the server.

Pairs with the client-side `data-lvt-redact` handling (companion PR `livetemplate/client#127`).

## Why a marked element, not a text token

An earlier iteration emitted a free-floating `[[name]]` text token that the client substituted via a DOM text scan. Review found a cross-session injection risk: attacker-posted content containing the token string could trigger substitution of the *viewing* user's stored value. The fix is to make the **DOM attribute the trust signal** — `Redact` emits `<span data-lvt-redact="name">`, and the client only ever fills elements carrying that attribute. User-posted text can't carry it, so it can't trigger substitution. (This also removed the whole `<<name>>`-vs-`[[name]]` escaping question — there's no text token anymore.)

## Security / correctness

- `name` is HTML-escaped via `html.EscapeString` before building the `template.HTML` (the return type bypasses the escaper) — matches the `ErrorTag`/`FlashTag` pattern. `TestTemplateContext_Redact` includes an `x"><script>…` case proving the attribute can't be broken out of.
- `Redact` is a content-context helper; it lives alongside `ErrorTag`/`AriaInvalid`/`FlashTag` in the `.lvt` family.

## Scope

Purely additive. No new `Config` option, protocol message, or `SessionStore` backend. Apps that don't use the helper are unaffected.

## Tests

- `TestTemplateContext_Redact` — element output (simple / snake_case / empty / HTML-special-chars-escaped).
- `TestTemplateContext_Redact_RendersAsElement` — renders as a live element in content context (not escaped to text).
- Full `go test ./...` green (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)