### PR TITLE
feat(upload): four upload modes — Direct/Proxied/Volume/Preview (#447)

### DIFF
--- a/docs/references/uploads.md
+++ b/docs/references/uploads.md
@@ -62,6 +62,12 @@ distinct sentinel, not `io.EOF`) so a truncated stream aborts instead of
 committing a partial object. Because nothing stages to disk, a pure-Proxied app
 needs no writable working directory and never creates `.uploads`.
 
+> **Note:** Adding a Proxied field routes **every** multipart POST to that
+> handler through the streaming path, including requests carrying only Volume
+> fields. Those Volume parts are staged to disk as usual (equivalent to the
+> default path), so mixing modes on one handler is fine — just be aware the
+> coupling exists.
+
 ### Preview — file stays on the device
 
 `Mode: UploadModePreview` keeps the file in the browser; only its metadata

--- a/docs/references/uploads.md
+++ b/docs/references/uploads.md
@@ -2,11 +2,80 @@
 
 ## Overview
 
-LiveTemplate provides a file upload system with support for:
-- **WebSocket chunked uploads** - Large file uploads with real-time progress
-- **External uploads** - Direct uploads to S3/cloud storage via presigned URLs
-- **Progress tracking** - Real-time upload progress with validation
-- **Template helpers** - Display upload state in your templates
+LiveTemplate provides a file upload system with four **modes**, chosen purely by
+server config on an otherwise identical `<input lvt-upload>`:
+
+| Mode | Bytes path | Server sees bytes? | Local disk? | Config |
+|------|------------|--------------------|-------------|--------|
+| **Volume** *(default)* | browser → server → retained directory | yes | yes | `Mode: UploadModeVolume, Dir: "..."` |
+| **Direct** | browser → cloud via presigned URL | no | no | `Mode: UploadModeDirect, External: presigner` |
+| **Proxied** | browser → server → remote storage, streamed | yes | **no** | `Mode: UploadModeProxied` + `OnUpload` |
+| **Preview** | stays on the device | metadata only | no | `Mode: UploadModePreview` |
+
+```go
+livetemplate.WithUpload("avatar", livetemplate.UploadConfig{
+    Mode:        livetemplate.UploadModeProxied, // stream to remote storage, zero disk
+    Accept:      []string{"image/*"},
+    MaxFileSize: 5 << 20,
+})
+```
+
+The mode is delivered to the client per-entry, so the same markup and the same
+`ctx.GetCompletedUploads(name)` consumption work across every mode. See
+[Upload modes](#upload-modes) below and the `upload-modes` example.
+
+## Upload modes
+
+### Volume — staged to the server's disk
+
+`Mode: UploadModeVolume` (the default) stages bytes to the server's filesystem.
+With `Dir` set the file is **retained** there and the app owns its lifecycle; with
+no `Dir` it stages to a temp dir that is cleaned up when the connection closes
+(the legacy stage-then-move pattern). Read the path from `entry.TempPath`.
+
+### Direct — browser uploads straight to cloud storage
+
+`Mode: UploadModeDirect` with an `External` presigner has the browser PUT bytes
+straight to S3/GCS/etc. via a presigned URL — they never touch the server. Read
+the reference from `entry.ExternalRef`. (Setting `External` without an explicit
+`Mode` is treated as Direct for backward compatibility.)
+
+### Proxied — stream through the server with zero local disk
+
+`Mode: UploadModeProxied` streams the in-flight bytes straight to a handler with
+no local-disk staging — ideal for forwarding to remote object storage. The
+controller implements `UploadStreamer`:
+
+```go
+func (c *Controller) OnUpload(part *livetemplate.UploadPart, ctx *livetemplate.Context) error {
+    ref, err := myBackend.Put(ctx, part.Filename, part) // part is an io.Reader
+    if err != nil {
+        return err
+    }
+    part.SetResult(ref) // surfaced via GetCompletedUploads(...).ExternalRef
+    return nil
+}
+```
+
+The reader enforces `MaxFileSize` mid-stream, returning `ErrUploadTooLarge` (a
+distinct sentinel, not `io.EOF`) so a truncated stream aborts instead of
+committing a partial object. Because nothing stages to disk, a pure-Proxied app
+needs no writable working directory and never creates `.uploads`.
+
+### Preview — file stays on the device
+
+`Mode: UploadModePreview` keeps the file in the browser; only its metadata
+(name/type/size) reaches the server. Render the on-device preview with the
+template helper:
+
+```html
+<input type="file" lvt-upload="draft" accept="image/*" />
+{{.lvt.UploadPreview "draft"}}
+```
+
+The client fills the placeholder from `URL.createObjectURL` and never uploads the
+bytes. The server records a metadata-only entry (`entry.Preview == true`, no
+`TempPath`/`ExternalRef`) readable via `GetCompletedUploads`.
 
 ## Quick Start
 

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -363,6 +363,15 @@ func (t *TemplateContext) Redact(name string) template.HTML {
 	return template.HTML(`<span data-lvt-redact="` + html.EscapeString(name) + `"></span>`)
 }
 
+// UploadPreview emits an <img data-lvt-upload-preview="name"> placeholder for a
+// Preview-mode upload field. The client fills its src from a local object URL
+// (URL.createObjectURL) when a file is selected, so the image previews
+// on-device without the bytes ever being uploaded. Empty until the client
+// attaches the blob.
+func (t *TemplateContext) UploadPreview(name string) template.HTML {
+	return template.HTML(`<img data-lvt-upload-preview="` + html.EscapeString(name) + `" alt="" />`)
+}
+
 const (
 	// TemplateContextKey is the key used to access lvt context in templates
 	TemplateContextKey = "lvt"

--- a/internal/send/message.go
+++ b/internal/send/message.go
@@ -90,6 +90,63 @@ func detectSubmitButtonName(values map[string][]string, actionFields map[string]
 	return candidate
 }
 
+// BuildActionFromValues reconstructs an ActionMessage from already-collected
+// multipart value parts (form key -> values). It mirrors parseMultipartForm's
+// value handling and is used by the streaming-upload path, which reads the body
+// via MultipartReader (so r.MultipartForm is never populated) and must rebuild
+// the action message from the value parts it buffered during iteration.
+func BuildActionFromValues(values map[string][]string) ActionMessage {
+	var msg ActionMessage
+
+	first := func(key string) string {
+		if vs, ok := values[key]; ok && len(vs) > 0 {
+			return vs[0]
+		}
+		return ""
+	}
+
+	msg.Action = first("lvt-action")
+	msg.Submitter = first("lvt-submitter")
+	resolveSubmitterFallback(&msg)
+
+	if dataStr := first("data"); dataStr != "" {
+		var data map[string]interface{}
+		if err := jsonutil.API.Unmarshal([]byte(dataStr), &data); err == nil {
+			msg.Data = data
+			return msg
+		}
+	}
+
+	actionFields := map[string]bool{"lvt-action": true, "lvt-submitter": true, "data": true}
+	if msg.Action == "" {
+		if name := detectSubmitButtonName(values, actionFields); name != "" {
+			msg.Action = name
+			actionFields[name] = true
+		}
+	}
+
+	msg.Data = make(map[string]interface{})
+	for key, vs := range values {
+		if actionFields[key] {
+			continue
+		}
+		switch len(vs) {
+		case 0:
+			// skip
+		case 1:
+			msg.Data[key] = vs[0]
+		default:
+			interfaceSlice := make([]interface{}, len(vs))
+			for i, v := range vs {
+				interfaceSlice[i] = v
+			}
+			msg.Data[key] = interfaceSlice
+		}
+	}
+
+	return msg
+}
+
 // parseMultipartForm parses action from multipart/form-data (file uploads).
 // Supports two data formats:
 //  1. JSON-encoded "data" form field (client library sends this)

--- a/internal/upload/protocol.go
+++ b/internal/upload/protocol.go
@@ -35,7 +35,8 @@ type UploadEntryInfo struct {
 	Valid      bool                `json:"valid"`              // Whether entry passed initial validation
 	Error      string              `json:"error"`              // Error message if validation failed
 	AutoUpload bool                `json:"auto_upload"`        // Whether to auto-upload on file selection
-	External   *ExternalUploadMeta `json:"external,omitempty"` // Presigned upload metadata (if External configured)
+	Mode       string              `json:"mode"`               // Upload mode: "volume" | "direct" | "proxied" | "preview"
+	External   *ExternalUploadMeta `json:"external,omitempty"` // Presigned upload metadata (Direct mode only)
 }
 
 // ExternalUploadMeta contains presigned upload configuration for external storage.
@@ -94,6 +95,18 @@ type CancelUploadMessage struct {
 type CancelUploadResponse struct {
 	EntryID string `json:"entry_id"` // Entry that was cancelled
 	Success bool   `json:"success"`  // Whether cancellation succeeded
+}
+
+// IsUploadStart reports whether a JSON message body is an upload_start action.
+// Used by the HTTP handshake fallback to peek the action without fully parsing.
+func IsUploadStart(data []byte) bool {
+	var probe struct {
+		Action string `json:"action"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+	return probe.Action == "upload_start"
 }
 
 // ParseUploadStartMessage parses an upload_start action from JSON.

--- a/internal/upload/protocol.go
+++ b/internal/upload/protocol.go
@@ -97,18 +97,6 @@ type CancelUploadResponse struct {
 	Success bool   `json:"success"`  // Whether cancellation succeeded
 }
 
-// IsUploadStart reports whether a JSON message body is an upload_start action.
-// Used by the HTTP handshake fallback to peek the action without fully parsing.
-func IsUploadStart(data []byte) bool {
-	var probe struct {
-		Action string `json:"action"`
-	}
-	if err := json.Unmarshal(data, &probe); err != nil {
-		return false
-	}
-	return probe.Action == "upload_start"
-}
-
 // ParseUploadStartMessage parses an upload_start action from JSON.
 func ParseUploadStartMessage(data []byte) (*UploadStartMessage, error) {
 	var msg UploadStartMessage

--- a/internal/upload/streaming.go
+++ b/internal/upload/streaming.go
@@ -73,10 +73,11 @@ func StreamMultipart(
 	return values, nil
 }
 
-// LimitGuard wraps a reader and enforces a maximum byte count mid-stream. When
-// the limit is exceeded it returns uploadtypes.ErrUploadTooLarge instead of
-// io.EOF, so a streaming copy to remote storage aborts rather than silently
-// committing a truncated object. A max of 0 means unlimited.
+// LimitGuard wraps a reader and enforces a maximum byte count mid-stream. It
+// passes through at most max bytes; once the source is found to exceed max it
+// returns uploadtypes.ErrUploadTooLarge (with zero bytes) instead of io.EOF, so
+// a streaming copy to remote storage aborts WITHOUT first writing the oversize
+// bytes — no truncated/partial object is committed. A max of 0 means unlimited.
 type LimitGuard struct {
 	r   io.Reader
 	n   int64
@@ -84,11 +85,34 @@ type LimitGuard struct {
 }
 
 func (l *LimitGuard) Read(p []byte) (int, error) {
+	if l.max <= 0 {
+		n, err := l.r.Read(p)
+		l.n += int64(n)
+		return n, err
+	}
+
+	remaining := l.max - l.n
+	if remaining <= 0 {
+		// We've already delivered max bytes. Peek one more to tell "exactly max"
+		// (EOF → success) from "more than max" (ErrUploadTooLarge) without ever
+		// handing the oversize byte to the consumer.
+		var probe [1]byte
+		m, err := l.r.Read(probe[:])
+		if m > 0 {
+			return 0, uploadtypes.ErrUploadTooLarge
+		}
+		if err == io.EOF {
+			return 0, io.EOF
+		}
+		return 0, err
+	}
+
+	// Never read more than the remaining budget so the consumer sees ≤ max bytes.
+	if int64(len(p)) > remaining {
+		p = p[:remaining]
+	}
 	n, err := l.r.Read(p)
 	l.n += int64(n)
-	if l.max > 0 && l.n > l.max {
-		return n, uploadtypes.ErrUploadTooLarge
-	}
 	return n, err
 }
 

--- a/internal/upload/streaming.go
+++ b/internal/upload/streaming.go
@@ -39,7 +39,7 @@ func StreamMultipart(
 	values := make(map[string][]string)
 	for {
 		part, err := mr.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/upload/streaming.go
+++ b/internal/upload/streaming.go
@@ -67,8 +67,9 @@ func StreamMultipart(
 				return values, err
 			}
 		}
-		// A non-streaming file part with no staged sink is intentionally dropped
-		// (e.g. Preview/Direct fields never send bytes here).
+		// A non-streaming file part with no staged sink is intentionally dropped.
+		// In practice this doesn't fire: Direct fields POST bytes straight to
+		// cloud, and Preview files stay on-device, so neither appears here.
 	}
 
 	return values, nil

--- a/internal/upload/streaming.go
+++ b/internal/upload/streaming.go
@@ -1,6 +1,7 @@
 package upload
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -95,16 +96,23 @@ func (l *LimitGuard) Read(p []byte) (int, error) {
 	if remaining <= 0 {
 		// We've already delivered max bytes. Peek one more to tell "exactly max"
 		// (EOF → success) from "more than max" (ErrUploadTooLarge) without ever
-		// handing the oversize byte to the consumer.
+		// handing the oversize byte to the consumer. Loop to tolerate a reader
+		// that returns (0, nil) (allowed by io.Reader); returning (0, nil) here
+		// would spin io.Copy.
 		var probe [1]byte
-		m, err := l.r.Read(probe[:])
-		if m > 0 {
-			return 0, uploadtypes.ErrUploadTooLarge
+		for {
+			m, err := l.r.Read(probe[:])
+			if m > 0 {
+				return 0, uploadtypes.ErrUploadTooLarge
+			}
+			if errors.Is(err, io.EOF) {
+				return 0, io.EOF
+			}
+			if err != nil {
+				return 0, err
+			}
+			// (0, nil): no data yet, not EOF — retry the probe.
 		}
-		if err == io.EOF {
-			return 0, io.EOF
-		}
-		return 0, err
 	}
 
 	// Never read more than the remaining budget so the consumer sees ≤ max bytes.

--- a/internal/upload/streaming.go
+++ b/internal/upload/streaming.go
@@ -1,0 +1,111 @@
+package upload
+
+import (
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/livetemplate/livetemplate/internal/uploadtypes"
+)
+
+// valuePartCap bounds how many bytes are read from a single non-file form part
+// (lvt-action, lvt-submitter, the data JSON envelope, plain fields). Form values
+// are small; this caps memory without affecting file streaming.
+const valuePartCap = 1 << 20 // 1 MB
+
+// StreamMultipart iterates a multipart/form-data body via r.MultipartReader()
+// WITHOUT calling ParseMultipartForm, so file bytes are never staged to disk by
+// the stdlib. Non-file parts are buffered into the returned values map (so the
+// caller can rebuild the action message). File parts are routed by
+// isStreaming(field): streaming fields go to onFile (consumed inline as an
+// io.Reader), all other file parts go to onStaged (may be nil).
+//
+// onFile/onStaged receive the live *multipart.Part. A callback that returns an
+// error aborts iteration and the error is returned verbatim, so a *ValidationError
+// from validation surfaces to the caller for per-field error mapping.
+func StreamMultipart(
+	r *http.Request,
+	isStreaming func(field string) bool,
+	onFile func(part *multipart.Part) error,
+	onStaged func(part *multipart.Part) error,
+) (map[string][]string, error) {
+	mr, err := r.MultipartReader()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read multipart body: %w", err)
+	}
+
+	values := make(map[string][]string)
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return values, fmt.Errorf("failed to read multipart part: %w", err)
+		}
+
+		// Value part (no filename): buffer it for action-message reconstruction.
+		if part.FileName() == "" {
+			name := part.FormName()
+			b, readErr := io.ReadAll(io.LimitReader(part, valuePartCap))
+			if readErr != nil {
+				return values, fmt.Errorf("failed to read form value %q: %w", name, readErr)
+			}
+			values[name] = append(values[name], string(b))
+			continue
+		}
+
+		// File part.
+		if isStreaming(part.FormName()) {
+			if err := onFile(part); err != nil {
+				return values, err
+			}
+		} else if onStaged != nil {
+			if err := onStaged(part); err != nil {
+				return values, err
+			}
+		}
+		// A non-streaming file part with no staged sink is intentionally dropped
+		// (e.g. Preview/Direct fields never send bytes here).
+	}
+
+	return values, nil
+}
+
+// LimitGuard wraps a reader and enforces a maximum byte count mid-stream. When
+// the limit is exceeded it returns uploadtypes.ErrUploadTooLarge instead of
+// io.EOF, so a streaming copy to remote storage aborts rather than silently
+// committing a truncated object. A max of 0 means unlimited.
+type LimitGuard struct {
+	r   io.Reader
+	n   int64
+	max int64
+}
+
+func (l *LimitGuard) Read(p []byte) (int, error) {
+	n, err := l.r.Read(p)
+	l.n += int64(n)
+	if l.max > 0 && l.n > l.max {
+		return n, uploadtypes.ErrUploadTooLarge
+	}
+	return n, err
+}
+
+// NewLimitGuard returns a reader over src that fails with
+// uploadtypes.ErrUploadTooLarge once more than max bytes are read (max 0 =
+// unlimited). It also reports the number of bytes read so far via Count.
+func NewLimitGuard(src io.Reader, max int64) *LimitGuard {
+	return &LimitGuard{r: src, max: max}
+}
+
+// Count returns the number of bytes read through the guard so far.
+func (l *LimitGuard) Count() int64 { return l.n }
+
+// ValidateFileHeader validates a streaming file part's Accept rule from its
+// header alone (filename + Content-Type), before any bytes are read. MaxFileSize
+// is enforced separately mid-stream by LimitGuard, since the part carries no
+// size under MultipartReader.
+func ValidateFileHeader(filename, contentType string, config uploadtypes.UploadConfig) error {
+	return validateFileType(filename, contentType, config.Accept)
+}

--- a/internal/upload/streaming.go
+++ b/internal/upload/streaming.go
@@ -10,6 +10,11 @@ import (
 	"github.com/livetemplate/livetemplate/internal/uploadtypes"
 )
 
+// maxEmptyProbeReads bounds how many consecutive (0, nil) reads the LimitGuard
+// EOF probe tolerates before giving up, so a permanently-stalled reader can't
+// spin forever (matches the spirit of io.Copy's no-progress guard).
+const maxEmptyProbeReads = 100
+
 // valuePartCap bounds how many bytes are read from a single non-file form part
 // (lvt-action, lvt-submitter, the data JSON envelope, plain fields). Form values
 // are small; this caps memory without affecting file streaming.
@@ -97,11 +102,12 @@ func (l *LimitGuard) Read(p []byte) (int, error) {
 	if remaining <= 0 {
 		// We've already delivered max bytes. Peek one more to tell "exactly max"
 		// (EOF → success) from "more than max" (ErrUploadTooLarge) without ever
-		// handing the oversize byte to the consumer. Loop to tolerate a reader
-		// that returns (0, nil) (allowed by io.Reader); returning (0, nil) here
-		// would spin io.Copy.
+		// handing the oversize byte to the consumer. Tolerate a reader that
+		// returns (0, nil) (allowed by io.Reader) — returning it would spin
+		// io.Copy — but bound the retries so a permanently-stalled reader can't
+		// loop forever; mirror io.Copy's own no-progress guard.
 		var probe [1]byte
-		for {
+		for retries := 0; ; retries++ {
 			m, err := l.r.Read(probe[:])
 			if m > 0 {
 				return 0, uploadtypes.ErrUploadTooLarge
@@ -111,6 +117,9 @@ func (l *LimitGuard) Read(p []byte) (int, error) {
 			}
 			if err != nil {
 				return 0, err
+			}
+			if retries >= maxEmptyProbeReads {
+				return 0, io.ErrNoProgress
 			}
 			// (0, nil): no data yet, not EOF — retry the probe.
 		}

--- a/internal/upload/streaming_test.go
+++ b/internal/upload/streaming_test.go
@@ -1,0 +1,55 @@
+package upload
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/livetemplate/internal/uploadtypes"
+)
+
+func TestLimitGuard_UnderAndExactLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data string
+		max  int64
+	}{
+		{"under", "hello", 10},
+		{"exact", "hello", 5},
+		{"unlimited", "hello world", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewLimitGuard(strings.NewReader(tc.data), tc.max)
+			got, err := io.ReadAll(g)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tc.data {
+				t.Errorf("got %q, want %q", got, tc.data)
+			}
+		})
+	}
+}
+
+// TestLimitGuard_OverLimitDeliversAtMostMax verifies the guard never hands the
+// oversize bytes to the consumer — a streaming copy aborts with ErrUploadTooLarge
+// having seen at most max bytes, so no partial object is committed downstream.
+func TestLimitGuard_OverLimitDeliversAtMostMax(t *testing.T) {
+	const max = 4
+	src := strings.NewReader("0123456789") // 10 bytes, limit 4
+
+	// Copy through the guard the way OnUpload would, into a sink that records
+	// exactly what it received.
+	var sink bytes.Buffer
+	g := NewLimitGuard(src, max)
+	_, err := io.Copy(&sink, g)
+
+	if !errors.Is(err, uploadtypes.ErrUploadTooLarge) {
+		t.Fatalf("expected ErrUploadTooLarge, got %v", err)
+	}
+	if int64(sink.Len()) > max {
+		t.Errorf("sink received %d bytes, must be <= max (%d) — oversize bytes leaked", sink.Len(), max)
+	}
+}

--- a/internal/upload/tempfile.go
+++ b/internal/upload/tempfile.go
@@ -10,6 +10,26 @@ import (
 	"time"
 )
 
+// CreateRetainedFile creates an empty staging file under dir for a Volume-mode
+// upload that should persist. Unlike TempFileManager.CreateTempFile, the file is
+// not tracked by any session, so RemoveSession never deletes it — the app owns
+// its lifecycle. Returns the created file's path (dir/uploadName/entryID).
+func CreateRetainedFile(dir, uploadName, entryID string) (string, error) {
+	target := filepath.Join(dir, uploadName)
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create upload dir %q: %w", target, err)
+	}
+	path := filepath.Join(target, entryID)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("failed to create retained file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("failed to close retained file: %w", err)
+	}
+	return path, nil
+}
+
 // TempFileManager manages temporary upload files with automatic cleanup.
 // Files are organized by session/upload/entry for easy tracking and cleanup.
 type TempFileManager struct {

--- a/internal/uploadtypes/types.go
+++ b/internal/uploadtypes/types.go
@@ -2,8 +2,14 @@ package uploadtypes
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrUploadTooLarge is returned by a streaming upload reader when the bytes
+// exceed MaxFileSize. It is a distinct sentinel (not io.EOF) so a streaming
+// copy aborts instead of committing a truncated object.
+var ErrUploadTooLarge = errors.New("livetemplate: upload exceeds MaxFileSize")
 
 // Presigner generates presigned upload URLs for external storage.
 type Presigner interface {
@@ -18,6 +24,39 @@ type UploadMeta struct {
 	Headers  map[string]string
 }
 
+// UploadMode selects where a field's uploaded bytes go. It is chosen purely by
+// server config; the same <input lvt-upload="..."> markup works for every mode.
+type UploadMode int
+
+const (
+	// UploadModeVolume stages bytes to the server's disk and retains them at the
+	// configured Dir (or a temp dir). The app reads the path via TempPath.
+	UploadModeVolume UploadMode = iota
+	// UploadModeDirect has the browser upload straight to cloud storage via a
+	// presigned URL (requires External). Bytes never touch the server.
+	UploadModeDirect
+	// UploadModeProxied streams bytes through the server to remote storage with
+	// zero local-disk staging (requires the controller to implement UploadStreamer).
+	UploadModeProxied
+	// UploadModePreview keeps the file on the device; the server receives only
+	// metadata (name/type/size). Visual-only — bytes are never uploaded.
+	UploadModePreview
+)
+
+// String renders the mode as the lowercase token sent to the client.
+func (m UploadMode) String() string {
+	switch m {
+	case UploadModeDirect:
+		return "direct"
+	case UploadModeProxied:
+		return "proxied"
+	case UploadModePreview:
+		return "preview"
+	default:
+		return "volume"
+	}
+}
+
 // UploadConfig configures file upload behavior for a specific upload field.
 type UploadConfig struct {
 	Accept      []string
@@ -25,7 +64,9 @@ type UploadConfig struct {
 	MaxFileSize int64
 	AutoUpload  bool
 	ChunkSize   int
-	External    Presigner
+	Mode        UploadMode // Selects the upload destination (default: Volume)
+	External    Presigner  // Required when Mode == UploadModeDirect
+	Dir         string     // Retain destination when Mode == UploadModeVolume (temp if empty)
 }
 
 // UploadEntry represents a single file upload with its state and metadata.
@@ -41,6 +82,7 @@ type UploadEntry struct {
 	TempPath    string
 	BytesRecv   int64 // Bytes received so far (for chunked uploads)
 	ExternalRef string
+	Preview     bool // True when the file stays on-device (UploadModePreview); no bytes received
 	CreatedAt   time.Time
 	CompletedAt time.Time
 }

--- a/internal/uploadtypes/types.go
+++ b/internal/uploadtypes/types.go
@@ -61,7 +61,7 @@ func (m UploadMode) String() string {
 type UploadConfig struct {
 	Accept      []string
 	MaxEntries  int
-	MaxFileSize int64
+	MaxFileSize int64 // Max bytes per file; 0 = no limit (also the only size cap for Proxied)
 	AutoUpload  bool
 	ChunkSize   int
 	Mode        UploadMode // Selects the upload destination (default: Volume)

--- a/mount.go
+++ b/mount.go
@@ -2390,9 +2390,9 @@ func (h *liveHandler) handleUploadAction(ctx context.Context, rawData []byte, ms
 		return false, nil // Not an upload action
 	}
 
-	if h.tempFileManager == nil {
-		return true, fmt.Errorf("uploads unavailable: temp file manager not initialized")
-	}
+	// No blanket temp-manager requirement: only Volume mode stages to disk, and
+	// its handshake branch guards a nil manager. Direct/Proxied/Preview need no
+	// local filesystem, so their handshake/complete actions work without one.
 
 	switch msg.Action {
 	case "upload_start":
@@ -2602,8 +2602,12 @@ func (h *liveHandler) buildUploadStartResponse(rawData []byte, sessionID string,
 
 		default: // UploadModeVolume
 			// Server-side staging: create a temp file the chunk handler appends to.
-			tempFileManager := h.tempFileManager.(*upload.TempFileManager)
-			tempPath, err := tempFileManager.CreateTempFile(sessionID, startMsg.UploadName, entryID)
+			tfm, ok := h.tempFileManager.(*upload.TempFileManager)
+			if !ok || tfm == nil {
+				entryInfo.Error = "uploads unavailable: temp file manager not initialized"
+				break
+			}
+			tempPath, err := tfm.CreateTempFile(sessionID, startMsg.UploadName, entryID)
 			if err != nil {
 				entryInfo.Error = fmt.Sprintf("failed to create temp file: %v", err)
 			} else {

--- a/mount.go
+++ b/mount.go
@@ -2838,6 +2838,12 @@ func (h *liveHandler) handleUploadComplete(ctx context.Context, rawData []byte, 
 			response.Error = actionErr.Error()
 		} else if actionErr == nil {
 			state.state = newState
+			// Persist the upload result so it survives a page refresh, matching
+			// the WS-action and HTTP-POST action paths. Without this, uploads
+			// completed over WebSocket (Direct, Volume) update only the in-memory
+			// connection state and are lost on reload.
+			h.persistState(ctx, connection.GroupID, state.state)
+			connection.Stores = state.state
 			// Drain ctx.Publish from an upload-complete handler — consistent
 			// with the WS-action and HTTP-POST action paths.
 			h.processTopicPublishes(connection, actionCtx.pendingTopicPublishes())

--- a/mount.go
+++ b/mount.go
@@ -2689,7 +2689,10 @@ func (h *liveHandler) buildUploadStartResponse(rawData []byte, sessionID string,
 		case uploadtypes.UploadModeProxied:
 			// Bytes arrive via a follow-on HTTP multipart POST that streams them
 			// straight to OnUpload. Nothing stages here — validate metadata only
-			// so the client can reject early before uploading.
+			// so the client can reject early before uploading. The returned
+			// EntryID is informational: Proxied has no chunked/cancel-by-ID
+			// protocol, and streamProxiedPart creates the authoritative entry when
+			// the bytes arrive (validating Accept again from the part header).
 			if err := upload.ValidateEntry(entry, uploadInstance.Config); err != nil {
 				entryInfo.Error = err.Error()
 			} else {

--- a/mount.go
+++ b/mount.go
@@ -1326,10 +1326,15 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Body = pr
 	}
 
-	// Proxied streaming uploads: a multipart request carrying a field whose Mode
-	// is Proxied is iterated via MultipartReader (zero disk) and each file part is
-	// streamed straight to Controller.OnUpload, bypassing ParseMultipartForm
-	// (which would stage large parts to os.TempDir).
+	// Proxied streaming uploads: each file part is iterated via MultipartReader
+	// (zero disk) and streamed straight to Controller.OnUpload, bypassing
+	// ParseMultipartForm (which would stage large parts to os.TempDir).
+	//
+	// hasProxied is static, so ONCE ANY field is Proxied every multipart POST to
+	// this handler takes the streaming path — including requests carrying only
+	// Volume fields. That's intentional: stageVolumePart stages those Volume
+	// parts to disk, and value parts are reconstructed via BuildActionFromValues,
+	// so the outcome matches the non-streaming path.
 	streamingRequest := strings.HasPrefix(ct, "multipart/form-data") && h.hasProxied
 
 	var msg message
@@ -1361,6 +1366,8 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		)
 		streamErr = serr
 		msg = send.BuildActionFromValues(values)
+		// Unconditional here (unlike the else branch's Content-Type guard) because
+		// streamingRequest already implies multipart/form-data.
 		applyDefaultAction(&msg)
 	} else {
 		// Parse message

--- a/mount.go
+++ b/mount.go
@@ -2570,7 +2570,19 @@ func (h *liveHandler) stageVolumePart(part *multipart.Part, uploadRegistry uploa
 		Done:       true,
 		Progress:   100,
 	}
-	return recordUploadEntry(uploadRegistry, field, entry)
+	if err := recordUploadEntry(uploadRegistry, field, entry); err != nil {
+		// The bytes are already written; if the entry can't be recorded, remove
+		// the file so a retained Dir upload doesn't leak (the WS-chunk handshake
+		// does the same on AddEntry failure).
+		if rmErr := os.Remove(dstPath); rmErr != nil {
+			slog.Warn("Failed to remove orphaned upload file",
+				slog.String("component", "upload_handler"),
+				slog.String("path", dstPath),
+				slog.Any("error", rmErr))
+		}
+		return err
+	}
+	return nil
 }
 
 // handleUploadStart processes upload_start action from WebSocket client.
@@ -2668,6 +2680,13 @@ func (h *liveHandler) buildUploadStartResponse(rawData []byte, sessionID string,
 		switch mode {
 		case uploadtypes.UploadModeDirect:
 			// Direct: presign so the browser PUTs straight to cloud storage.
+			// Guard a config that set Mode:Direct without an External presigner —
+			// the back-compat shim only promotes External-without-Mode, so this
+			// explicit shape would otherwise nil-panic.
+			if uploadInstance.Config.External == nil {
+				entryInfo.Error = "Direct upload mode requires an External presigner"
+				break
+			}
 			presignMeta, err := uploadInstance.Config.External.Presign(entry)
 			if err != nil {
 				entryInfo.Error = fmt.Sprintf("failed to presign: %v", err)

--- a/mount.go
+++ b/mount.go
@@ -2590,14 +2590,33 @@ func (h *liveHandler) buildUploadStartResponse(rawData []byte, sessionID string,
 				}
 			}
 
-		case uploadtypes.UploadModeProxied, uploadtypes.UploadModePreview:
-			// Proxied bytes arrive via a follow-on HTTP multipart POST; Preview
-			// bytes never leave the device. Neither stages to disk here — the
-			// handshake only validates metadata so the client can dispatch.
+		case uploadtypes.UploadModeProxied:
+			// Bytes arrive via a follow-on HTTP multipart POST that streams them
+			// straight to OnUpload. Nothing stages here — validate metadata only
+			// so the client can reject early before uploading.
 			if err := upload.ValidateEntry(entry, uploadInstance.Config); err != nil {
 				entryInfo.Error = err.Error()
 			} else {
 				entryInfo.Valid = true
+			}
+
+		case uploadtypes.UploadModePreview:
+			// The file stays on the device; only its metadata reaches the server.
+			// Record a metadata-only entry (Preview=true, no TempPath/ExternalRef)
+			// so the app can render a placeholder via GetCompletedUploads, then
+			// the client shows the bytes locally via URL.createObjectURL.
+			if err := upload.ValidateEntry(entry, uploadInstance.Config); err != nil {
+				entryInfo.Error = err.Error()
+			} else {
+				entry.Preview = true
+				entry.Valid = true
+				entry.Done = true
+				entry.Progress = 100
+				if err := uploadInstance.AddEntry(entry); err != nil {
+					entryInfo.Error = err.Error()
+				} else {
+					entryInfo.Valid = true
+				}
 			}
 
 		default: // UploadModeVolume

--- a/mount.go
+++ b/mount.go
@@ -1267,31 +1267,29 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	ct := r.Header.Get("Content-Type")
 
 	// Upload handshake over HTTP (WS-disabled fallback): the client posts the
-	// upload_start JSON when the socket isn't open. Answer with the same
-	// UploadStartResponse the WS path produces so mode dispatch + Direct presign
-	// work without a WebSocket. JSON body, peeked for an upload action.
-	if strings.HasPrefix(ct, "application/json") && len(h.config.UploadConfigs) > 0 {
-		body, readErr := io.ReadAll(r.Body)
+	// upload_start JSON with the X-Lvt-Upload: start header when the socket isn't
+	// open. Answer with the same UploadStartResponse the WS path produces so mode
+	// dispatch + Direct presign work without a WebSocket. Gated on the header so
+	// normal JSON action POSTs never pay a body read; the read is bounded since a
+	// handshake is only small file-metadata.
+	if r.Header.Get(uploadStartHeader) == "start" && strings.HasPrefix(ct, "application/json") && len(h.config.UploadConfigs) > 0 {
+		body, readErr := io.ReadAll(io.LimitReader(r.Body, maxUploadHandshakeBytes))
 		if readErr != nil {
 			http.Error(w, "failed to read request body", http.StatusBadRequest)
 			return
 		}
-		if upload.IsUploadStart(body) {
-			response, buildErr := h.buildUploadStartResponse(body, groupID, uploadRegistry)
-			if buildErr != nil {
-				http.Error(w, buildErr.Error(), http.StatusBadRequest)
-				return
-			}
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(response); err != nil {
-				slog.Warn("Failed to write upload_start HTTP response",
-					slog.String("component", "live_handler"),
-					slog.Any("error", err))
-			}
+		response, buildErr := h.buildUploadStartResponse(body, groupID, uploadRegistry)
+		if buildErr != nil {
+			http.Error(w, buildErr.Error(), http.StatusBadRequest)
 			return
 		}
-		// Not an upload handshake — restore the body for normal action parsing.
-		r.Body = io.NopCloser(bytes.NewReader(body))
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			slog.Warn("Failed to write upload_start HTTP response",
+				slog.String("component", "live_handler"),
+				slog.Any("error", err))
+		}
+		return
 	}
 
 	// Proxied streaming uploads: a multipart request carrying a field whose Mode
@@ -2406,6 +2404,15 @@ func (h *liveHandler) handleUploadAction(ctx context.Context, rawData []byte, ms
 	}
 }
 
+const (
+	// uploadStartHeader marks an HTTP upload_start handshake (WS-disabled
+	// fallback) so normal JSON action POSTs are never probed.
+	uploadStartHeader = "X-Lvt-Upload"
+	// maxUploadHandshakeBytes bounds the handshake body read — it carries only
+	// small file metadata, never file bytes.
+	maxUploadHandshakeBytes = 1 << 20
+)
+
 // hasProxiedUpload reports whether any configured upload field uses Proxied mode.
 func (h *liveHandler) hasProxiedUpload() bool {
 	for _, c := range h.config.UploadConfigs {
@@ -2465,14 +2472,19 @@ func (h *liveHandler) streamProxiedPart(part *multipart.Part, uploadRegistry upl
 	entry.Done = true
 	entry.Progress = 100
 
-	if reg, ok := uploadRegistry.(*upload.Registry); ok {
-		if u := reg.GetUpload(field); u != nil {
-			if upl, ok := u.(*upload.Upload); ok {
-				if addErr := upl.AddEntry(entry); addErr != nil {
-					return &upload.ValidationError{Field: field, Message: addErr.Error()}
-				}
-			}
-		}
+	// Record the completed entry. The bytes have already been streamed to
+	// OnUpload, so a registry-lookup miss here is a real failure (an orphaned
+	// upload), not something to swallow — surface it as a field error.
+	reg, ok := uploadRegistry.(*upload.Registry)
+	if !ok {
+		return &upload.ValidationError{Field: field, Message: "invalid upload registry type"}
+	}
+	upl, ok := reg.GetUpload(field).(*upload.Upload)
+	if !ok {
+		return &upload.ValidationError{Field: field, Message: fmt.Sprintf("upload %q not configured", field)}
+	}
+	if addErr := upl.AddEntry(entry); addErr != nil {
+		return &upload.ValidationError{Field: field, Message: addErr.Error()}
 	}
 	return nil
 }

--- a/mount.go
+++ b/mount.go
@@ -173,6 +173,7 @@ type liveHandler struct {
 	limits          *session.ConnectionLimits
 	metricsExporter *observe.PrometheusExporter
 	tempFileManager uploadTempFileManager
+	hasProxied      bool     // true if any upload field uses Proxied mode (static, computed at Handle)
 	httpTemplates   sync.Map // groupID → *httpTemplateCacheEntry (cached for HTTP POST diff optimization)
 	httpLastPaths   sync.Map // groupID → string (last served request path, for detecting URL changes)
 
@@ -1297,7 +1298,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	// streamed straight to Controller.OnUpload. This bypasses ParseMultipartForm
 	// (which would stage large parts to os.TempDir) and the byte-progress wrapper
 	// (which would consume the body before MultipartReader sees it).
-	streamingRequest := strings.HasPrefix(ct, "multipart/form-data") && h.hasProxiedUpload()
+	streamingRequest := strings.HasPrefix(ct, "multipart/form-data") && h.hasProxied
 
 	var msg message
 	var streamErr error
@@ -1319,7 +1320,12 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			func(part *multipart.Part) error {
 				return h.streamProxiedPart(part, uploadRegistry, streamCtx)
 			},
-			nil, // no staged sink: non-streaming file parts in a Proxied request are ignored
+			// Staged sink: a Volume file part sharing a streaming request is
+			// staged to disk rather than dropped (Direct/Preview carry no bytes
+			// here, so non-Volume parts are skipped inside stageVolumePart).
+			func(part *multipart.Part) error {
+				return h.stageVolumePart(part, uploadRegistry, groupID)
+			},
 		)
 		streamErr = serr
 		msg = send.BuildActionFromValues(values)
@@ -2413,16 +2419,6 @@ const (
 	maxUploadHandshakeBytes = 1 << 20
 )
 
-// hasProxiedUpload reports whether any configured upload field uses Proxied mode.
-func (h *liveHandler) hasProxiedUpload() bool {
-	for _, c := range h.config.UploadConfigs {
-		if c.Mode == uploadtypes.UploadModeProxied {
-			return true
-		}
-	}
-	return false
-}
-
 // streamProxiedPart streams one Proxied file part straight to Controller.OnUpload
 // with zero local-disk staging, then records the result as a completed upload
 // entry (ExternalRef set by the handler via SetResult) so the follow-on action
@@ -2464,6 +2460,10 @@ func (h *liveHandler) streamProxiedPart(part *multipart.Part, uploadRegistry upl
 	}
 
 	if err := streamer.OnUpload(up, ctx); err != nil {
+		// Surface an over-limit stream on the field, not as a general error.
+		if errors.Is(err, uploadtypes.ErrUploadTooLarge) {
+			return &upload.ValidationError{Field: field, Message: fmt.Sprintf("file exceeds maximum size of %d bytes", cfg.MaxFileSize)}
+		}
 		return err
 	}
 
@@ -2472,9 +2472,14 @@ func (h *liveHandler) streamProxiedPart(part *multipart.Part, uploadRegistry upl
 	entry.Done = true
 	entry.Progress = 100
 
-	// Record the completed entry. The bytes have already been streamed to
-	// OnUpload, so a registry-lookup miss here is a real failure (an orphaned
-	// upload), not something to swallow — surface it as a field error.
+	// The bytes have already been streamed to OnUpload, so a registry-lookup
+	// miss here is a real failure (an orphaned upload), surfaced as a field error.
+	return recordUploadEntry(uploadRegistry, field, entry)
+}
+
+// recordUploadEntry adds a completed entry to its upload in the registry,
+// mapping any lookup/validation failure to a field error.
+func recordUploadEntry(uploadRegistry uploadRegistry, field string, entry *uploadtypes.UploadEntry) error {
 	reg, ok := uploadRegistry.(*upload.Registry)
 	if !ok {
 		return &upload.ValidationError{Field: field, Message: "invalid upload registry type"}
@@ -2487,6 +2492,73 @@ func (h *liveHandler) streamProxiedPart(part *multipart.Part, uploadRegistry upl
 		return &upload.ValidationError{Field: field, Message: addErr.Error()}
 	}
 	return nil
+}
+
+// stageVolumePart writes a Volume file part that shares a streaming (Proxied)
+// request to disk — retained under Dir, or staged to the session temp dir —
+// instead of dropping it. Non-Volume parts (Direct/Preview carry no bytes here)
+// are skipped. MaxFileSize/Accept are enforced as on the WS-chunk path.
+func (h *liveHandler) stageVolumePart(part *multipart.Part, uploadRegistry uploadRegistry, sessionID string) error {
+	field := part.FormName()
+	cfg, ok := h.config.UploadConfigs[field]
+	if !ok || cfg.Mode != uploadtypes.UploadModeVolume {
+		return nil
+	}
+	if err := upload.ValidateFileHeader(part.FileName(), part.Header.Get("Content-Type"), cfg); err != nil {
+		return err
+	}
+
+	entryID, err := upload.GenerateEntryID()
+	if err != nil {
+		return fmt.Errorf("failed to generate entry ID: %w", err)
+	}
+
+	var dstPath string
+	if cfg.Dir != "" {
+		dstPath, err = upload.CreateRetainedFile(cfg.Dir, field, entryID)
+	} else if tfm, ok := h.tempFileManager.(*upload.TempFileManager); ok && tfm != nil {
+		dstPath, err = tfm.CreateTempFile(sessionID, field, entryID)
+	} else {
+		return &upload.ValidationError{Field: field, Message: "uploads unavailable: temp file manager not initialized"}
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create upload file: %w", err)
+	}
+
+	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to open upload file: %w", err)
+	}
+	guard := upload.NewLimitGuard(part, cfg.MaxFileSize)
+	_, copyErr := io.Copy(dst, guard)
+	closeErr := dst.Close()
+	if copyErr != nil || closeErr != nil {
+		if rmErr := os.Remove(dstPath); rmErr != nil {
+			slog.Warn("Failed to remove upload file",
+				slog.String("component", "upload_handler"),
+				slog.String("path", dstPath),
+				slog.Any("error", rmErr))
+		}
+		if errors.Is(copyErr, uploadtypes.ErrUploadTooLarge) {
+			return &upload.ValidationError{Field: field, Message: fmt.Sprintf("file exceeds maximum size of %d bytes", cfg.MaxFileSize)}
+		}
+		if copyErr != nil {
+			return fmt.Errorf("failed to write upload file: %w", copyErr)
+		}
+		return fmt.Errorf("failed to close upload file: %w", closeErr)
+	}
+
+	entry := &uploadtypes.UploadEntry{
+		ID:         entryID,
+		ClientName: part.FileName(),
+		ClientType: part.Header.Get("Content-Type"),
+		ClientSize: guard.Count(),
+		TempPath:   dstPath,
+		Valid:      true,
+		Done:       true,
+		Progress:   100,
+	}
+	return recordUploadEntry(uploadRegistry, field, entry)
 }
 
 // handleUploadStart processes upload_start action from WebSocket client.

--- a/mount.go
+++ b/mount.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
@@ -1262,88 +1264,152 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Tier 1 file uploads: wrap request body with progress tracking before
-	// any multipart parsing occurs. ParseMultipartForm reads through this
-	// wrapper, giving us byte-level progress for WebSocket clients.
 	ct := r.Header.Get("Content-Type")
-	if strings.HasPrefix(ct, "multipart/form-data") && r.ContentLength > 0 && len(h.config.UploadConfigs) > 0 {
-		pr := upload.NewProgressReader(r.Body, r.ContentLength)
-		pr.OnProgress = func(bytesRead, total int64) {
-			conns := h.registry.GetByGroupExcept(groupID, nil)
-			if len(conns) == 0 {
+
+	// Upload handshake over HTTP (WS-disabled fallback): the client posts the
+	// upload_start JSON when the socket isn't open. Answer with the same
+	// UploadStartResponse the WS path produces so mode dispatch + Direct presign
+	// work without a WebSocket. JSON body, peeked for an upload action.
+	if strings.HasPrefix(ct, "application/json") && len(h.config.UploadConfigs) > 0 {
+		body, readErr := io.ReadAll(r.Body)
+		if readErr != nil {
+			http.Error(w, "failed to read request body", http.StatusBadRequest)
+			return
+		}
+		if upload.IsUploadStart(body) {
+			response, buildErr := h.buildUploadStartResponse(body, groupID, uploadRegistry)
+			if buildErr != nil {
+				http.Error(w, buildErr.Error(), http.StatusBadRequest)
 				return
 			}
-			pct := int(bytesRead * 100 / total)
-			progressMsg := &upload.UploadProgressMessage{
-				Type:       "upload_progress",
-				UploadName: "multipart",
-				Progress:   pct,
-				BytesRecv:  bytesRead,
-				BytesTotal: total,
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				slog.Warn("Failed to write upload_start HTTP response",
+					slog.String("component", "live_handler"),
+					slog.Any("error", err))
 			}
-			progressBytes, err := upload.SerializeUploadProgressMessage(progressMsg)
-			if err != nil {
-				return
-			}
-			for _, conn := range conns {
-				if err := conn.Send(WSTextMessage, progressBytes); err != nil {
-					// Client may have disconnected — non-fatal for progress updates
-					continue
+			return
+		}
+		// Not an upload handshake — restore the body for normal action parsing.
+		r.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	// Proxied streaming uploads: a multipart request carrying a field whose Mode
+	// is Proxied is iterated via MultipartReader (zero disk) and each file part is
+	// streamed straight to Controller.OnUpload. This bypasses ParseMultipartForm
+	// (which would stage large parts to os.TempDir) and the byte-progress wrapper
+	// (which would consume the body before MultipartReader sees it).
+	streamingRequest := strings.HasPrefix(ct, "multipart/form-data") && h.hasProxiedUpload()
+
+	var msg message
+	var streamErr error
+
+	if streamingRequest {
+		streamCtx := NewContext(r.Context(), "", nil)
+		streamCtx = streamCtx.WithUserID(userID)
+		streamCtx = streamCtx.WithGroupID(groupID)
+		streamCtx = streamCtx.WithTopicSubscriber(h.topicSubscriberFor(nil, r))
+		streamCtx = streamCtx.WithHTTP(w, r)
+		streamCtx = streamCtx.WithUploads(uploadRegistry)
+		streamCtx = streamCtx.WithSession(newLocalSession(h, groupID))
+
+		values, serr := upload.StreamMultipart(r,
+			func(field string) bool {
+				c, ok := h.config.UploadConfigs[field]
+				return ok && c.Mode == uploadtypes.UploadModeProxied
+			},
+			func(part *multipart.Part) error {
+				return h.streamProxiedPart(part, uploadRegistry, streamCtx)
+			},
+			nil, // no staged sink: non-streaming file parts in a Proxied request are ignored
+		)
+		streamErr = serr
+		msg = send.BuildActionFromValues(values)
+		applyDefaultAction(&msg)
+	} else {
+		// Tier 1 file uploads: wrap request body with progress tracking before
+		// any multipart parsing occurs. ParseMultipartForm reads through this
+		// wrapper, giving us byte-level progress for WebSocket clients.
+		if strings.HasPrefix(ct, "multipart/form-data") && r.ContentLength > 0 && len(h.config.UploadConfigs) > 0 {
+			pr := upload.NewProgressReader(r.Body, r.ContentLength)
+			pr.OnProgress = func(bytesRead, total int64) {
+				conns := h.registry.GetByGroupExcept(groupID, nil)
+				if len(conns) == 0 {
+					return
+				}
+				pct := int(bytesRead * 100 / total)
+				progressMsg := &upload.UploadProgressMessage{
+					Type:       "upload_progress",
+					UploadName: "multipart",
+					Progress:   pct,
+					BytesRecv:  bytesRead,
+					BytesTotal: total,
+				}
+				progressBytes, err := upload.SerializeUploadProgressMessage(progressMsg)
+				if err != nil {
+					return
+				}
+				for _, conn := range conns {
+					if err := conn.Send(WSTextMessage, progressBytes); err != nil {
+						// Client may have disconnected — non-fatal for progress updates
+						continue
+					}
 				}
 			}
+			r.Body = pr
 		}
-		r.Body = pr
-	}
 
-	// Parse message
-	msg, err := parseActionFromHTTP(r)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
+		// Parse message
+		var err error
+		msg, err = parseActionFromHTTP(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 
-	// Route browser form submissions without explicit action to Submit().
-	// Only apply for form Content-Types, not JSON action requests.
-	if strings.HasPrefix(ct, "application/x-www-form-urlencoded") || strings.HasPrefix(ct, "multipart/form-data") {
-		applyDefaultAction(&msg)
-	}
+		// Route browser form submissions without explicit action to Submit().
+		// Only apply for form Content-Types, not JSON action requests.
+		if strings.HasPrefix(ct, "application/x-www-form-urlencoded") || strings.HasPrefix(ct, "multipart/form-data") {
+			applyDefaultAction(&msg)
+		}
 
-	// Tier 1 file uploads: extract multipart files into the upload registry.
-	// ParseMultipartForm was already called by parseActionFromHTTP above,
-	// so r.MultipartForm is populated. We iterate configured upload fields
-	// and extract matching files.
-	if strings.HasPrefix(ct, "multipart/form-data") && len(h.config.UploadConfigs) > 0 {
-		if registry, ok := uploadRegistry.(*upload.Registry); ok {
-			tempMgr, tempErr := upload.NewTempFileManager("")
-			if tempErr != nil {
-				slog.Warn("Failed to create temp file manager for multipart upload",
-					slog.String("component", "live_handler"),
-					slog.Any("error", tempErr))
-			} else {
-				for name := range h.config.UploadConfigs {
-					u := registry.GetUpload(name)
-					if u == nil {
-						continue
-					}
-					upl, ok := u.(*upload.Upload)
-					if !ok {
-						continue
-					}
-					entries, err := upload.ParseMultipartUpload(r, name, upl.Config, groupID, tempMgr)
-					if err != nil {
-						// No files for this field or parse error — not fatal
-						slog.Debug("Multipart upload parse",
-							slog.String("component", "live_handler"),
-							slog.String("upload_name", name),
-							slog.Any("result", err.Error()))
-						continue
-					}
-					for _, entry := range entries {
-						if err := upl.AddEntry(entry); err != nil {
-							slog.Debug("Multipart upload entry rejected",
+		// Tier 1 file uploads: extract multipart files into the upload registry.
+		// ParseMultipartForm was already called by parseActionFromHTTP above,
+		// so r.MultipartForm is populated. We iterate configured upload fields
+		// and extract matching files.
+		if strings.HasPrefix(ct, "multipart/form-data") && len(h.config.UploadConfigs) > 0 {
+			if registry, ok := uploadRegistry.(*upload.Registry); ok {
+				tempMgr, tempErr := upload.NewTempFileManager("")
+				if tempErr != nil {
+					slog.Warn("Failed to create temp file manager for multipart upload",
+						slog.String("component", "live_handler"),
+						slog.Any("error", tempErr))
+				} else {
+					for name := range h.config.UploadConfigs {
+						u := registry.GetUpload(name)
+						if u == nil {
+							continue
+						}
+						upl, ok := u.(*upload.Upload)
+						if !ok {
+							continue
+						}
+						entries, err := upload.ParseMultipartUpload(r, name, upl.Config, groupID, tempMgr)
+						if err != nil {
+							// No files for this field or parse error — not fatal
+							slog.Debug("Multipart upload parse",
 								slog.String("component", "live_handler"),
 								slog.String("upload_name", name),
-								slog.Any("error", err))
+								slog.Any("result", err.Error()))
+							continue
+						}
+						for _, entry := range entries {
+							if err := upl.AddEntry(entry); err != nil {
+								slog.Debug("Multipart upload entry rejected",
+									slog.String("component", "live_handler"),
+									slog.String("upload_name", name),
+									slog.Any("error", err))
+							}
 						}
 					}
 				}
@@ -1353,6 +1419,23 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Clear previous errors
 	connSt.clearErrors()
+
+	// Surface a streaming-upload failure as a field error before dispatch, so the
+	// follow-on action still runs (and reads whatever uploads did succeed).
+	if streamErr != nil {
+		switch e := streamErr.(type) {
+		case FieldError:
+			connSt.setError(e.Field, e.Message)
+		case MultiError:
+			for _, fe := range e {
+				connSt.setError(fe.Field, fe.Message)
+			}
+		case *upload.ValidationError:
+			connSt.setError(e.Field, e.Message)
+		default:
+			connSt.setError("_general", streamErr.Error())
+		}
+	}
 
 	// __navigate__ is a WebSocket-only reserved action. Reject early so HTTP
 	// clients get a clear "wrong transport" error instead of a confusing
@@ -2323,154 +2406,83 @@ func (h *liveHandler) handleUploadAction(ctx context.Context, rawData []byte, ms
 	}
 }
 
+// hasProxiedUpload reports whether any configured upload field uses Proxied mode.
+func (h *liveHandler) hasProxiedUpload() bool {
+	for _, c := range h.config.UploadConfigs {
+		if c.Mode == uploadtypes.UploadModeProxied {
+			return true
+		}
+	}
+	return false
+}
+
+// streamProxiedPart streams one Proxied file part straight to Controller.OnUpload
+// with zero local-disk staging, then records the result as a completed upload
+// entry (ExternalRef set by the handler via SetResult) so the follow-on action
+// reads it via ctx.GetCompletedUploads. Accept is validated from the header
+// before any bytes are read; MaxFileSize is enforced mid-stream by LimitGuard.
+func (h *liveHandler) streamProxiedPart(part *multipart.Part, uploadRegistry uploadRegistry, ctx *Context) error {
+	field := part.FormName()
+	cfg := h.config.UploadConfigs[field]
+
+	if err := upload.ValidateFileHeader(part.FileName(), part.Header.Get("Content-Type"), cfg); err != nil {
+		return err
+	}
+
+	streamer, ok := h.config.Controller.(UploadStreamer)
+	if !ok {
+		return &upload.ValidationError{Field: field, Message: "controller does not implement OnUpload for streaming uploads"}
+	}
+
+	entryID, err := upload.GenerateEntryID()
+	if err != nil {
+		return fmt.Errorf("failed to generate entry ID: %w", err)
+	}
+
+	entry := &uploadtypes.UploadEntry{
+		ID:         entryID,
+		ClientName: part.FileName(),
+		ClientType: part.Header.Get("Content-Type"),
+		ClientSize: -1,
+	}
+
+	guard := upload.NewLimitGuard(part, cfg.MaxFileSize)
+	up := &UploadPart{
+		Reader:     guard,
+		Field:      field,
+		Filename:   entry.ClientName,
+		ClientType: entry.ClientType,
+		ClientSize: -1,
+		entry:      entry,
+	}
+
+	if err := streamer.OnUpload(up, ctx); err != nil {
+		return err
+	}
+
+	entry.ClientSize = guard.Count()
+	entry.Valid = true
+	entry.Done = true
+	entry.Progress = 100
+
+	if reg, ok := uploadRegistry.(*upload.Registry); ok {
+		if u := reg.GetUpload(field); u != nil {
+			if upl, ok := u.(*upload.Upload); ok {
+				if addErr := upl.AddEntry(entry); addErr != nil {
+					return &upload.ValidationError{Field: field, Message: addErr.Error()}
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // handleUploadStart processes upload_start action from WebSocket client.
 // Client sends file metadata, server creates upload entries and responds with entry IDs.
 func (h *liveHandler) handleUploadStart(rawData []byte, state *connState, uploadRegistry uploadRegistry, connection *session.Connection) error {
-	// Parse upload_start message from raw WebSocket data
-	startMsg, err := upload.ParseUploadStartMessage(rawData)
+	response, err := h.buildUploadStartResponse(rawData, state.groupID, uploadRegistry)
 	if err != nil {
-		return fmt.Errorf("invalid upload_start message: %w", err)
-	}
-
-	// Type assert to get concrete Registry type
-	registry, ok := uploadRegistry.(*upload.Registry)
-	if !ok {
-		return fmt.Errorf("invalid upload registry type")
-	}
-
-	// Get upload configuration
-	uploadObj := registry.GetUpload(startMsg.UploadName)
-	if uploadObj == nil {
-		return fmt.Errorf("upload %q not configured", startMsg.UploadName)
-	}
-
-	uploadInstance, ok := uploadObj.(*upload.Upload)
-	if !ok {
-		return fmt.Errorf("invalid upload object type")
-	}
-
-	// Validate file count
-	if err := upload.ValidateCount(len(startMsg.Files), uploadInstance.Config); err != nil {
-		return fmt.Errorf("file count validation failed: %w", err)
-	}
-
-	// Create upload entries for each file
-	response := &upload.UploadStartResponse{
-		UploadName: startMsg.UploadName,
-		Entries:    make([]upload.UploadEntryInfo, 0, len(startMsg.Files)),
-	}
-
-	tempFileManager := h.tempFileManager.(*upload.TempFileManager)
-	sessionID := state.groupID
-
-	// Check if external presigner is configured
-	isExternal := uploadInstance.Config.External != nil
-
-	for _, fileMeta := range startMsg.Files {
-		// Generate entry ID
-		entryID, err := upload.GenerateEntryID()
-		if err != nil {
-			return fmt.Errorf("failed to generate entry ID: %w", err)
-		}
-
-		// Create upload entry with metadata
-		entry := &uploadtypes.UploadEntry{
-			ID:         entryID,
-			ClientName: fileMeta.Name,
-			ClientType: fileMeta.Type,
-			ClientSize: fileMeta.Size,
-			Progress:   0,
-			Done:       false,
-			Valid:      false, // Will be validated when entry is added
-			BytesRecv:  0,
-		}
-
-		var entryInfo upload.UploadEntryInfo
-
-		if isExternal {
-			// External upload: generate presigned URL
-			presignMeta, err := uploadInstance.Config.External.Presign(entry)
-			if err != nil {
-				entryInfo = upload.UploadEntryInfo{
-					EntryID:    entryID,
-					ClientName: fileMeta.Name,
-					Valid:      false,
-					Error:      fmt.Sprintf("failed to presign: %v", err),
-					AutoUpload: uploadInstance.Config.AutoUpload,
-				}
-			} else {
-				// Store external reference in entry
-				entry.ExternalRef = presignMeta.URL
-
-				// Validate and add entry to registry
-				if err := uploadInstance.AddEntry(entry); err != nil {
-					entryInfo = upload.UploadEntryInfo{
-						EntryID:    entryID,
-						ClientName: fileMeta.Name,
-						Valid:      false,
-						Error:      err.Error(),
-						AutoUpload: uploadInstance.Config.AutoUpload,
-					}
-				} else {
-					// Return presigned metadata to client
-					entryInfo = upload.UploadEntryInfo{
-						EntryID:    entryID,
-						ClientName: fileMeta.Name,
-						Valid:      true,
-						Error:      "",
-						AutoUpload: uploadInstance.Config.AutoUpload,
-						External: &upload.ExternalUploadMeta{
-							Uploader: presignMeta.Uploader,
-							URL:      presignMeta.URL,
-							Fields:   presignMeta.Fields,
-							Headers:  presignMeta.Headers,
-						},
-					}
-				}
-			}
-		} else {
-			// Server-side upload: create temp file
-			tempPath, err := tempFileManager.CreateTempFile(sessionID, startMsg.UploadName, entryID)
-			if err != nil {
-				entryInfo = upload.UploadEntryInfo{
-					EntryID:    entryID,
-					ClientName: fileMeta.Name,
-					Valid:      false,
-					Error:      fmt.Sprintf("failed to create temp file: %v", err),
-					AutoUpload: uploadInstance.Config.AutoUpload,
-				}
-			} else {
-				entry.TempPath = tempPath
-
-				// Validate and add entry to registry
-				if err := uploadInstance.AddEntry(entry); err != nil {
-					entryInfo = upload.UploadEntryInfo{
-						EntryID:    entryID,
-						ClientName: fileMeta.Name,
-						Valid:      false,
-						Error:      err.Error(),
-						AutoUpload: uploadInstance.Config.AutoUpload,
-					}
-					// Remove temp file since entry is invalid
-					if rmErr := os.Remove(tempPath); rmErr != nil {
-						slog.Warn("Failed to remove temp file",
-							slog.String("component", "upload_handler"),
-							slog.String("path", tempPath),
-							slog.Any("error", rmErr))
-					}
-				} else {
-					entryInfo = upload.UploadEntryInfo{
-						EntryID:    entryID,
-						ClientName: fileMeta.Name,
-						Valid:      true,
-						Error:      "",
-						AutoUpload: uploadInstance.Config.AutoUpload,
-					}
-				}
-			}
-		}
-
-		response.Entries = append(response.Entries, entryInfo)
+		return err
 	}
 
 	// Send UploadStartResponse to client so it can create upload entries
@@ -2488,6 +2500,133 @@ func (h *liveHandler) handleUploadStart(rawData []byte, state *connState, upload
 	// upload completion when store data actually changes.
 
 	return nil
+}
+
+// buildUploadStartResponse validates the requested files and produces the
+// per-entry handshake reply (mode, validation, presigned meta) WITHOUT sending
+// it. Both the WebSocket handler and the HTTP fallback (used when the socket is
+// disabled) call this and transmit the result over their own transport.
+func (h *liveHandler) buildUploadStartResponse(rawData []byte, sessionID string, uploadRegistry uploadRegistry) (*upload.UploadStartResponse, error) {
+	// Parse upload_start message from raw transport data
+	startMsg, err := upload.ParseUploadStartMessage(rawData)
+	if err != nil {
+		return nil, fmt.Errorf("invalid upload_start message: %w", err)
+	}
+
+	// Type assert to get concrete Registry type
+	registry, ok := uploadRegistry.(*upload.Registry)
+	if !ok {
+		return nil, fmt.Errorf("invalid upload registry type")
+	}
+
+	// Get upload configuration
+	uploadObj := registry.GetUpload(startMsg.UploadName)
+	if uploadObj == nil {
+		return nil, fmt.Errorf("upload %q not configured", startMsg.UploadName)
+	}
+
+	uploadInstance, ok := uploadObj.(*upload.Upload)
+	if !ok {
+		return nil, fmt.Errorf("invalid upload object type")
+	}
+
+	// Validate file count
+	if err := upload.ValidateCount(len(startMsg.Files), uploadInstance.Config); err != nil {
+		return nil, fmt.Errorf("file count validation failed: %w", err)
+	}
+
+	// Create upload entries for each file
+	response := &upload.UploadStartResponse{
+		UploadName: startMsg.UploadName,
+		Entries:    make([]upload.UploadEntryInfo, 0, len(startMsg.Files)),
+	}
+
+	autoUpload := uploadInstance.Config.AutoUpload
+	mode := uploadInstance.Config.Mode
+
+	for _, fileMeta := range startMsg.Files {
+		// Generate entry ID
+		entryID, err := upload.GenerateEntryID()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate entry ID: %w", err)
+		}
+
+		// Create upload entry with metadata
+		entry := &uploadtypes.UploadEntry{
+			ID:         entryID,
+			ClientName: fileMeta.Name,
+			ClientType: fileMeta.Type,
+			ClientSize: fileMeta.Size,
+			Progress:   0,
+			Done:       false,
+			Valid:      false, // Will be validated when entry is added
+			BytesRecv:  0,
+		}
+
+		entryInfo := upload.UploadEntryInfo{
+			EntryID:    entryID,
+			ClientName: fileMeta.Name,
+			AutoUpload: autoUpload,
+		}
+
+		switch mode {
+		case uploadtypes.UploadModeDirect:
+			// Direct: presign so the browser PUTs straight to cloud storage.
+			presignMeta, err := uploadInstance.Config.External.Presign(entry)
+			if err != nil {
+				entryInfo.Error = fmt.Sprintf("failed to presign: %v", err)
+			} else {
+				entry.ExternalRef = presignMeta.URL
+				if err := uploadInstance.AddEntry(entry); err != nil {
+					entryInfo.Error = err.Error()
+				} else {
+					entryInfo.Valid = true
+					entryInfo.External = &upload.ExternalUploadMeta{
+						Uploader: presignMeta.Uploader,
+						URL:      presignMeta.URL,
+						Fields:   presignMeta.Fields,
+						Headers:  presignMeta.Headers,
+					}
+				}
+			}
+
+		case uploadtypes.UploadModeProxied, uploadtypes.UploadModePreview:
+			// Proxied bytes arrive via a follow-on HTTP multipart POST; Preview
+			// bytes never leave the device. Neither stages to disk here — the
+			// handshake only validates metadata so the client can dispatch.
+			if err := upload.ValidateEntry(entry, uploadInstance.Config); err != nil {
+				entryInfo.Error = err.Error()
+			} else {
+				entryInfo.Valid = true
+			}
+
+		default: // UploadModeVolume
+			// Server-side staging: create a temp file the chunk handler appends to.
+			tempFileManager := h.tempFileManager.(*upload.TempFileManager)
+			tempPath, err := tempFileManager.CreateTempFile(sessionID, startMsg.UploadName, entryID)
+			if err != nil {
+				entryInfo.Error = fmt.Sprintf("failed to create temp file: %v", err)
+			} else {
+				entry.TempPath = tempPath
+				if err := uploadInstance.AddEntry(entry); err != nil {
+					entryInfo.Error = err.Error()
+					if rmErr := os.Remove(tempPath); rmErr != nil {
+						slog.Warn("Failed to remove temp file",
+							slog.String("component", "upload_handler"),
+							slog.String("path", tempPath),
+							slog.Any("error", rmErr))
+					}
+				} else {
+					entryInfo.Valid = true
+				}
+			}
+		}
+
+		entryInfo.Mode = mode.String()
+		response.Entries = append(response.Entries, entryInfo)
+	}
+
+	return response, nil
 }
 
 // handleUploadChunk processes upload_chunk action from WebSocket client.

--- a/mount.go
+++ b/mount.go
@@ -2601,21 +2601,27 @@ func (h *liveHandler) buildUploadStartResponse(rawData []byte, sessionID string,
 			}
 
 		default: // UploadModeVolume
-			// Server-side staging: create a temp file the chunk handler appends to.
-			tfm, ok := h.tempFileManager.(*upload.TempFileManager)
-			if !ok || tfm == nil {
+			// Create the staging file the chunk handler appends to. With Dir set
+			// the file is retained there (the app owns its lifecycle); otherwise
+			// it stages under the session temp dir and is cleaned on disconnect.
+			var tempPath string
+			var err error
+			if dir := uploadInstance.Config.Dir; dir != "" {
+				tempPath, err = upload.CreateRetainedFile(dir, startMsg.UploadName, entryID)
+			} else if tfm, ok := h.tempFileManager.(*upload.TempFileManager); ok && tfm != nil {
+				tempPath, err = tfm.CreateTempFile(sessionID, startMsg.UploadName, entryID)
+			} else {
 				entryInfo.Error = "uploads unavailable: temp file manager not initialized"
 				break
 			}
-			tempPath, err := tfm.CreateTempFile(sessionID, startMsg.UploadName, entryID)
 			if err != nil {
-				entryInfo.Error = fmt.Sprintf("failed to create temp file: %v", err)
+				entryInfo.Error = fmt.Sprintf("failed to create upload file: %v", err)
 			} else {
 				entry.TempPath = tempPath
 				if err := uploadInstance.AddEntry(entry); err != nil {
 					entryInfo.Error = err.Error()
 					if rmErr := os.Remove(tempPath); rmErr != nil {
-						slog.Warn("Failed to remove temp file",
+						slog.Warn("Failed to remove upload file",
 							slog.String("component", "upload_handler"),
 							slog.String("path", tempPath),
 							slog.Any("error", rmErr))

--- a/mount.go
+++ b/mount.go
@@ -1293,11 +1293,43 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Byte-level progress: wrap the multipart body before any parsing so both the
+	// streaming (MultipartReader) and Tier-1 (ParseMultipartForm) paths broadcast
+	// upload progress to connections in the group. ProgressReader is a pass-through
+	// counter, so MultipartReader reads through it unaffected.
+	if strings.HasPrefix(ct, "multipart/form-data") && r.ContentLength > 0 && len(h.config.UploadConfigs) > 0 {
+		pr := upload.NewProgressReader(r.Body, r.ContentLength)
+		pr.OnProgress = func(bytesRead, total int64) {
+			conns := h.registry.GetByGroupExcept(groupID, nil)
+			if len(conns) == 0 {
+				return
+			}
+			pct := int(bytesRead * 100 / total)
+			progressMsg := &upload.UploadProgressMessage{
+				Type:       "upload_progress",
+				UploadName: "multipart",
+				Progress:   pct,
+				BytesRecv:  bytesRead,
+				BytesTotal: total,
+			}
+			progressBytes, err := upload.SerializeUploadProgressMessage(progressMsg)
+			if err != nil {
+				return
+			}
+			for _, conn := range conns {
+				if err := conn.Send(WSTextMessage, progressBytes); err != nil {
+					// Client may have disconnected — non-fatal for progress updates
+					continue
+				}
+			}
+		}
+		r.Body = pr
+	}
+
 	// Proxied streaming uploads: a multipart request carrying a field whose Mode
 	// is Proxied is iterated via MultipartReader (zero disk) and each file part is
-	// streamed straight to Controller.OnUpload. This bypasses ParseMultipartForm
-	// (which would stage large parts to os.TempDir) and the byte-progress wrapper
-	// (which would consume the body before MultipartReader sees it).
+	// streamed straight to Controller.OnUpload, bypassing ParseMultipartForm
+	// (which would stage large parts to os.TempDir).
 	streamingRequest := strings.HasPrefix(ct, "multipart/form-data") && h.hasProxied
 
 	var msg message
@@ -1331,38 +1363,6 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		msg = send.BuildActionFromValues(values)
 		applyDefaultAction(&msg)
 	} else {
-		// Tier 1 file uploads: wrap request body with progress tracking before
-		// any multipart parsing occurs. ParseMultipartForm reads through this
-		// wrapper, giving us byte-level progress for WebSocket clients.
-		if strings.HasPrefix(ct, "multipart/form-data") && r.ContentLength > 0 && len(h.config.UploadConfigs) > 0 {
-			pr := upload.NewProgressReader(r.Body, r.ContentLength)
-			pr.OnProgress = func(bytesRead, total int64) {
-				conns := h.registry.GetByGroupExcept(groupID, nil)
-				if len(conns) == 0 {
-					return
-				}
-				pct := int(bytesRead * 100 / total)
-				progressMsg := &upload.UploadProgressMessage{
-					Type:       "upload_progress",
-					UploadName: "multipart",
-					Progress:   pct,
-					BytesRecv:  bytesRead,
-					BytesTotal: total,
-				}
-				progressBytes, err := upload.SerializeUploadProgressMessage(progressMsg)
-				if err != nil {
-					return
-				}
-				for _, conn := range conns {
-					if err := conn.Send(WSTextMessage, progressBytes); err != nil {
-						// Client may have disconnected — non-fatal for progress updates
-						continue
-					}
-				}
-			}
-			r.Body = pr
-		}
-
 		// Parse message
 		var err error
 		msg, err = parseActionFromHTTP(r)
@@ -2460,11 +2460,17 @@ func (h *liveHandler) streamProxiedPart(part *multipart.Part, uploadRegistry upl
 	}
 
 	if err := streamer.OnUpload(up, ctx); err != nil {
-		// Surface an over-limit stream on the field, not as a general error.
+		// Preserve an app-targeted error (it may name a different field); surface
+		// everything else — including ErrUploadTooLarge and opaque backend errors
+		// — on this upload's field rather than as a general banner.
+		switch err.(type) {
+		case FieldError, MultiError, *upload.ValidationError:
+			return err
+		}
 		if errors.Is(err, uploadtypes.ErrUploadTooLarge) {
 			return &upload.ValidationError{Field: field, Message: fmt.Sprintf("file exceeds maximum size of %d bytes", cfg.MaxFileSize)}
 		}
-		return err
+		return &upload.ValidationError{Field: field, Message: err.Error()}
 	}
 
 	entry.ClientSize = guard.Count()
@@ -2533,6 +2539,12 @@ func (h *liveHandler) stageVolumePart(part *multipart.Part, uploadRegistry uploa
 	_, copyErr := io.Copy(dst, guard)
 	closeErr := dst.Close()
 	if copyErr != nil || closeErr != nil {
+		if copyErr != nil && closeErr != nil {
+			slog.Warn("Volume staging failed on both write and close",
+				slog.String("component", "upload_handler"),
+				slog.Any("write_error", copyErr),
+				slog.Any("close_error", closeErr))
+		}
 		if rmErr := os.Remove(dstPath); rmErr != nil {
 			slog.Warn("Failed to remove upload file",
 				slog.String("component", "upload_handler"),

--- a/preview_test.go
+++ b/preview_test.go
@@ -1,0 +1,68 @@
+package livetemplate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/livetemplate/internal/upload"
+)
+
+// TestPreviewUpload_SynthesizesMetadataEntry verifies that a Preview field's
+// handshake records a metadata-only entry (no bytes, no disk) that the app reads
+// via GetCompletedUploads to render a placeholder.
+func TestPreviewUpload_SynthesizesMetadataEntry(t *testing.T) {
+	reg := upload.NewRegistry()
+	if err := reg.CreateUpload("draft", UploadConfig{Mode: UploadModePreview}); err != nil {
+		t.Fatalf("CreateUpload: %v", err)
+	}
+
+	h := &liveHandler{}
+	raw := []byte(`{"action":"upload_start","upload_name":"draft","files":[{"name":"p.png","type":"image/png","size":10}]}`)
+	resp, err := h.buildUploadStartResponse(raw, "sess", reg)
+	if err != nil {
+		t.Fatalf("buildUploadStartResponse: %v", err)
+	}
+	if len(resp.Entries) != 1 || !resp.Entries[0].Valid {
+		t.Fatalf("expected 1 valid entry, got %+v", resp.Entries)
+	}
+	if resp.Entries[0].Mode != "preview" {
+		t.Errorf("expected mode=preview, got %q", resp.Entries[0].Mode)
+	}
+
+	u := reg.GetUpload("draft").(*upload.Upload)
+	completed := u.GetCompletedEntries()
+	if len(completed) != 1 {
+		t.Fatalf("expected 1 completed (preview) entry, got %d", len(completed))
+	}
+	e := completed[0]
+	if !e.Preview {
+		t.Error("expected entry.Preview=true")
+	}
+	if e.TempPath != "" || e.ExternalRef != "" {
+		t.Errorf("preview entry must carry no bytes ref: TempPath=%q ExternalRef=%q", e.TempPath, e.ExternalRef)
+	}
+	if e.ClientName != "p.png" || e.ClientSize != 10 {
+		t.Errorf("expected metadata p.png/10, got %s/%d", e.ClientName, e.ClientSize)
+	}
+}
+
+// TestUploadPreviewHelper verifies the template helper emits the placeholder the
+// client fills with a local object URL.
+func TestUploadPreviewHelper(t *testing.T) {
+	tmpl, err := New("test", WithUpload("draft", UploadConfig{Mode: UploadModePreview}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := tmpl.Parse(`<div>{{.lvt.UploadPreview "draft"}}</div>`); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, AsState(&testHandleState{}), nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := sb.String()
+	if !strings.Contains(out, `data-lvt-upload-preview="draft"`) {
+		t.Errorf("expected preview placeholder in output, got: %s", out)
+	}
+}

--- a/streaming_proxied_test.go
+++ b/streaming_proxied_test.go
@@ -1,0 +1,203 @@
+package livetemplate
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// proxiedState is pure data for the Proxied streaming tests.
+type proxiedState struct {
+	Ref string `lvt:"persist"`
+}
+
+// proxiedController implements UploadStreamer, streaming each part into an
+// in-memory "remote" backend instead of local disk.
+type proxiedController struct {
+	received map[string][]byte
+	refs     []string
+}
+
+func (c *proxiedController) OnUpload(part *UploadPart, ctx *Context) error {
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, part); err != nil {
+		return err // e.g. ErrUploadTooLarge — aborts before SetResult
+	}
+	if c.received == nil {
+		c.received = make(map[string][]byte)
+	}
+	c.received[part.Filename] = buf.Bytes()
+	part.SetResult("memory://" + part.Filename)
+	return nil
+}
+
+func (c *proxiedController) SaveDoc(state proxiedState, ctx *Context) (proxiedState, error) {
+	for _, e := range ctx.GetCompletedUploads("doc") {
+		state.Ref = e.ExternalRef
+		c.refs = append(c.refs, e.ExternalRef)
+	}
+	return state, nil
+}
+
+// postProxiedFile POSTs a multipart form with one "doc" file part and the
+// SaveDoc action, returning the response status.
+func postProxiedFile(t *testing.T, serverURL string, cookies []*http.Cookie, filename string, content []byte) int {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("lvt-action", "SaveDoc"); err != nil {
+		t.Fatalf("WriteField failed: %v", err)
+	}
+	part, err := writer.CreateFormFile("doc", filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile failed: %v", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		t.Fatalf("write file content failed: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer close failed: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", serverURL+"/", &body)
+	if err != nil {
+		t.Fatalf("NewRequest failed: %v", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Logf("body close failed: %v", err)
+	}
+	return resp.StatusCode
+}
+
+func newProxiedServer(t *testing.T, cfg UploadConfig, ctrl *proxiedController) (*httptest.Server, []*http.Cookie) {
+	t.Helper()
+	tmpl, err := New("test", WithUpload("doc", cfg))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>{{.Ref}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	server := httptest.NewServer(tmpl.Handle(ctrl, AsState(&proxiedState{})))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(".uploads"); err != nil {
+			t.Logf("cleanup .uploads failed: %v", err)
+		}
+	})
+
+	resp, err := http.Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	cookies := resp.Cookies()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("body close failed: %v", err)
+	}
+	return server, cookies
+}
+
+// uploadsTempFileCount counts regular files staged under ./.uploads (the temp
+// staging tree). Proxied streaming must never write here.
+func uploadsTempFileCount(t *testing.T) int {
+	t.Helper()
+	count := 0
+	_ = filepath.Walk(".uploads", func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info != nil && !info.IsDir() {
+			count++
+		}
+		return nil
+	})
+	return count
+}
+
+func TestProxiedUpload_StreamsToBackend_ZeroDisk(t *testing.T) {
+	ctrl := &proxiedController{}
+	server, cookies := newProxiedServer(t, UploadConfig{
+		Mode:        UploadModeProxied,
+		Accept:      []string{"image/png"},
+		MaxFileSize: 5 << 20,
+	}, ctrl)
+
+	payload := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x01, 0x02}
+	if status := postProxiedFile(t, server.URL, cookies, "scan.png", payload); status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+
+	// The handler streamed the exact bytes to the in-memory backend.
+	got, ok := ctrl.received["scan.png"]
+	if !ok {
+		t.Fatal("backend did not receive the file")
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("backend bytes mismatch: got %x want %x", got, payload)
+	}
+
+	// The follow-on action read the streamed result via ExternalRef.
+	if len(ctrl.refs) != 1 || ctrl.refs[0] != "memory://scan.png" {
+		t.Errorf("expected ExternalRef from GetCompletedUploads, got %v", ctrl.refs)
+	}
+
+	// Zero-disk: nothing was staged under .uploads.
+	if n := uploadsTempFileCount(t); n != 0 {
+		t.Errorf("expected zero staged temp files, found %d", n)
+	}
+}
+
+func TestProxiedUpload_OversizeAborts(t *testing.T) {
+	ctrl := &proxiedController{}
+	server, cookies := newProxiedServer(t, UploadConfig{
+		Mode:        UploadModeProxied,
+		MaxFileSize: 4, // smaller than the payload
+	}, ctrl)
+
+	if status := postProxiedFile(t, server.URL, cookies, "big.bin", []byte("0123456789")); status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+
+	// Oversize stream aborts: no completed upload, no ExternalRef recorded.
+	if len(ctrl.refs) != 0 {
+		t.Errorf("expected no completed uploads on oversize, got %v", ctrl.refs)
+	}
+	if n := uploadsTempFileCount(t); n != 0 {
+		t.Errorf("expected zero staged temp files, found %d", n)
+	}
+}
+
+func TestProxiedUpload_RejectsDisallowedType(t *testing.T) {
+	ctrl := &proxiedController{}
+	server, cookies := newProxiedServer(t, UploadConfig{
+		Mode:   UploadModeProxied,
+		Accept: []string{"image/png"},
+	}, ctrl)
+
+	if status := postProxiedFile(t, server.URL, cookies, "notes.txt", []byte("hello")); status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+
+	// Accept rejection happens from the header before OnUpload runs.
+	if _, ok := ctrl.received["notes.txt"]; ok {
+		t.Error("OnUpload should not run for a disallowed type")
+	}
+	if len(ctrl.refs) != 0 {
+		t.Errorf("expected no completed uploads, got %v", ctrl.refs)
+	}
+}

--- a/streaming_proxied_test.go
+++ b/streaming_proxied_test.go
@@ -2,12 +2,14 @@ package livetemplate
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -179,6 +181,50 @@ func TestProxiedUpload_OversizeAborts(t *testing.T) {
 	}
 	if n := uploadsTempFileCount(t); n != 0 {
 		t.Errorf("expected zero staged temp files, found %d", n)
+	}
+}
+
+func TestProxiedUpload_HTTPHandshake_WSDisabled(t *testing.T) {
+	ctrl := &proxiedController{}
+	server, cookies := newProxiedServer(t, UploadConfig{
+		Mode:   UploadModeProxied,
+		Accept: []string{"image/*"},
+	}, ctrl)
+
+	body := `{"action":"upload_start","upload_name":"doc","files":[{"name":"scan.png","type":"image/png","size":10}]}`
+	req, err := http.NewRequest("POST", server.URL+"/", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Lvt-Upload", "start") // marks the WS-disabled handshake
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var out struct {
+		UploadName string `json:"upload_name"`
+		Entries    []struct {
+			Valid bool   `json:"valid"`
+			Mode  string `json:"mode"`
+		} `json:"entries"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode handshake response: %v", err)
+	}
+	if out.UploadName != "doc" || len(out.Entries) != 1 {
+		t.Fatalf("unexpected handshake response: %+v", out)
+	}
+	if !out.Entries[0].Valid || out.Entries[0].Mode != "proxied" {
+		t.Errorf("expected valid proxied entry, got %+v", out.Entries[0])
 	}
 }
 

--- a/streaming_proxied_test.go
+++ b/streaming_proxied_test.go
@@ -184,6 +184,92 @@ func TestProxiedUpload_OversizeAborts(t *testing.T) {
 	}
 }
 
+type mixedState struct{}
+
+type mixedController struct {
+	proxied map[string][]byte
+}
+
+func (c *mixedController) OnUpload(part *UploadPart, ctx *Context) error {
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, part); err != nil {
+		return err
+	}
+	if c.proxied == nil {
+		c.proxied = make(map[string][]byte)
+	}
+	c.proxied[part.Filename] = buf.Bytes()
+	part.SetResult("mem://" + part.Filename)
+	return nil
+}
+
+func (c *mixedController) Submit(s mixedState, ctx *Context) (mixedState, error) { return s, nil }
+
+// TestMixedProxiedVolume_StagesBothInOneRequest verifies that a Volume file part
+// sharing a streaming (Proxied) multipart request is staged to disk rather than
+// silently dropped.
+func TestMixedProxiedVolume_StagesBothInOneRequest(t *testing.T) {
+	volumeDir := t.TempDir()
+	ctrl := &mixedController{}
+	tmpl := Must(New("test",
+		WithUpload("doc", UploadConfig{Mode: UploadModeProxied}),
+		WithUpload("scan", UploadConfig{Mode: UploadModeVolume, Dir: volumeDir}),
+	))
+	tmpl = Must(tmpl.Parse(`<div>ok</div>`))
+	server := httptest.NewServer(tmpl.Handle(ctrl, AsState(&mixedState{})))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { _ = os.RemoveAll(".uploads") })
+
+	resp, err := http.Get(server.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	cookies := resp.Cookies()
+	_ = resp.Body.Close()
+
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	_ = w.WriteField("lvt-action", "Submit")
+	docPart, _ := w.CreateFormFile("doc", "d.png")
+	_, _ = docPart.Write([]byte("proxied-bytes"))
+	scanPart, _ := w.CreateFormFile("scan", "s.png")
+	_, _ = scanPart.Write([]byte("volume-bytes"))
+	_ = w.Close()
+
+	req, _ := http.NewRequest("POST", server.URL+"/", &body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp2, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_ = resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp2.StatusCode)
+	}
+
+	// Proxied part streamed to OnUpload.
+	if got := ctrl.proxied["d.png"]; string(got) != "proxied-bytes" {
+		t.Errorf("proxied part = %q, want %q", got, "proxied-bytes")
+	}
+	// Volume part staged to disk (not dropped).
+	found := false
+	_ = filepath.Walk(volumeDir, func(p string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && !info.IsDir() {
+			if b, _ := os.ReadFile(p); string(b) == "volume-bytes" {
+				found = true
+			}
+		}
+		return nil
+	})
+	if !found {
+		t.Error("volume part was dropped — expected it staged under Dir")
+	}
+}
+
 func TestProxiedUpload_HTTPHandshake_WSDisabled(t *testing.T) {
 	ctrl := &proxiedController{}
 	server, cookies := newProxiedServer(t, UploadConfig{

--- a/template.go
+++ b/template.go
@@ -629,7 +629,21 @@ func WithCookieMaxAge(maxAge time.Duration) Option {
 //	    }
 //	    return state, nil
 //	}
-//
+func WithUpload(name string, config uploadtypes.UploadConfig) Option {
+	return func(c *Config) {
+		if c.UploadConfigs == nil {
+			c.UploadConfigs = make(map[string]uploadtypes.UploadConfig)
+		}
+		// Back-compat: a config that sets External without an explicit Mode is a
+		// Direct (presigned) upload. UploadModeVolume is the zero value, so this
+		// only promotes the legacy "External implies direct-to-storage" shape.
+		if config.External != nil && config.Mode == uploadtypes.UploadModeVolume {
+			config.Mode = uploadtypes.UploadModeDirect
+		}
+		c.UploadConfigs[name] = config
+	}
+}
+
 // uploadConfigsNeedDisk reports whether any configured upload field stages bytes
 // to the local filesystem (Volume mode). Direct/Proxied/Preview never do, so a
 // template using only those needs no temp file manager.
@@ -651,21 +665,6 @@ func uploadConfigsHaveProxied(configs map[string]uploadtypes.UploadConfig) bool 
 		}
 	}
 	return false
-}
-
-func WithUpload(name string, config uploadtypes.UploadConfig) Option {
-	return func(c *Config) {
-		if c.UploadConfigs == nil {
-			c.UploadConfigs = make(map[string]uploadtypes.UploadConfig)
-		}
-		// Back-compat: a config that sets External without an explicit Mode is a
-		// Direct (presigned) upload. UploadModeVolume is the zero value, so this
-		// only promotes the legacy "External implies direct-to-storage" shape.
-		if config.External != nil && config.Mode == uploadtypes.UploadModeVolume {
-			config.Mode = uploadtypes.UploadModeDirect
-		}
-		c.UploadConfigs[name] = config
-	}
 }
 
 // WithPubSubBroadcaster enables distributed peer-fan-out across multiple application instances.

--- a/template.go
+++ b/template.go
@@ -634,6 +634,12 @@ func WithUpload(name string, config uploadtypes.UploadConfig) Option {
 		if c.UploadConfigs == nil {
 			c.UploadConfigs = make(map[string]uploadtypes.UploadConfig)
 		}
+		// Back-compat: a config that sets External without an explicit Mode is a
+		// Direct (presigned) upload. UploadModeVolume is the zero value, so this
+		// only promotes the legacy "External implies direct-to-storage" shape.
+		if config.External != nil && config.Mode == uploadtypes.UploadModeVolume {
+			config.Mode = uploadtypes.UploadModeDirect
+		}
 		c.UploadConfigs[name] = config
 	}
 }

