### PR TITLE
feat(upload): expose preceding form fields to OnUpload (Proxied streaming)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to LiveTemplate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changes
+
+- feat(upload): expose form fields parsed before the file part to `Controller.OnUpload`
+  via `ctx.GetString(...)`, so a Proxied streaming handler can associate the bytes with a
+  record id (order the input ahead of the file input). Enables zero-disk streaming that still
+  routes to a per-record/per-tenant destination.
+
 ## [v0.12.0] - 2026-06-10
 
 ### Changes

--- a/docs/references/uploads.md
+++ b/docs/references/uploads.md
@@ -48,7 +48,8 @@ controller implements `UploadStreamer`:
 
 ```go
 func (c *Controller) OnUpload(part *livetemplate.UploadPart, ctx *livetemplate.Context) error {
-    ref, err := myBackend.Put(ctx, part.Filename, part) // part is an io.Reader
+    // "id" must be ordered before the file input in the form (see below).
+    ref, err := myBackend.Put(ctx, ctx.GetString("id"), part.Filename, part)
     if err != nil {
         return err
     }
@@ -56,6 +57,13 @@ func (c *Controller) OnUpload(part *livetemplate.UploadPart, ctx *livetemplate.C
     return nil
 }
 ```
+
+Inside `OnUpload`, `ctx` carries the request identity (`ctx.UserID()`,
+`ctx.GroupID()`) **and** the form fields parsed *before* this file part, read via
+`ctx.GetString(...)`. Because parts stream in body order, a field is visible only
+if its input precedes the file input — so order any field you need mid-stream
+(e.g. the record id to route the bytes to the right destination) ahead of the
+file input. Fields after the file part reach only the follow-on action.
 
 The reader enforces `MaxFileSize` mid-stream, returning `ErrUploadTooLarge` (a
 distinct sentinel, not `io.EOF`) so a truncated stream aborts instead of

--- a/internal/upload/streaming.go
+++ b/internal/upload/streaming.go
@@ -30,10 +30,16 @@ const valuePartCap = 1 << 20 // 1 MB
 // onFile/onStaged receive the live *multipart.Part. A callback that returns an
 // error aborts iteration and the error is returned verbatim, so a *ValidationError
 // from validation surfaces to the caller for per-field error mapping.
