### PR TITLE
fix(ws): WebSocket upgrader follow-ups (#243 #244 #245 #247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Broadcaster.SubscribeServerActions` → `Broadcaster.RegisterServerActionHandler`
   - `GroupActionBroadcaster.SubscribeGroupActions` → `GroupActionBroadcaster.RegisterGroupActionHandler`
   - `TopicActionBroadcaster.SubscribeToTopicActions` → `TopicActionBroadcaster.RegisterTopicActionHandler`
+- `WSIsUpgrade` now fully validates the RFC 6455 handshake: in addition to the GET method and `Connection: upgrade` / `Upgrade: websocket` headers, it requires a non-empty `Sec-WebSocket-Key` and `Sec-WebSocket-Version: 13`. Requests missing these are routed as plain HTTP (they would have failed at `Upgrade()` anyway); well-behaved WebSocket clients always send them.
+
+### Fixed
+
+- `NewGorillaUpgrader` now gives each upgrader its own write-buffer `sync.Pool` instead of sharing a package-level global, so upgraders configured with different `WriteBufferSize` values can no longer draw mismatched buffers from a shared pool.
 
 ## [v0.14.0] - 2026-06-13
 

--- a/systemcard_bench_test.go
+++ b/systemcard_bench_test.go
@@ -606,6 +606,7 @@ func measureGCPressure(scenario appScenario, sessionCount int) gcResult {
 	var wg sync.WaitGroup
 	deadline := time.Now().Add(duration)
 
+	var firstErr atomic.Value
 	for idx := 0; idx < sessionCount; idx++ {
 		wg.Add(1)
 		go func(tmpl *Template, session int) {
@@ -616,12 +617,21 @@ func measureGCPressure(scenario appScenario, sessionCount int) gcResult {
 				iteration++
 				state := scenario.UpdateState(iteration + session*10000)
 				buf.Reset()
-				_ = tmpl.ExecuteUpdates(&buf, state)
+				if err := tmpl.ExecuteUpdates(&buf, state); err != nil {
+					firstErr.CompareAndSwap(nil, err)
+					return
+				}
 			}
 		}(templates[idx], idx)
 	}
 
 	wg.Wait()
+
+	// Surface worker errors: if ExecuteUpdates fails, the GC numbers measure
+	// almost no work and would be meaningless. Mirrors measureUpdateThroughput.
+	if v := firstErr.Load(); v != nil {
+		panic(fmt.Sprintf("measureGCPressure: ExecuteUpdates failed: %v", v))
+	}
 
 	var after runtime.MemStats
 	runtime.ReadMemStats(&after)

--- a/ws.go
+++ b/ws.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/livetemplate/livetemplate/internal/session"
 )
 
 // WSConn is the interface for a WebSocket connection.
@@ -17,6 +19,16 @@ type WSConn interface {
 	WriteMessage(messageType int, data []byte) error
 	Close() error
 }
+
+// Compile-time assertions that this WSConn and the session package's mirror
+// (session.WSConn, defined separately to avoid a circular import) stay in sync.
+// Both directions are checked, so adding or removing a method on either
+// interface without matching the other breaks the build here rather than
+// silently at the connection-handoff call site.
+var (
+	_ session.WSConn = (WSConn)(nil)
+	_ WSConn         = (session.WSConn)(nil)
+)
 
 // WSUpgrader upgrades an HTTP connection to a WebSocket connection.
 type WSUpgrader interface {
@@ -101,11 +113,16 @@ func WSIsUnexpectedCloseError(err error, expectedCodes ...int) bool {
 }
 
 // WSIsUpgrade reports whether the HTTP request is a WebSocket upgrade request
-// per RFC 6455 §4.1 (requires GET method).
+// per RFC 6455 §4.1: a GET carrying Connection: upgrade, Upgrade: websocket,
+// a Sec-WebSocket-Key, and Sec-WebSocket-Version: 13. Requests missing the
+// Sec-WebSocket-* headers are not valid handshakes and are routed as plain HTTP
+// (where the upgrade would otherwise fail at Upgrade() anyway).
 func WSIsUpgrade(r *http.Request) bool {
 	return r.Method == http.MethodGet &&
 		headerContainsValue(r.Header, "Connection", "upgrade") &&
-		headerContainsValue(r.Header, "Upgrade", "websocket")
+		headerContainsValue(r.Header, "Upgrade", "websocket") &&
+		r.Header.Get("Sec-WebSocket-Key") != "" &&
+		headerContainsValue(r.Header, "Sec-WebSocket-Version", "13")
 }
 
 func headerContainsValue(h http.Header, key, val string) bool {

--- a/ws_gorilla.go
+++ b/ws_gorilla.go
@@ -8,12 +8,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// defaultWriteBufferPool is a shared pool for gorilla write buffers.
-// Using a pool avoids per-connection write buffer allocation (~1KB saved per connection).
-// Intentionally has no New func — gorilla allocates the buffer on nil Get() and returns
-// it to the pool after write, so the pool self-populates after the first write per connection.
-var defaultWriteBufferPool = &sync.Pool{}
-
 // GorillaUpgrader wraps gorilla/websocket.Upgrader as a WSUpgrader.
 type GorillaUpgrader struct {
 	inner *websocket.Upgrader
@@ -29,7 +23,13 @@ func NewGorillaUpgrader(opts ...GorillaOption) *GorillaUpgrader {
 	u := &websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
-		WriteBufferPool: defaultWriteBufferPool,
+		// Per-upgrader write buffer pool (not a package-level global): pooling
+		// avoids per-connection allocation (~1KB each), and keeping it per
+		// upgrader ensures upgraders configured with different WriteBufferSize
+		// values never draw mismatched buffers from a shared pool. The pool has
+		// no New func — gorilla allocates on a nil Get() and returns the buffer
+		// after each write, so it self-populates after the first write.
+		WriteBufferPool: &sync.Pool{},
 	}
 	for _, opt := range opts {
 		opt(u)

--- a/ws_gorilla.go
+++ b/ws_gorilla.go
@@ -23,12 +23,8 @@ func NewGorillaUpgrader(opts ...GorillaOption) *GorillaUpgrader {
 	u := &websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
-		// Per-upgrader write buffer pool (not a package-level global): pooling
-		// avoids per-connection allocation (~1KB each), and keeping it per
-		// upgrader ensures upgraders configured with different WriteBufferSize
-		// values never draw mismatched buffers from a shared pool. The pool has
-		// no New func — gorilla allocates on a nil Get() and returns the buffer
-		// after each write, so it self-populates after the first write.
+		// Per-upgrader pool so upgraders with different WriteBufferSize never share buffers.
+		// No New func — gorilla allocates on a nil Get() and returns the buffer after each write.
 		WriteBufferPool: &sync.Pool{},
 	}
 	for _, opt := range opts {
@@ -65,6 +61,9 @@ func WithGorillaCompression() GorillaOption {
 }
 
 // Copy creates a shallow copy of the upgrader to avoid mutating shared state.
+// The copy intentionally shares the parent's WriteBufferPool pointer — safe
+// because the copy keeps the same WriteBufferSize (only SetCompression /
+// SetCheckOrigin mutate copies, never the buffer size).
 func (g *GorillaUpgrader) Copy() *GorillaUpgrader {
 	innerCopy := *g.inner
 	return &GorillaUpgrader{inner: &innerCopy}

--- a/ws_test.go
+++ b/ws_test.go
@@ -1,0 +1,73 @@
+package livetemplate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestWSIsUpgrade(t *testing.T) {
+	// validReq builds a fully-valid RFC 6455 handshake, then applies mutate.
+	validReq := func(mutate func(h http.Header)) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("Connection", "Upgrade")
+		r.Header.Set("Upgrade", "websocket")
+		r.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+		r.Header.Set("Sec-WebSocket-Version", "13")
+		mutate(r.Header)
+		return r
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(h http.Header)
+		want   bool
+	}{
+		{"valid handshake", func(http.Header) {}, true},
+		{"missing Sec-WebSocket-Key", func(h http.Header) { h.Del("Sec-WebSocket-Key") }, false},
+		{"empty Sec-WebSocket-Key", func(h http.Header) { h.Set("Sec-WebSocket-Key", "") }, false},
+		{"missing Sec-WebSocket-Version", func(h http.Header) { h.Del("Sec-WebSocket-Version") }, false},
+		{"wrong Sec-WebSocket-Version", func(h http.Header) { h.Set("Sec-WebSocket-Version", "8") }, false},
+		{"missing Upgrade header", func(h http.Header) { h.Del("Upgrade") }, false},
+		{"missing Connection header", func(h http.Header) { h.Del("Connection") }, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := WSIsUpgrade(validReq(tt.mutate)); got != tt.want {
+				t.Errorf("WSIsUpgrade() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("non-GET method", func(t *testing.T) {
+		r := validReq(func(http.Header) {})
+		r.Method = http.MethodPost
+		if WSIsUpgrade(r) {
+			t.Error("WSIsUpgrade() = true for POST, want false")
+		}
+	})
+}
+
+func TestGorillaUpgrader_PerInstanceWriteBufferPool(t *testing.T) {
+	u1 := NewGorillaUpgrader()
+	u2 := NewGorillaUpgrader()
+
+	if u1.inner.WriteBufferPool == nil {
+		t.Fatal("expected a non-nil default WriteBufferPool")
+	}
+	// Each upgrader must own its pool so that upgraders with different
+	// WriteBufferSize values never share mismatched buffers.
+	if u1.inner.WriteBufferPool == u2.inner.WriteBufferPool {
+		t.Error("expected per-upgrader WriteBufferPool, got a shared instance")
+	}
+
+	// An explicit pool via WithGorillaWriteBufferPool still overrides the default.
+	shared := &sync.Pool{}
+	u3 := NewGorillaUpgrader(WithGorillaWriteBufferPool(shared))
+	if u3.inner.WriteBufferPool != websocket.BufferPool(shared) {
+		t.Error("WithGorillaWriteBufferPool did not override the default pool")
+	}
+}

--- a/ws_test.go
+++ b/ws_test.go
@@ -27,6 +27,7 @@ func TestWSIsUpgrade(t *testing.T) {
 		want   bool
 	}{
 		{"valid handshake", func(http.Header) {}, true},
+		{"version list containing 13", func(h http.Header) { h.Set("Sec-WebSocket-Version", "8, 13") }, true},
 		{"missing Sec-WebSocket-Key", func(h http.Header) { h.Del("Sec-WebSocket-Key") }, false},
 		{"empty Sec-WebSocket-Key", func(h http.Header) { h.Set("Sec-WebSocket-Key", "") }, false},
 		{"missing Sec-WebSocket-Version", func(h http.Header) { h.Del("Sec-WebSocket-Version") }, false},


### PR DESCRIPTION
Bundles the four PR #235 WebSocket-upgrader review follow-ups.

## What changed

| # | Change | Where |
|---|--------|-------|
| #243 | Bidirectional compile-time assertions that root `WSConn` ⇄ `session.WSConn` stay in sync | `ws.go` |
| #244 | Per-upgrader write-buffer `sync.Pool` instead of a package-level global | `ws_gorilla.go` |
| #245 | `WSIsUpgrade` fully validates the RFC 6455 handshake (adds `Sec-WebSocket-Key` + `Version: 13`) | `ws.go` |
| #247 | `measureGCPressure` surfaces `ExecuteUpdates` worker errors | `systemcard_bench_test.go` |

New `ws_test.go` (WSIsUpgrade table tests + per-upgrader pool test) and an `[Unreleased]` CHANGELOG entry.

## Notes for review

- **#243**: both assertions live in the root package because `internal/session` can't import root (import cycle) — root is the only package that can name both interfaces. Bidirectional (not the issue's one-liner) so drift in *either* direction breaks the build. The assertions compile today (interfaces are identical); they only fail on future drift.
- **#244**: `Copy()` shallow-copies `inner`, so copies share the pool pointer — safe, because a copy keeps the identical `WriteBufferSize` (only `SetCompression`/`SetCheckOrigin` mutate copies, never the size). `WithGorillaWriteBufferPool(nil/custom)` still overrides the per-instance default.
- **#245 — behavior note**: this is an exported-function behavior change (hence the CHANGELOG entry). A request carrying `Connection: upgrade` + `Upgrade: websocket` but missing `Sec-WebSocket-Key`/`Version` now routes to the plain-HTTP path instead of reaching `handleWebSocket` (where gorilla's `Upgrade()` would have returned 400). Real WebSocket clients always send these headers, so only malformed handshakes are affected. The two added header lookups are short-circuited behind the existing `Connection`/`Upgrade` checks, so plain HTTP traffic pays nothing.
- **#247**: mirrors the existing `measureUpdateThroughput` `firstErr`/panic pattern rather than extracting a shared helper — the two bench helpers differ in return type and surrounding measurement, and the inline duplication keeps each self-contained (per CLAUDE.md's anti-over-abstraction guidance).

## Testing

- `go test ./...` passes (full suite).
- New `TestWSIsUpgrade` (7 header cases + non-GET) and `TestGorillaUpgrader_PerInstanceWriteBufferPool` pass; existing `TestWebSocketDisabled_UpgradeRejected` (sends full headers) still green.
- `/simplify` run pre-commit: clean across reuse/simplification/efficiency/altitude.

Closes #243, #244, #245, #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)