### PR TITLE
docs+test: selective-persistence cleanup follow-ups (#309 #310 #311 #312 #313 #314)

### DIFF
--- a/docs/references/session.md
+++ b/docs/references/session.md
@@ -56,6 +56,16 @@ Fields tagged with `lvt:"persist"` follow this persistence schedule. Untagged fi
 | Server action | Persisted (once per group) | In-memory for connection lifetime |
 | Page refresh | Restored from store | Zero value, loaded by Mount() |
 
+### Persistence and Path Navigation
+
+`lvt:"persist"` fields survive a **same-URL page refresh** (F5) and a **WebSocket reconnect**. They do **not** survive navigation to a different path:
+
+- Persistence is keyed by `groupID`, not by URL path.
+- When a GET request arrives on a path different from the group's last-seen path, LiveTemplate resets to fresh state for the new URL (persist fields go back to their zero values, then `Mount()` runs) and **overwrites** the group's stored persist fields with that fresh state.
+- Because the store is overwritten on navigation, navigating **back** to the original path does **not** restore the previously persisted values — they were replaced. Persist fields only ever round-trip across a refresh/reconnect on the *same* path.
+
+This matches the pre-`lvt:"persist"` behavior where a path change always meant fresh state. Treat `lvt:"persist"` as "survives refresh," not "survives navigation."
+
 ### Explicit Peer Refresh
 
 ```go
@@ -235,6 +245,8 @@ type SessionStore interface {
     List(ctx context.Context) []string
 }
 ```
+
+**`[]byte` contract for selective persistence:** when the framework persists `lvt:"persist"` fields, it always passes `[]byte` (JSON) to `Set()` and requires `Get()` to return that same `[]byte` (or `nil`) unchanged. A custom `SessionStore` that transforms the value on the round-trip — for example, JSON-unmarshalling it into a `map` — breaks persistence: persist fields silently fall back to fresh state on every request (a warning is logged, no error returned). Both built-in stores honor this automatically; see the `SessionStore` doc comment for the full contract.
 
 ### SingleStoreSetter
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -1,6 +1,7 @@
 package livetemplate
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -3376,4 +3377,63 @@ func TestRedirect_RelativeBranch(t *testing.T) {
 			t.Errorf("Redirect error = %v, want ErrInvalidRedirectURL", err)
 		}
 	})
+}
+
+// ============================================================================
+// Persist-path edge cases (restorePersistedState / persistState)
+// ============================================================================
+
+// mockSessionStore is a configurable SessionStore for persist-path tests.
+// getReturn is what Get yields; setCalls records Set invocations.
+type mockSessionStore struct {
+	getReturn interface{}
+	setCalls  int
+}
+
+func (m *mockSessionStore) Get(ctx context.Context, groupID string) interface{} {
+	return m.getReturn
+}
+
+func (m *mockSessionStore) Set(ctx context.Context, groupID string, state interface{}) {
+	m.setCalls++
+}
+
+func (m *mockSessionStore) Delete(ctx context.Context, groupID string) {}
+
+func (m *mockSessionStore) List(ctx context.Context) []string { return nil }
+
+// TestRestorePersistedState_TypeMismatch verifies that when a custom SessionStore
+// returns a non-[]byte value (violating the persistence contract), the handler
+// falls back to fresh state gracefully — no panic, ok=false, nil state.
+func TestRestorePersistedState_TypeMismatch(t *testing.T) {
+	store := &mockSessionStore{getReturn: testHandleState{Count: 5}}
+	h := &liveHandler{
+		config:      mountConfig{SessionStore: store},
+		persistable: AsState(&testHandleState{}).(persistableState),
+	}
+
+	state, ok := h.restorePersistedState(context.Background(), "g1")
+	if ok {
+		t.Error("Expected ok=false when stored value is not []byte")
+	}
+	if state != nil {
+		t.Errorf("Expected nil state on type mismatch, got %v", state)
+	}
+}
+
+// TestPersistState_SerializationFailureIsGraceful verifies that when
+// ExtractPersistFields fails to serialize, persistState logs and returns without
+// calling SessionStore.Set — no panic, no partial write.
+func TestPersistState_SerializationFailureIsGraceful(t *testing.T) {
+	store := &mockSessionStore{}
+	h := &liveHandler{
+		config:      mountConfig{SessionStore: store},
+		persistable: AsState(&unserializableState{}).(persistableState),
+	}
+
+	h.persistState(context.Background(), "g1", unserializableState{Bad: func() {}})
+
+	if store.setCalls != 0 {
+		t.Errorf("Expected Set to not be called on serialization failure, got %d calls", store.setCalls)
+	}
 }

