### PR TITLE
docs: compare against templ + htmx, tighten the standard-HTML claim

### DIFF
--- a/docs/guides/standard-html-reactivity.md
+++ b/docs/guides/standard-html-reactivity.md
@@ -95,18 +95,23 @@ See [PubSub Reference](../references/pubsub.md) for details.
 
 ## Comparison with Other Frameworks
 
-Every major reactive framework requires custom attributes on HTML elements. LiveTemplate is unique in making standard HTML reactive without modification.
+Every major reactive framework makes HTML reactive by adding a layer on top of it — custom attributes (`hx-*`, `wire:*`, `phx-*`) or a templating DSL. LiveTemplate keeps the HTML standard and moves the reactivity to the server: you add an `lvt-*` attribute only when the behavior is something HTML itself cannot define (timing, keyboard shortcuts, reactive DOM), never to make ordinary HTML reactive. The boundary is *what HTML can express*, not *how common the case is*.
 
-| Framework | Form markup required | Custom attributes |
-|-----------|---------------------|-------------------|
-| **htmx** | `<form hx-post="/todos" hx-target="#list">` | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
-| **Laravel Livewire** | `<form wire:submit="add">` | `wire:submit`, `wire:model`, `wire:click` |
-| **Phoenix LiveView** | `<form phx-submit="add">` | `phx-submit`, `phx-click`, `phx-change` |
-| **LiveTemplate** | `<form method="POST">` | None for standard interactions |
+| Framework | How you author markup | Attributes to make it reactive |
+|-----------|----------------------|--------------------------------|
+| **htmx** | Plain HTML | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
+| **templ + htmx** | A Go DSL (`templ` components) | `hx-post`, `hx-target`, `hx-swap`, … (htmx still does the interactivity) |
+| **Laravel Livewire** | Blade templates | `wire:submit`, `wire:model`, `wire:click` |
+| **Phoenix LiveView** | HEEx templates | `phx-submit`, `phx-click`, `phx-change` |
+| **LiveTemplate** | Standard `html/template` | None for standard interactions; `lvt-*` only for what HTML can't express |
 
 ### htmx
 
 htmx extends HTML with `hx-*` attributes for AJAX interactions. A form without `hx-post` submits normally (full page reload). Every interactive element needs explicit `hx-*` attributes.