--- a/template.go
+++ b/template.go
@@ -642,6 +642,17 @@ func uploadConfigsNeedDisk(configs map[string]uploadtypes.UploadConfig) bool {
 	return false
 }
 
+// uploadConfigsHaveProxied reports whether any configured upload field uses
+// Proxied mode (cached on the handler to gate the streaming HTTP path).
+func uploadConfigsHaveProxied(configs map[string]uploadtypes.UploadConfig) bool {
+	for _, c := range configs {
+		if c.Mode == uploadtypes.UploadModeProxied {
+			return true
+		}
+	}
+	return false
+}
+
 func WithUpload(name string, config uploadtypes.UploadConfig) Option {
 	return func(c *Config) {
 		if c.UploadConfigs == nil {
@@ -1648,6 +1659,7 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 		limits:          limits,
 		metricsExporter: metricsExporter,
 		tempFileManager: tempFileManager,
+		hasProxied:      uploadConfigsHaveProxied(t.config.UploadConfigs),
 		shutdownChan:    make(chan struct{}),
 	}
 

--- a/template.go
+++ b/template.go
@@ -629,6 +629,19 @@ func WithCookieMaxAge(maxAge time.Duration) Option {
 //	    }
 //	    return state, nil
 //	}
+//
+// uploadConfigsNeedDisk reports whether any configured upload field stages bytes
+// to the local filesystem (Volume mode). Direct/Proxied/Preview never do, so a
+// template using only those needs no temp file manager.
+func uploadConfigsNeedDisk(configs map[string]uploadtypes.UploadConfig) bool {
+	for _, c := range configs {
+		if c.Mode == uploadtypes.UploadModeVolume {
+			return true
+		}
+	}
+	return false
+}
+
 func WithUpload(name string, config uploadtypes.UploadConfig) Option {
 	return func(c *Config) {
 		if c.UploadConfigs == nil {
@@ -1608,13 +1621,16 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 	// Initialize upload factories (lazy, done once)
 	initUploadFactories()
 
-	// Avoid creating .uploads temp directory for templates that don't use uploads
+	// Only stage to local disk for Volume-mode uploads. Direct, Proxied, and
+	// Preview never touch the server's filesystem, so a pure-remote-storage app
+	// needs no writable working directory and must not fail at startup creating
+	// .uploads — the deploy-time failure that motivated streaming uploads (#447).
 	var tempFileManager uploadTempFileManager
-	if len(t.config.UploadConfigs) > 0 {
+	if uploadConfigsNeedDisk(t.config.UploadConfigs) {
 		var err error
 		tempFileManager, err = newUploadTempFileManager("")
 		if err != nil {
-			slog.Error("Failed to create temp file manager - uploads will not work",
+			slog.Error("Failed to create temp file manager - Volume-mode uploads will not work",
 				slog.Any("error", err))
 		}
 	}

--- a/upload.go
+++ b/upload.go
@@ -16,7 +16,9 @@ import (
 //   - AutoUpload: Whether to start upload automatically on file selection
 //   - ChunkSize: Chunk size for WebSocket uploads in bytes (default: 256KB)
 //   - Mode: Upload destination (Volume | Direct | Proxied | Preview; default Volume)
-//   - External: Presigner for Direct mode (browser → cloud via presigned URL)
+//   - External: Presigner for Direct mode (browser → cloud via presigned URL).
+//     Setting External without an explicit Mode promotes the field to
+//     UploadModeDirect for backward compatibility.
 //   - Dir: Retain destination for Volume mode (defaults to a temp dir)
 type UploadConfig = uploadtypes.UploadConfig
 
@@ -40,6 +42,10 @@ const (
 // uploads inline as an io.Reader, with zero local-disk staging. OnUpload is
 // invoked once per file part while the bytes are still in flight; the handler
 // streams them to remote storage and records the final reference via SetResult.
+//
+// OnUpload runs during the multipart body read, before the action handler, so
+// ctx does NOT carry session/typed state — use SetResult to hand the stored
+// reference to the follow-on action (read there via ctx.GetCompletedUploads).
 //
 //	func (c *C) OnUpload(part *livetemplate.UploadPart, ctx *livetemplate.Context) error {
 //	    ref, err := myBackend.Put(ctx, part.Filename, part) // part is an io.Reader
@@ -68,8 +74,10 @@ type UploadPart struct {
 }
 
 // SetResult records the final remote-storage reference for this part (e.g. an
-// object URL or key). The follow-on action reads it via
-// ctx.GetCompletedUploads(field)[i].ExternalRef.
+// object URL or key). Call it only after the full read succeeds — if OnUpload
+// then returns an error (e.g. ErrUploadTooLarge) the entry is discarded, so a
+// reference set before a truncated read never reaches the action. The follow-on
+// action reads it via ctx.GetCompletedUploads(field)[i].ExternalRef.
 func (p *UploadPart) SetResult(ref string) {
 	if p.entry != nil {
 		p.entry.ExternalRef = ref

--- a/upload.go
+++ b/upload.go
@@ -75,10 +75,11 @@ type UploadPart struct {
 }
 
 // SetResult records the final remote-storage reference for this part (e.g. an
-// object URL or key). Call it only after the full read succeeds — if OnUpload
-// then returns an error (e.g. ErrUploadTooLarge) the entry is discarded, so a
-// reference set before a truncated read never reaches the action. The follow-on
-// action reads it via ctx.GetCompletedUploads(field)[i].ExternalRef.
+// object URL or key). It is self-correcting: calling it before a read that then
+// fails is safe, because OnUpload returning an error discards the entry — so a
+// reference set before a truncated read (e.g. ErrUploadTooLarge) never reaches
+// the action. The follow-on action reads it via
+// ctx.GetCompletedUploads(field)[i].ExternalRef.
 func (p *UploadPart) SetResult(ref string) {
 	if p.entry != nil {
 		p.entry.ExternalRef = ref

--- a/upload.go
+++ b/upload.go
@@ -1,6 +1,8 @@
 package livetemplate
 
 import (
+	"io"
+
 	"github.com/livetemplate/livetemplate/internal/uploadtypes"
 )
 
@@ -13,8 +15,71 @@ import (
 //   - MaxFileSize: Maximum file size in bytes (0 = unlimited)
 //   - AutoUpload: Whether to start upload automatically on file selection
 //   - ChunkSize: Chunk size for WebSocket uploads in bytes (default: 256KB)
-//   - External: Optional Presigner for direct-to-storage uploads (S3, GCS, etc.)
+//   - Mode: Upload destination (Volume | Direct | Proxied | Preview; default Volume)
+//   - External: Presigner for Direct mode (browser → cloud via presigned URL)
+//   - Dir: Retain destination for Volume mode (defaults to a temp dir)
 type UploadConfig = uploadtypes.UploadConfig
+
+// UploadMode selects where a field's uploaded bytes go. Configured purely
+// server-side; the same <input lvt-upload="..."> markup works for every mode.
+type UploadMode = uploadtypes.UploadMode
+
+const (
+	// UploadModeVolume stages bytes to the server's disk and retains them at Dir.
+	UploadModeVolume = uploadtypes.UploadModeVolume
+	// UploadModeDirect uploads browser → cloud via a presigned URL (needs External).
+	UploadModeDirect = uploadtypes.UploadModeDirect
+	// UploadModeProxied streams bytes through the server to remote storage, zero disk
+	// (the controller must implement UploadStreamer).
+	UploadModeProxied = uploadtypes.UploadModeProxied
+	// UploadModePreview keeps the file on the device; the server gets metadata only.
+	UploadModePreview = uploadtypes.UploadModePreview
+)
+
+// UploadStreamer is optionally implemented by a Controller to receive Proxied
+// uploads inline as an io.Reader, with zero local-disk staging. OnUpload is
+// invoked once per file part while the bytes are still in flight; the handler
+// streams them to remote storage and records the final reference via SetResult.
+//
+//	func (c *C) OnUpload(part *livetemplate.UploadPart, ctx *livetemplate.Context) error {
+//	    ref, err := myBackend.Put(ctx, part.Filename, part) // part is an io.Reader
+//	    if err != nil {
+//	        return err
+//	    }
+//	    part.SetResult(ref)
+//	    return nil
+//	}
+type UploadStreamer interface {
+	OnUpload(part *UploadPart, ctx *Context) error
+}
+
+// UploadPart is a single streaming upload handed to Controller.OnUpload. The
+// embedded io.Reader yields the file bytes directly off the HTTP request;
+// reading past MaxFileSize returns ErrUploadTooLarge (the read must be aborted,
+// not treated as a complete short file). The reader is consumed once, inline
+// with the request — no seek or replay.
+type UploadPart struct {
+	io.Reader
+	Field      string // Upload field name (disambiguates a shared OnUpload)
+	Filename   string // Original client filename
+	ClientType string // Client-reported MIME type
+	ClientSize int64  // Client-reported size, or -1 when unknown
+	entry      *uploadtypes.UploadEntry
+}
+
+// SetResult records the final remote-storage reference for this part (e.g. an
+// object URL or key). The follow-on action reads it via
+// ctx.GetCompletedUploads(field)[i].ExternalRef.
+func (p *UploadPart) SetResult(ref string) {
+	if p.entry != nil {
+		p.entry.ExternalRef = ref
+	}
+}
+
+// ErrUploadTooLarge is returned by a UploadPart reader when the streamed bytes
+// exceed the field's MaxFileSize. It is a distinct sentinel (not io.EOF) so a
+// streaming copy aborts instead of committing a truncated object.
+var ErrUploadTooLarge = uploadtypes.ErrUploadTooLarge
 
 // Presigner generates presigned upload URLs for external storage (S3, GCS, etc).
 // This enables direct client-to-storage uploads, bypassing the server.

--- a/upload.go
+++ b/upload.go
@@ -47,6 +47,8 @@ const (
 // ctx does NOT carry session/typed state. It does carry request identity —
 // ctx.UserID() and ctx.GroupID() — so use SetResult to hand the stored
 // reference to the follow-on action (read there via ctx.GetCompletedUploads).
+// ctx is upload-scoped: ctx.Publish / ctx.With* calls made inside OnUpload do
+// NOT propagate to the follow-on action handler (which builds its own context).
 //
 //	func (c *C) OnUpload(part *livetemplate.UploadPart, ctx *livetemplate.Context) error {
 //	    ref, err := myBackend.Put(ctx, part.Filename, part) // part is an io.Reader

--- a/upload.go
+++ b/upload.go
@@ -44,7 +44,8 @@ const (
 // streams them to remote storage and records the final reference via SetResult.
 //
 // OnUpload runs during the multipart body read, before the action handler, so
-// ctx does NOT carry session/typed state — use SetResult to hand the stored
+// ctx does NOT carry session/typed state. It does carry request identity —
+// ctx.UserID() and ctx.GroupID() — so use SetResult to hand the stored
 // reference to the follow-on action (read there via ctx.GetCompletedUploads).
 //
 //	func (c *C) OnUpload(part *livetemplate.UploadPart, ctx *livetemplate.Context) error {

--- a/upload_test.go
+++ b/upload_test.go
@@ -608,6 +608,60 @@ func (c *uploadCompleteNoBroadcastController) UploadAvatarComplete(state uploadC
 	return state, nil
 }
 
+type persistUploadState struct {
+	Ref string `lvt:"persist"`
+}
+
+type persistUploadController struct{}
+
+func (c *persistUploadController) UploadAvatarComplete(state persistUploadState, ctx *Context) (persistUploadState, error) {
+	if ups := ctx.GetCompletedUploads("avatar"); len(ups) > 0 {
+		state.Ref = ups[0].TempPath
+	}
+	return state, nil
+}
+
+// TestHandleUploadComplete_PersistsState verifies that an upload completed over
+// WebSocket persists the resulting state to the session store, so it survives a
+// page refresh (the regression the persist fix addresses).
+func TestHandleUploadComplete_PersistsState(t *testing.T) {
+	store := NewMemorySessionStore()
+	tmpl := Must(New("test",
+		WithUpload("avatar", UploadConfig{}),
+		WithSessionStore(store),
+	))
+	tmpl = Must(tmpl.Parse(`<div>{{.Ref}}</div>`))
+	handler := tmpl.Handle(&persistUploadController{}, AsState(&persistUploadState{})).(*liveHandler)
+
+	uploadRegistry := upload.NewRegistry()
+	if err := uploadRegistry.CreateUpload("avatar", UploadConfig{}); err != nil {
+		t.Fatalf("CreateUpload: %v", err)
+	}
+	uploadObj := uploadRegistry.GetUpload("avatar").(*upload.Upload)
+	if err := uploadObj.AddEntry(&uploadtypes.UploadEntry{
+		ID: "entry-1", ClientName: "a.txt", ClientType: "text/plain", ClientSize: 1,
+		TempPath: "/tmp/a.txt", Valid: true,
+	}); err != nil {
+		t.Fatalf("AddEntry: %v", err)
+	}
+
+	if store.Get(context.Background(), "g1") != nil {
+		t.Fatal("precondition: store should be empty for g1")
+	}
+
+	conn := &session.Connection{GroupID: "g1", UserID: "u1", Template: tmpl}
+	state := &connState{state: persistUploadState{}, messages: make(map[string]string), groupID: "g1"}
+	raw := []byte(`{"action":"upload_complete","upload_name":"avatar","entry_ids":["entry-1"]}`)
+
+	if err := handler.handleUploadComplete(context.Background(), raw, state, uploadRegistry, conn); err != nil {
+		t.Fatalf("handleUploadComplete: %v", err)
+	}
+
+	if store.Get(context.Background(), "g1") == nil {
+		t.Error("expected state persisted to the session store after upload_complete, got nil")
+	}
+}
+
 func TestHandleUploadComplete_DoesNotImplicitlyBroadcastToPeers(t *testing.T) {
 	tmpl, err := New("test", WithUpload("avatar", UploadConfig{}))
 	if err != nil {

--- a/upload_test.go
+++ b/upload_test.go
@@ -545,31 +545,52 @@ func TestHandle_TempFileManagerInitialized_WithUploadConfig(t *testing.T) {
 	}
 }
 
-func TestHandleUploadAction_NilTempFileManager(t *testing.T) {
-	handler := &liveHandler{
-		tempFileManager: nil,
+// TestHandle_NoTempFileManager_ForNonVolumeModes verifies Phase 6's contract:
+// Direct/Proxied/Preview fields stage nothing to disk, so the handler must not
+// create a temp file manager (and therefore must not fail at startup on a
+// read-only working directory — the deploy-time failure that motivated #447).
+func TestHandle_NoTempFileManager_ForNonVolumeModes(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   UploadConfig
+		wantDisk bool
+	}{
+		{"proxied", UploadConfig{Mode: UploadModeProxied}, false},
+		{"preview", UploadConfig{Mode: UploadModePreview}, false},
+		{"direct", UploadConfig{Mode: UploadModeDirect, External: &mockPresigner{}}, false},
+		{"volume", UploadConfig{Mode: UploadModeVolume}, true},
+		{"default-is-volume", UploadConfig{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl, err := New("test", WithUpload("file", tc.config))
+			if err != nil {
+				t.Fatalf("New failed: %v", err)
+			}
+			tmpl, err = tmpl.Parse("<div>{{.Count}}</div>")
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			handler := tmpl.Handle(&testHandleController{}, AsState(&testHandleState{}))
+			lh := handler.(*liveHandler)
+			if tc.wantDisk && lh.tempFileManager == nil {
+				t.Errorf("%s: expected a temp file manager, got nil", tc.name)
+			}
+			if !tc.wantDisk && lh.tempFileManager != nil {
+				t.Errorf("%s: expected no temp file manager, got one", tc.name)
+			}
+		})
 	}
 
-	actions := []string{"upload_start", "upload_chunk", "upload_complete", "cancel_upload"}
-	for _, action := range actions {
-		msg := message{Action: action}
-		handled, err := handler.handleUploadAction(context.Background(), nil, msg, nil, nil, nil)
-		if !handled {
-			t.Errorf("action %q: expected handled=true, got false", action)
-		}
-		if err == nil {
-			t.Errorf("action %q: expected error for nil tempFileManager, got nil", action)
-		}
-	}
-
-	// Non-upload actions should return handled=false
+	// Non-upload actions are never claimed by the upload router.
+	lh := &liveHandler{tempFileManager: nil}
 	msg := message{Action: "some_other_action"}
-	handled, err := handler.handleUploadAction(context.Background(), nil, msg, nil, nil, nil)
-	if handled {
-		t.Error("non-upload action: expected handled=false, got true")
+	if handled, err := lh.handleUploadAction(context.Background(), nil, msg, nil, nil, nil); handled || err != nil {
+		t.Errorf("non-upload action: expected handled=false,nil err; got %v,%v", handled, err)
 	}
-	if err != nil {
-		t.Errorf("non-upload action: expected no error, got %v", err)
+
+	if err := os.RemoveAll(".uploads"); err != nil {
+		t.Logf("cleanup .uploads failed: %v", err)
 	}
 }
 

--- a/volume_test.go
+++ b/volume_test.go
@@ -46,6 +46,27 @@ func TestVolumeUpload_RetainsFileAtDir(t *testing.T) {
 	}
 }
 
+// TestDirectUpload_NilExternal_NoPanic verifies the handshake returns an error
+// entry (not a panic) when a field is explicitly Mode:Direct without a presigner.
+func TestDirectUpload_NilExternal_NoPanic(t *testing.T) {
+	reg := upload.NewRegistry()
+	if err := reg.CreateUpload("x", UploadConfig{Mode: UploadModeDirect}); err != nil {
+		t.Fatalf("CreateUpload: %v", err)
+	}
+	h := &liveHandler{}
+	raw := []byte(`{"action":"upload_start","upload_name":"x","files":[{"name":"a.png","type":"image/png","size":10}]}`)
+	resp, err := h.buildUploadStartResponse(raw, "sess", reg)
+	if err != nil {
+		t.Fatalf("buildUploadStartResponse: %v", err)
+	}
+	if len(resp.Entries) != 1 || resp.Entries[0].Valid {
+		t.Fatalf("expected 1 invalid entry, got %+v", resp.Entries)
+	}
+	if resp.Entries[0].Error == "" {
+		t.Error("expected an error message for Direct mode without External")
+	}
+}
+
 // TestVolumeUpload_EphemeralWithoutDir verifies that a Volume field with no Dir
 // stages under the session temp tree (.uploads), preserving the legacy
 // stage-then-app-moves pattern.

--- a/volume_test.go
+++ b/volume_test.go
@@ -1,0 +1,82 @@
+package livetemplate
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/livetemplate/internal/upload"
+)
+
+const volumeStartMsg = `{"action":"upload_start","upload_name":"scan","files":[{"name":"x.png","type":"image/png","size":10}]}`
+
+// TestVolumeUpload_RetainsFileAtDir verifies that a Volume field with Dir set
+// stages the file under that directory (not the session temp tree) so it
+// survives session cleanup — the app owns its lifecycle.
+func TestVolumeUpload_RetainsFileAtDir(t *testing.T) {
+	dir := t.TempDir()
+	reg := upload.NewRegistry()
+	if err := reg.CreateUpload("scan", UploadConfig{Mode: UploadModeVolume, Dir: dir}); err != nil {
+		t.Fatalf("CreateUpload: %v", err)
+	}
+
+	// No temp file manager needed: Dir-retained Volume never uses it.
+	h := &liveHandler{}
+	resp, err := h.buildUploadStartResponse([]byte(volumeStartMsg), "sess-1", reg)
+	if err != nil {
+		t.Fatalf("buildUploadStartResponse: %v", err)
+	}
+	if len(resp.Entries) != 1 || !resp.Entries[0].Valid {
+		t.Fatalf("expected 1 valid entry, got %+v", resp.Entries)
+	}
+	if resp.Entries[0].Mode != "volume" {
+		t.Errorf("expected mode=volume, got %q", resp.Entries[0].Mode)
+	}
+
+	u := reg.GetUpload("scan").(*upload.Upload)
+	entry := u.GetEntry(resp.Entries[0].EntryID)
+	if entry == nil {
+		t.Fatal("entry not found in registry")
+	}
+	if !strings.HasPrefix(entry.TempPath, dir) {
+		t.Errorf("expected TempPath under Dir %q, got %q", dir, entry.TempPath)
+	}
+	if _, err := os.Stat(entry.TempPath); err != nil {
+		t.Errorf("retained file should exist: %v", err)
+	}
+}
+
+// TestVolumeUpload_EphemeralWithoutDir verifies that a Volume field with no Dir
+// stages under the session temp tree (.uploads), preserving the legacy
+// stage-then-app-moves pattern.
+func TestVolumeUpload_EphemeralWithoutDir(t *testing.T) {
+	tfm, err := upload.NewTempFileManager("")
+	if err != nil {
+		t.Fatalf("NewTempFileManager: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(".uploads"); err != nil {
+			t.Logf("cleanup .uploads failed: %v", err)
+		}
+	})
+
+	reg := upload.NewRegistry()
+	if err := reg.CreateUpload("scan", UploadConfig{Mode: UploadModeVolume}); err != nil {
+		t.Fatalf("CreateUpload: %v", err)
+	}
+
+	h := &liveHandler{tempFileManager: tfm}
+	resp, err := h.buildUploadStartResponse([]byte(volumeStartMsg), "sess-1", reg)
+	if err != nil {
+		t.Fatalf("buildUploadStartResponse: %v", err)
+	}
+	if len(resp.Entries) != 1 || !resp.Entries[0].Valid {
+		t.Fatalf("expected 1 valid entry, got %+v", resp.Entries)
+	}
+
+	u := reg.GetUpload("scan").(*upload.Upload)
+	entry := u.GetEntry(resp.Entries[0].EntryID)
+	if entry == nil || !strings.Contains(entry.TempPath, ".uploads") {
+		t.Errorf("expected ephemeral TempPath under .uploads, got %q", entry.TempPath)
+	}
+}


### PR DESCRIPTION
Closes #447.

Adds an opt-in **streaming upload mode** (zero local-disk pass-through) and generalizes uploads into four modes selected purely by server config on identical `<input lvt-upload>` markup.

## Modes
| Mode | Bytes path | Server sees bytes? | Local disk? |
|------|------------|--------------------|-------------|
| **Volume** *(default)* | browser → server → retained `Dir` | yes | yes |
| **Direct** | browser → cloud via presigned URL | no | no |
| **Proxied** *(#447)* | browser → server → remote storage, streamed | yes | **no** |
| **Preview** | stays on the device | metadata only | no |

```go
WithUpload("avatar", UploadConfig{Mode: UploadModeProxied}) // controller implements OnUpload(part, ctx)
```

## Highlights
- **Proxied** streams each part straight to `Controller.OnUpload(part *UploadPart, ctx)` via `MultipartReader` (never `ParseMultipartForm`), `LimitGuard` enforces `MaxFileSize` mid-stream returning `ErrUploadTooLarge` (not silent EOF). Result recorded via `part.SetResult(ref)` → `GetCompletedUploads`.
- **Temp-manager skip**: pure non-Volume apps create no `.uploads` and no longer fail at startup on a read-only cwd — the deploy-time failure #447 reported.
- **Mode reaches the client** by generalizing the existing `upload_start` handshake's per-entry flag; the handshake also answers over HTTP (`X-Lvt-Upload: start`) so Proxied + Preview are fully WebSocket-independent.
- **Direct** is the existing `External` path re-expressed as `Mode: Direct` (back-compat: `External` without a `Mode` ⇒ Direct).
- **Volume** retains at `Dir` (excluded from session cleanup); empty `Dir` keeps the legacy ephemeral staging.
- **Preview** records a metadata-only entry; `{{.lvt.UploadPreview}}` placeholder filled client-side via `createObjectURL`.

## Verification
Unit + mount tests (incl. a zero-disk assertion), and a chromedp e2e (in the docs example) driving all four modes + a WS-disabled Proxied variant. All four manually validated in a browser.

## Companion PRs (land in order)
- Client: `livetemplate/client` `upload-modes` (mode dispatch + Proxied/Preview/WS-disabled transport)
- Docs: `livetemplate/docs` `upload-modes` (runnable `upload-modes` example)

## Follow-ups (documented gaps)
- #448 — Direct completion over HTTP (WS-disabled)
- #449 — Volume HTTP-multipart fallback honoring `Dir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)