--- a/session_stores.go
+++ b/session_stores.go
@@ -23,15 +23,27 @@ import (
 // For authenticated users: groupID is typically the userID (each user has isolated state).
 //
 // Thread-safety: All implementations must be safe for concurrent access from multiple goroutines.
+// Selective persistence ([]byte contract): when the framework persists
+// lvt:"persist" fields, it always passes []byte (JSON) to Set and requires
+// Get to return that same []byte (or nil) unchanged. A custom implementation
+// that transforms the value on the round-trip (e.g. unmarshals it into a map)
+// will cause persist fields to silently fall back to fresh state on every
+// request — no error, just a warning log. Both built-in stores honor this:
+// MemorySessionStore returns the value as-is, and RedisSessionStore returns
+// the stored JSON as []byte. Values other than []byte (e.g. the struct passed
+// by SessionStoreHealthChecker) are accepted but are outside the persistence
+// contract.
 type SessionStore interface {
 	// Get retrieves the state for a session group.
 	// Returns nil if the group doesn't exist.
 	// The context can be used for cancellation, timeouts, and tracing.
+	// For selective persistence, must return the []byte passed to Set unchanged.
 	Get(ctx context.Context, groupID string) interface{}
 
 	// Set stores state for a session group.
 	// Creates a new group if it doesn't exist, updates if it does.
 	// The context can be used for cancellation, timeouts, and tracing.
+	// For selective persistence, the framework always passes []byte (JSON).
 	Set(ctx context.Context, groupID string, state interface{})
 
 	// Delete removes a session group and all its state.
@@ -439,7 +451,11 @@ func (s *RedisSessionStore) Set(ctx context.Context, groupID string, state inter
 		return
 	}
 
-	// State can be raw JSON bytes (from selective persistence) or a struct
+	// State can be raw JSON bytes or a struct. Selective persistence
+	// (persistState in mount.go) always passes []byte and takes the first
+	// branch. The json.Marshal branch is NOT dead: SessionStoreHealthChecker.Check
+	// passes a *healthCheckState struct, and custom callers may pass arbitrary
+	// values, so both paths must be supported.
 	var stateJSON []byte
 	var err error
 	if raw, ok := state.([]byte); ok {

--- a/state_test.go
+++ b/state_test.go
@@ -335,3 +335,50 @@ func TestValidatePersistTag(t *testing.T) {
 		t.Error("Case-sensitive: 'Persist' should not match 'persist'")
 	}
 }
+
+// TestPersistFields_SchemaEvolution locks in the forward-compatibility guarantee:
+// stored JSON containing a key for a field that no longer exists in the struct is
+// silently dropped, while known persist fields still restore. This covers the case
+// where a struct dropped a persist field after data was already stored.
+func TestPersistFields_SchemaEvolution(t *testing.T) {
+	state := AsState(&testPersistState{})
+	js := state.(*jsonState[testPersistState])
+
+	// Stored data from an older schema: "filter" is still a persist field,
+	// but "old_field" was removed from the struct since it was written.
+	stored := []byte(`{"filter":"active","old_field":"value"}`)
+
+	restored, err := js.InjectPersistFields(stored)
+	if err != nil {
+		t.Fatalf("InjectPersistFields failed: %v", err)
+	}
+
+	restoredState := restored.(testPersistState)
+	if restoredState.Filter != "active" {
+		t.Errorf("Filter: got %q, want %q", restoredState.Filter, "active")
+	}
+	// The unknown "old_field" key must be silently dropped — it maps to no field.
+	// Page (a known persist field absent from the stored data) stays zero.
+	if restoredState.Page != 0 {
+		t.Errorf("Page should be zero (absent from stored data), got %d", restoredState.Page)
+	}
+}
+
+// unserializableState has a persist field whose value cannot be JSON-encoded.
+// A func-typed field passes AsState's purity validation (which only rejects
+// pointer/interface dependency types) but fails json.Marshal at extract time.
+type unserializableState struct {
+	Bad func() `json:"bad" lvt:"persist"`
+}
+
+// TestPersistFields_SerializationFailure verifies ExtractPersistFields surfaces a
+// serialization error rather than silently producing empty/partial data.
+func TestPersistFields_SerializationFailure(t *testing.T) {
+	state := AsState(&unserializableState{})
+	js := state.(*jsonState[unserializableState])
+
+	_, err := js.ExtractPersistFields(unserializableState{Bad: func() {}})
+	if err == nil {
+		t.Fatal("Expected ExtractPersistFields to fail for a non-serializable field")
+	}
+}


### PR DESCRIPTION
Bundles the six PR #308 review follow-ups that touch the same code region (`session_stores.go`, `state_test.go`, `handle_test.go`, `docs/references/session.md`) into one coherent diff.

## What changed

| # | Change | Where |
|---|--------|-------|
| #309 | Documented the `[]byte` persistence contract on the interface + reference docs | `session_stores.go`, `docs/references/session.md` |
| #310 | Documented path-navigation behavior for persist fields | `docs/references/session.md` |
| #311 | Kept + explained the (not-actually-dead) `json.Marshal` branch | `session_stores.go` |
| #312 | `TestPersistFields_SchemaEvolution` — unknown stored keys are dropped | `state_test.go` |
| #313 | `TestRestorePersistedState_TypeMismatch` — non-`[]byte` `Get` falls back safely | `handle_test.go` |
| #314 | `TestPersistFields_SerializationFailure` + `persistState` graceful test | `state_test.go`, `handle_test.go` |

## Two issue premises were corrected, not blindly applied

- **#311** described the `else { json.Marshal(state) }` branch in `RedisSessionStore.Set()` as dead code. It is **not**: `SessionStoreHealthChecker.Check` passes a `*healthCheckState` struct through it, and custom callers may pass arbitrary values. Took the issue's documented *alternative* (keep the branch + add a comment explaining why) rather than narrowing the signature to `[]byte`, which would break the health checker.
- **#310** claimed "navigating back to the original path restores the previously persisted values." Verified against `mount.go` (~L1089–1192): a path change resets to fresh state **and** overwrites the `groupID`-keyed store with that fresh state. So navigating back does **not** restore prior values — they were replaced. Documented the real behavior.

## Testing

- `go test ./...` passes (full suite).
- New tests exercise the two previously-untested error paths (type mismatch on restore, serialization failure on persist) and the schema-evolution forward-compat guarantee.
- Pre-commit (gofmt, golangci-lint, full test suite) green.

Closes #309, #310, #311, #312, #313, #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)