+
+### templ + htmx
+
+[templ](https://templ.guide) is a Go DSL for authoring and composing HTML as type-safe Go components — a popular alternative to `html/template`. It is a *templating* layer, not an interactivity layer, so it is commonly paired with htmx for reactivity. That means two things to learn and adopt: a new markup language **and** `hx-*` attributes on the rendered HTML. LiveTemplate takes the opposite trade: it stays on Go's standard `html/template` (no new DSL) and provides the reactivity itself, so composability comes from the model — partials, per-session state, and one render-and-diff pipeline — rather than from a language. If you specifically want compile-time-checked, function-composed markup, templ is the better fit; if you want standard HTML to be reactive without a DSL or `hx-*` wiring, that's LiveTemplate.
 
 ### Laravel Livewire
 

--- a/docs/guides/standard-html-reactivity.md
+++ b/docs/guides/standard-html-reactivity.md
@@ -103,7 +103,7 @@ The boundary is *what HTML can express*, not *how common the case is*.
 
 | Framework | Markup for a form action | Attributes to make it reactive |
 |-----------|--------------------------|--------------------------------|
-| **htmx** | `<form hx-post="/todos">` (plain HTML) | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
+| **htmx** | `<form hx-post="/todos">` | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
 | **templ + htmx** | a `templ` component (Go DSL) rendering `<form hx-post="/todos">` | `hx-post`, `hx-target`, … (htmx still does the interactivity) |
 | **Laravel Livewire** | `<form wire:submit="add">` (Blade) | `wire:submit`, `wire:model`, `wire:click` |
 | **Phoenix LiveView** | `<form phx-submit="add">` (HEEx) | `phx-submit`, `phx-click`, `phx-change` |
@@ -115,7 +115,9 @@ htmx extends HTML with `hx-*` attributes for AJAX interactions. A form without `
 
 ### templ + htmx
 
-[templ](https://templ.guide) is a Go DSL for authoring and composing HTML as type-safe Go components — a popular alternative to `html/template`. It is a *templating* layer, not an interactivity layer, so it is commonly paired with htmx for reactivity. That means two things to learn and adopt: a new markup language **and** `hx-*` attributes on the rendered HTML. LiveTemplate takes the opposite trade: it stays on Go's standard `html/template` (no new DSL) and provides the reactivity itself. You compose with what `html/template` already gives you — partials and the `{{template}}` action — plus per-session state and one render-and-diff pipeline, rather than adopting a new language for either authoring or interactivity. If you specifically want compile-time-checked, function-composed markup, templ is the better fit; if you want standard HTML to be reactive without a DSL or `hx-*` wiring, that's LiveTemplate.
+[templ](https://templ.guide) is a Go DSL for authoring and composing HTML as type-safe Go components — a popular alternative to `html/template`. It is a *templating* layer, not an interactivity layer, so it is commonly paired with htmx for reactivity. That means two things to learn and adopt: a new markup language **and** `hx-*` attributes on the rendered HTML.
+
+LiveTemplate takes the opposite trade: it stays on Go's standard `html/template` (no new DSL) and provides the reactivity itself. You compose with what `html/template` already gives you — partials and the `{{template}}` action — plus per-session state and one render-and-diff pipeline, rather than adopting a new language for either authoring or interactivity. If you specifically want compile-time-checked, function-composed markup, templ is the better fit; if you want standard HTML to be reactive without a DSL or `hx-*` wiring, that's LiveTemplate.
 
 ### Laravel Livewire
 

--- a/docs/guides/standard-html-reactivity.md
+++ b/docs/guides/standard-html-reactivity.md
@@ -104,7 +104,7 @@ The boundary is *what HTML can express*, not *how common the case is*.
 | Framework | Markup for a form action | Attributes to make it reactive |
 |-----------|--------------------------|--------------------------------|
 | **htmx** | `<form hx-post="/todos">` | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
-| **templ + htmx** | a `templ` component (Go DSL) rendering `<form hx-post="/todos">` | `hx-post`, `hx-target`, … (htmx still does the interactivity) |
+| **templ + htmx** | `templ form()` → `<form hx-post="/todos">` (a Go DSL) | `hx-post`, `hx-target`, … (htmx still does the interactivity) |
 | **Laravel Livewire** | `<form wire:submit="add">` (Blade) | `wire:submit`, `wire:model`, `wire:click` |
 | **Phoenix LiveView** | `<form phx-submit="add">` (HEEx) | `phx-submit`, `phx-click`, `phx-change` |
 | **LiveTemplate** | `<form method="POST">` (standard `html/template`) | None for standard interactions; `lvt-*` only for what HTML can't express |

--- a/docs/guides/standard-html-reactivity.md
+++ b/docs/guides/standard-html-reactivity.md
@@ -95,15 +95,19 @@ See [PubSub Reference](../references/pubsub.md) for details.
 
 ## Comparison with Other Frameworks
 
-Every major reactive framework makes HTML reactive by adding a layer on top of it — custom attributes (`hx-*`, `wire:*`, `phx-*`) or a templating DSL. LiveTemplate keeps the HTML standard and moves the reactivity to the server: you add an `lvt-*` attribute only when the behavior is something HTML itself cannot define (timing, keyboard shortcuts, reactive DOM), never to make ordinary HTML reactive. The boundary is *what HTML can express*, not *how common the case is*.
+Every major reactive framework makes HTML reactive by adding a layer on top of it — custom attributes (`hx-*`, `wire:*`, `phx-*`) or a templating DSL.
 
-| Framework | How you author markup | Attributes to make it reactive |
-|-----------|----------------------|--------------------------------|
-| **htmx** | Plain HTML | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
-| **templ + htmx** | A Go DSL (`templ` components) | `hx-post`, `hx-target`, `hx-swap`, … (htmx still does the interactivity) |
-| **Laravel Livewire** | Blade templates | `wire:submit`, `wire:model`, `wire:click` |
-| **Phoenix LiveView** | HEEx templates | `phx-submit`, `phx-click`, `phx-change` |
-| **LiveTemplate** | Standard `html/template` | None for standard interactions; `lvt-*` only for what HTML can't express |
+LiveTemplate keeps the HTML standard and moves the reactivity to the server. You add an `lvt-*` attribute only when the behavior is something HTML itself cannot define — timing, keyboard shortcuts, reactive DOM — never to make ordinary HTML reactive.
+
+The boundary is *what HTML can express*, not *how common the case is*.
+
+| Framework | Markup for a form action | Attributes to make it reactive |
+|-----------|--------------------------|--------------------------------|
+| **htmx** | `<form hx-post="/todos">` (plain HTML) | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
+| **templ + htmx** | a `templ` component (Go DSL) rendering `<form hx-post="/todos">` | `hx-post`, `hx-target`, … (htmx still does the interactivity) |
+| **Laravel Livewire** | `<form wire:submit="add">` (Blade) | `wire:submit`, `wire:model`, `wire:click` |
+| **Phoenix LiveView** | `<form phx-submit="add">` (HEEx) | `phx-submit`, `phx-click`, `phx-change` |
+| **LiveTemplate** | `<form method="POST">` (standard `html/template`) | None for standard interactions; `lvt-*` only for what HTML can't express |
 
 ### htmx
 
@@ -111,7 +115,7 @@ htmx extends HTML with `hx-*` attributes for AJAX interactions. A form without `
 
 ### templ + htmx
 
-[templ](https://templ.guide) is a Go DSL for authoring and composing HTML as type-safe Go components — a popular alternative to `html/template`. It is a *templating* layer, not an interactivity layer, so it is commonly paired with htmx for reactivity. That means two things to learn and adopt: a new markup language **and** `hx-*` attributes on the rendered HTML. LiveTemplate takes the opposite trade: it stays on Go's standard `html/template` (no new DSL) and provides the reactivity itself, so composability comes from the model — partials, per-session state, and one render-and-diff pipeline — rather than from a language. If you specifically want compile-time-checked, function-composed markup, templ is the better fit; if you want standard HTML to be reactive without a DSL or `hx-*` wiring, that's LiveTemplate.
+[templ](https://templ.guide) is a Go DSL for authoring and composing HTML as type-safe Go components — a popular alternative to `html/template`. It is a *templating* layer, not an interactivity layer, so it is commonly paired with htmx for reactivity. That means two things to learn and adopt: a new markup language **and** `hx-*` attributes on the rendered HTML. LiveTemplate takes the opposite trade: it stays on Go's standard `html/template` (no new DSL) and provides the reactivity itself. You compose with what `html/template` already gives you — partials and the `{{template}}` action — plus per-session state and one render-and-diff pipeline, rather than adopting a new language for either authoring or interactivity. If you specifically want compile-time-checked, function-composed markup, templ is the better fit; if you want standard HTML to be reactive without a DSL or `hx-*` wiring, that's LiveTemplate.
 
 ### Laravel Livewire
 

--- a/docs/guides/standard-html-reactivity.md
+++ b/docs/guides/standard-html-reactivity.md
@@ -104,7 +104,7 @@ The boundary is *what HTML can express*, not *how common the case is*.
 | Framework | Markup for a form action | Attributes to make it reactive |
 |-----------|--------------------------|--------------------------------|
 | **htmx** | `<form hx-post="/todos">` | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
-| **templ + htmx** | `<form hx-post="/todos">` (authored in templ, a Go DSL) | `hx-post`, `hx-target`, … (htmx still does the interactivity) |
+| **templ + htmx** | `<form hx-post="/todos">` (authored in templ, a Go DSL) | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
 | **Laravel Livewire** | `<form wire:submit="add">` (Blade) | `wire:submit`, `wire:model`, `wire:click` |
 | **Phoenix LiveView** | `<form phx-submit="add">` (HEEx) | `phx-submit`, `phx-click`, `phx-change` |
 | **LiveTemplate** | `<form method="POST">` (standard `html/template`) | None for standard interactions; `lvt-*` only for what HTML can't express |

--- a/docs/guides/standard-html-reactivity.md
+++ b/docs/guides/standard-html-reactivity.md
@@ -104,7 +104,7 @@ The boundary is *what HTML can express*, not *how common the case is*.
 | Framework | Markup for a form action | Attributes to make it reactive |
 |-----------|--------------------------|--------------------------------|
 | **htmx** | `<form hx-post="/todos">` | `hx-post`, `hx-target`, `hx-swap`, `hx-trigger` |
-| **templ + htmx** | `templ form()` → `<form hx-post="/todos">` (a Go DSL) | `hx-post`, `hx-target`, … (htmx still does the interactivity) |
+| **templ + htmx** | `<form hx-post="/todos">` (authored in templ, a Go DSL) | `hx-post`, `hx-target`, … (htmx still does the interactivity) |
 | **Laravel Livewire** | `<form wire:submit="add">` (Blade) | `wire:submit`, `wire:model`, `wire:click` |
 | **Phoenix LiveView** | `<form phx-submit="add">` (HEEx) | `phx-submit`, `phx-click`, `phx-change` |
 | **LiveTemplate** | `<form method="POST">` (standard `html/template`) | None for standard interactions; `lvt-*` only for what HTML can't express |


### PR DESCRIPTION
Part of surfacing LiveTemplate's core differentiator (standard HTML + one reactive model) more prominently in the docs.

- Adds a **templ + htmx** row to the framework comparison in the Standard HTML Reactivity guide: templ is a Go DSL to author markup, still paired with `hx-*` attributes for interactivity — two things to adopt, vs LiveTemplate's standard `html/template` + no attributes for common cases.
- Tightens the absolute "unique in making standard HTML reactive without modification" claim to its **defensible boundary**: standard HTML defines the interaction; an `lvt-*` attribute appears only for behaviour HTML itself cannot express (timing, keyboard, reactive DOM). The boundary is *what HTML can express*, not *how common the case is* — which survives scrutiny against examples like `todos` that legitimately use `lvt-*`.

Companion docs-site changes (home hero, mental model, cross-user seat-picker recipe) land in livetemplate/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)