### PR TITLE
docs(uploads): note SSR'd lvt-upload inputs bind on connect (#453)

### DIFF
--- a/docs/references/uploads.md
+++ b/docs/references/uploads.md
@@ -463,10 +463,10 @@ ChunkSize: 512 * 1024, // 512KB chunks
 - Verify `lvt-upload` attribute matches the field name in `WithUpload()`
 - Check browser console for JavaScript errors
 - Ensure the template includes `lvt-upload="fieldName"` on the file input
-- Server-rendered `lvt-upload` inputs bind their change handler on connect, so
-  `AutoUpload` fires on select even when the first render is hydrate-idempotent
-  (added in `@livetemplate/client` v0.13.1; before that an SSR'd input whose
-  first WebSocket render added no new nodes was left without a listener — see
+- **SSR'd input + `AutoUpload` not firing on first select?** Upgrade to
+  `@livetemplate/client` >= v0.13.1. Before that fix, a server-rendered
+  `lvt-upload` input whose first WebSocket render added no new nodes was left
+  without a change listener (see
   [#453](https://github.com/livetemplate/livetemplate/issues/453))
 
 ### Progress Not Updating

--- a/docs/references/uploads.md
+++ b/docs/references/uploads.md
@@ -463,6 +463,11 @@ ChunkSize: 512 * 1024, // 512KB chunks
 - Verify `lvt-upload` attribute matches the field name in `WithUpload()`
 - Check browser console for JavaScript errors
 - Ensure the template includes `lvt-upload="fieldName"` on the file input
+- Server-rendered `lvt-upload` inputs bind their change handler on connect, so
+  `AutoUpload` fires on select even when the first render is hydrate-idempotent
+  (added in `@livetemplate/client` v0.13.1; before that an SSR'd input whose
+  first WebSocket render added no new nodes was left without a listener — see
+  [#453](https://github.com/livetemplate/livetemplate/issues/453))
 
 ### Progress Not Updating
 


### PR DESCRIPTION
Adds a troubleshooting note to `docs/references/uploads.md`: server-rendered `lvt-upload` inputs bind their `change` handler on connect, so `AutoUpload` fires on select even when the first render is hydrate-idempotent.

Documents the fix for #453 (client-side; shipped in `@livetemplate/client` v0.13.1 — see livetemplate/client#131). Before that, an SSR'd input whose first WebSocket render added no new nodes was left without a listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)