+//
+// onFile additionally receives the form values parsed *so far* — every non-file
+// part that appeared before this file part in the body. Because parts stream in
+// body order, a value is visible to onFile only if its input precedes the file
+// input in the form (the caller exposes these to Controller.OnUpload, so a record
+// id must be ordered ahead of the file input to be readable mid-stream).
 func StreamMultipart(
 	r *http.Request,
 	isStreaming func(field string) bool,
-	onFile func(part *multipart.Part) error,
+	onFile func(part *multipart.Part, values map[string][]string) error,
 	onStaged func(part *multipart.Part) error,
 ) (map[string][]string, error) {
 	mr, err := r.MultipartReader()
@@ -64,7 +70,7 @@ func StreamMultipart(
 
 		// File part.
 		if isStreaming(part.FormName()) {
-			if err := onFile(part); err != nil {
+			if err := onFile(part, values); err != nil {
 				return values, err
 			}
 		} else if onStaged != nil {

--- a/mount.go
+++ b/mount.go
@@ -1355,10 +1355,8 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 				return ok && c.Mode == uploadtypes.UploadModeProxied
 			},
 			func(part *multipart.Part, values map[string][]string) error {
-				// Expose the form fields parsed before this file part to OnUpload
-				// (e.g. a record id ordered ahead of the file input), so a handler
-				// can associate the streamed bytes with a target. These are the same
-				// values the follow-on action receives via BuildActionFromValues.
+				// Form fields seen before this file part are readable in OnUpload
+				// (ordering invariant — see the UploadStreamer docstring).
 				partCtx := streamCtx.WithData(send.BuildActionFromValues(values).Data)
 				return h.streamProxiedPart(part, uploadRegistry, partCtx)
 			},

--- a/mount.go
+++ b/mount.go
@@ -1354,8 +1354,13 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 				c, ok := h.config.UploadConfigs[field]
 				return ok && c.Mode == uploadtypes.UploadModeProxied
 			},
-			func(part *multipart.Part) error {
-				return h.streamProxiedPart(part, uploadRegistry, streamCtx)
+			func(part *multipart.Part, values map[string][]string) error {
+				// Expose the form fields parsed before this file part to OnUpload
+				// (e.g. a record id ordered ahead of the file input), so a handler
+				// can associate the streamed bytes with a target. These are the same
+				// values the follow-on action receives via BuildActionFromValues.
+				partCtx := streamCtx.WithData(send.BuildActionFromValues(values).Data)
+				return h.streamProxiedPart(part, uploadRegistry, partCtx)
 			},
 			// Staged sink: a Volume file part sharing a streaming request is
 			// staged to disk rather than dropped (Direct/Preview carry no bytes

--- a/streaming_proxied_test.go
+++ b/streaming_proxied_test.go
@@ -23,9 +23,15 @@ type proxiedState struct {
 type proxiedController struct {
 	received map[string][]byte
 	refs     []string
+	// Form fields visible inside OnUpload, captured per call: proves a field
+	// ordered before the file part is readable mid-stream and one after is not.
+	onUploadBeforeField string
+	onUploadAfterField  string
 }
 
 func (c *proxiedController) OnUpload(part *UploadPart, ctx *Context) error {
+	c.onUploadBeforeField = ctx.GetString("record_id")
+	c.onUploadAfterField = ctx.GetString("trailing")
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, part); err != nil {
 		return err // e.g. ErrUploadTooLarge — aborts before SetResult
@@ -331,5 +337,64 @@ func TestProxiedUpload_RejectsDisallowedType(t *testing.T) {
 	}
 	if len(ctrl.refs) != 0 {
 		t.Errorf("expected no completed uploads, got %v", ctrl.refs)
+	}
+}
+
+// TestProxiedUpload_OnUploadReadsPrecedingFormField proves OnUpload can read a
+// form field ordered before the file part (so a handler can associate the
+// streamed bytes with a record id) — and that a field ordered after the file is
+// NOT visible, because parts stream in body order.
+func TestProxiedUpload_OnUploadReadsPrecedingFormField(t *testing.T) {
+	ctrl := &proxiedController{}
+	server, cookies := newProxiedServer(t, UploadConfig{Mode: UploadModeProxied}, ctrl)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for _, f := range []struct{ name, val string }{
+		{"lvt-action", "SaveDoc"},
+		{"record_id", "item-42"}, // before the file part → visible in OnUpload
+	} {
+		if err := writer.WriteField(f.name, f.val); err != nil {
+			t.Fatalf("WriteField %q: %v", f.name, err)
+		}
+	}
+	filePart, err := writer.CreateFormFile("doc", "scan.png")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := filePart.Write([]byte("bytes")); err != nil {
+		t.Fatalf("write file content: %v", err)
+	}
+	if err := writer.WriteField("trailing", "too-late"); err != nil { // after → not visible
+		t.Fatalf("WriteField trailing: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer close: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", server.URL+"/", &body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Logf("body close: %v", err)
+	}
+
+	if ctrl.onUploadBeforeField != "item-42" {
+		t.Errorf("OnUpload should read a field ordered before the file part: got record_id=%q want %q",
+			ctrl.onUploadBeforeField, "item-42")
+	}
+	if ctrl.onUploadAfterField != "" {
+		t.Errorf("OnUpload must not see a field ordered after the file part: got trailing=%q want empty",
+			ctrl.onUploadAfterField)
 	}
 }

--- a/upload.go
+++ b/upload.go
@@ -44,14 +44,19 @@ const (
 // streams them to remote storage and records the final reference via SetResult.
 //
 // OnUpload runs during the multipart body read, before the action handler, so
-// ctx does NOT carry session/typed state. It does carry request identity —
-// ctx.UserID() and ctx.GroupID() — so use SetResult to hand the stored
-// reference to the follow-on action (read there via ctx.GetCompletedUploads).
+// ctx does NOT carry typed state. It DOES carry request identity — ctx.UserID()
+// and ctx.GroupID() — and the form fields parsed *before* this file part, read
+// via ctx.GetString(...). Because parts stream in body order, a field is visible
+// only if its input precedes the file input in the form, so order an input you
+// need mid-stream (e.g. the record id to associate the bytes with) ahead of the
+// file input. Use SetResult to hand the stored reference to the follow-on action
+// (read there via ctx.GetCompletedUploads).
 // ctx is upload-scoped: ctx.Publish / ctx.With* calls made inside OnUpload do
 // NOT propagate to the follow-on action handler (which builds its own context).
 //
 //	func (c *C) OnUpload(part *livetemplate.UploadPart, ctx *livetemplate.Context) error {
-//	    ref, err := myBackend.Put(ctx, part.Filename, part) // part is an io.Reader
+//	    // "id" must be ordered ahead of the file input in the form.
+//	    ref, err := myBackend.Put(ctx, ctx.GetString("id"), part.Filename, part)
 //	    if err != nil {
 //	        return err
 //	    }

--- a/upload.go
+++ b/upload.go
@@ -50,7 +50,10 @@ const (
 // only if its input precedes the file input in the form, so order an input you
 // need mid-stream (e.g. the record id to associate the bytes with) ahead of the
 // file input. Use SetResult to hand the stored reference to the follow-on action
-// (read there via ctx.GetCompletedUploads).
+// (read there via ctx.GetCompletedUploads). Caveat: if a `data` JSON-envelope
+// field precedes the file part, individual plain fields are folded into that
+// envelope and are not separately addressable via ctx.GetString — mirroring how
+// the follow-on action sees the same values.
 // ctx is upload-scoped: ctx.Publish / ctx.With* calls made inside OnUpload do
 // NOT propagate to the follow-on action handler (which builds its own context).
 //


### PR DESCRIPTION
## What

`OnUpload` (Proxied streaming) runs mid-body with an identity-only ctx (`UserID`/`GroupID`), so a streaming handler had no way to associate the bytes with a record — only the file metadata was available, not sibling form fields. Multi-tenant / per-record zero-disk streaming was therefore impossible.

`StreamMultipart` now passes the form values parsed **before** the file part into its `onFile` callback; `mount.go` attaches them to the `OnUpload` ctx via `WithData`, so a handler reads them with `ctx.GetString(...)`. These are the same values the follow-on action receives via `BuildActionFromValues`.

**Ordering:** a field is visible only if its input precedes the file input (parts stream in body order); fields after the file reach only the action.

## Tests

Discriminating test in `streaming_proxied_test.go`: a field before the file part is readable in `OnUpload`, one after is not (fails under the old nil-ctx behavior). Full module suite + lint green via pre-commit.

## Part of a 3-repo change (merge order: this → client → docs)

1. **this** — server reads preceding form values in OnUpload
2. `livetemplate/client` form-field serialization in `uploadProxied`
3. `livetemplate/docs` example + E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)