### PR TITLE
fix(parse): 3-index slice support + document callMethod arg behavior (#202 #203)

### DIFF
--- a/internal/parse/eval.go
+++ b/internal/parse/eval.go
@@ -352,20 +352,12 @@ func resolveFieldChain(value interface{}, fields []string) (interface{}, error) 
 	return value, nil
 }
 
-// callMethod calls a zero-argument method and returns its result.
-//
-// A method that requires arguments is returned UNCALLED (as a callable reflect
-// value), not invoked here. This is deliberate and load-bearing: resolveFieldChain
-// runs before the caller knows whether trailing arguments follow, so it must not
-// call a method that might still receive args. Returning the bound method is what
-// makes a chain like {{.ctx.Get "key"}} work — resolveFieldChain yields the bound
-// Get method, then callMethodOrFieldWithArgs applies "key".
-//
-// Caveat (tracked in #459): a *bare* reference to an argument-requiring method
-// (e.g. {{.Get}} with no trailing args) yields the uncalled method value, which
-// then stringifies to a confusing func representation instead of erroring like
-// text/template. A proper fix must distinguish the bare-terminal case at the
-// eval-node level, where the presence of args is known — callMethod cannot tell.
+// callMethod calls a zero-argument method and returns its result. A method that
+// requires arguments is returned UNCALLED so the caller can still apply trailing
+// args (e.g. the {{.ctx.Get "key"}} chain): resolveFieldChain resolves the method
+// before arg presence is known, so it must not invoke one that may receive args.
+// A bare reference to an arg-requiring method therefore yields the uncalled value
+// rather than erroring like text/template; the eval-node-level fix is tracked in #459.
 func callMethod(method reflect.Value) (interface{}, error) {
 	mt := method.Type()
 	if mt.NumIn() != 0 {

--- a/internal/parse/eval.go
+++ b/internal/parse/eval.go
@@ -369,7 +369,7 @@ func resolveFieldChain(value interface{}, fields []string) (interface{}, error) 
 func callMethod(method reflect.Value) (interface{}, error) {
 	mt := method.Type()
 	if mt.NumIn() != 0 {
-		return method.Interface(), nil // Return the method itself (it's a callable)
+		return method.Interface(), nil
 	}
 	results := method.Call(nil)
 	if len(results) == 0 {

--- a/internal/parse/eval.go
+++ b/internal/parse/eval.go
@@ -353,6 +353,19 @@ func resolveFieldChain(value interface{}, fields []string) (interface{}, error) 
 }
 
 // callMethod calls a zero-argument method and returns its result.
+//
+// A method that requires arguments is returned UNCALLED (as a callable reflect
+// value), not invoked here. This is deliberate and load-bearing: resolveFieldChain
+// runs before the caller knows whether trailing arguments follow, so it must not
+// call a method that might still receive args. Returning the bound method is what
+// makes a chain like {{.ctx.Get "key"}} work — resolveFieldChain yields the bound
+// Get method, then callMethodOrFieldWithArgs applies "key".
+//
+// Caveat (tracked in #459): a *bare* reference to an argument-requiring method
+// (e.g. {{.Get}} with no trailing args) yields the uncalled method value, which
+// then stringifies to a confusing func representation instead of erroring like
+// text/template. A proper fix must distinguish the bare-terminal case at the
+// eval-node level, where the presence of args is known — callMethod cannot tell.
 func callMethod(method reflect.Value) (interface{}, error) {
 	mt := method.Type()
 	if mt.NumIn() != 0 {
@@ -860,6 +873,25 @@ func builtinSlice(item interface{}, indices ...interface{}) (interface{}, error)
 			return nil, err
 		}
 		return v.Slice(i, j).Interface(), nil
+	case 3:
+		i, err := toIntIndex(indices[0])
+		if err != nil {
+			return nil, err
+		}
+		j, err := toIntIndex(indices[1])
+		if err != nil {
+			return nil, err
+		}
+		k, err := toIntIndex(indices[2])
+		if err != nil {
+			return nil, err
+		}
+		// 3-index slicing (x[i:j:k], capacity bound) is only valid on slices and
+		// arrays; reflect.Slice3 panics on a string, so reject it like text/template.
+		if v.Kind() == reflect.String {
+			return nil, fmt.Errorf("cannot 3-index slice a string")
+		}
+		return v.Slice3(i, j, k).Interface(), nil
 	default:
 		return nil, fmt.Errorf("too many indices for slice")
 	}

--- a/internal/parse/eval_test.go
+++ b/internal/parse/eval_test.go
@@ -1,0 +1,41 @@
+package parse
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuiltinSlice_ThreeIndex(t *testing.T) {
+	s := []int{0, 1, 2, 3, 4, 5}
+	got, err := builtinSlice(s, 1, 3, 5)
+	if err != nil {
+		t.Fatalf("builtinSlice 3-index failed: %v", err)
+	}
+	gs, ok := got.([]int)
+	if !ok {
+		t.Fatalf("expected []int, got %T", got)
+	}
+	// s[1:3:5] → elements {1,2}, len 2, cap 4
+	if len(gs) != 2 || cap(gs) != 4 {
+		t.Errorf("s[1:3:5]: got len=%d cap=%d, want len=2 cap=4", len(gs), cap(gs))
+	}
+	if gs[0] != 1 || gs[1] != 2 {
+		t.Errorf("s[1:3:5]: got %v, want [1 2]", gs)
+	}
+}
+
+func TestBuiltinSlice_ThreeIndexStringErrors(t *testing.T) {
+	_, err := builtinSlice("hello", 1, 3, 4)
+	if err == nil {
+		t.Fatal("expected error when 3-indexing a string")
+	}
+	if !strings.Contains(err.Error(), "cannot 3-index slice a string") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBuiltinSlice_TooManyIndices(t *testing.T) {
+	if _, err := builtinSlice([]int{1, 2, 3}, 0, 1, 2, 3); err == nil {
+		t.Fatal("expected error for more than 3 indices")
+	}
+}

--- a/internal/parse/eval_test.go
+++ b/internal/parse/eval_test.go
@@ -39,3 +39,20 @@ func TestBuiltinSlice_TooManyIndices(t *testing.T) {
 		t.Fatal("expected error for more than 3 indices")
 	}
 }
+
+// TestSliceThreeIndexString_ErrorsViaTemplate confirms the string guard is
+// reachable through the real template path (Parse + BuildTree), not just a
+// direct builtinSlice call.
+func TestSliceThreeIndexString_ErrorsViaTemplate(t *testing.T) {
+	tmpl, err := Parse("{{slice .S 1 3 4}}", nil)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	_, err = BuildTree(tmpl, map[string]interface{}{"S": "hello"}, &Context{IncludeStatics: true})
+	if err == nil {
+		t.Fatal("expected error when 3-indexing a string via template")
+	}
+	if !strings.Contains(err.Error(), "cannot 3-index slice a string") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/parse/stdlib_parity_test.go
+++ b/internal/parse/stdlib_parity_test.go
@@ -251,6 +251,44 @@ func TestStdlibParity_Pipelines(t *testing.T) {
 	}
 }
 
+// TestStdlibParity_SliceThreeIndex verifies the slice builtin's 3-index form
+// (slice x i j k → x[i:j:k]) matches text/template, including capacity behavior.
+func TestStdlibParity_SliceThreeIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		tmpl string
+		data interface{}
+	}{
+		{
+			name: "three-index slice elements",
+			tmpl: "{{slice .S 1 3 5}}",
+			data: map[string]interface{}{"S": []int{0, 1, 2, 3, 4, 5}},
+		},
+		{
+			name: "three-index then len",
+			tmpl: "{{len (slice .S 1 4 6)}}",
+			data: map[string]interface{}{"S": []int{0, 1, 2, 3, 4, 5}},
+		},
+		{
+			// slice .S 0 2 5 → len 2, cap 5; re-slicing to len 4 only succeeds if
+			// the capacity bound was applied, so this exercises 3-index semantics.
+			name: "three-index capacity allows re-slice",
+			tmpl: "{{slice (slice .S 0 2 5) 0 4}}",
+			data: map[string]interface{}{"S": []int{0, 1, 2, 3, 4, 5}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdlib := stdlibRender(t, tt.tmpl, tt.data, nil)
+			lvt := lvtRender(t, tt.tmpl, tt.data, nil)
+			if stdlib != lvt {
+				t.Errorf("output mismatch:\n  stdlib: %q\n  lvt:    %q", stdlib, lvt)
+			}
+		})
+	}
+}
+
 // TestStdlibParity_WithBlocks tests with block behavior.
 func TestStdlibParity_WithBlocks(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Bundles the two PR #199 parse/eval parity follow-ups.

## #202 — 3-index slice support (real fix)

`builtinSlice` now handles the 3-index form `slice x i j k` → `x[i:j:k]` (capacity bound), matching `text/template`. A 3-index slice of a **string** is rejected with `cannot 3-index slice a string`, because `reflect.Slice3` only works on slices/arrays (the existing 2-index `reflect.Slice` path handles strings fine).

Tests: unit tests for capacity / string-error / too-many-indices, plus a `stdlib` parity test — including `{{slice (slice .S 0 2 5) 0 4}}`, which only renders correctly if the capacity bound was actually applied.

## #203 — documented (option B); real fix tracked in #459

The issue offered "return a `ParseError` **or** document the expected call pattern more clearly." The error path was found to break a legitimate, Go-parity pattern, so this PR takes the documentation option and files the real fix separately.

**Why not error in `callMethod`:** returning an argument-requiring method *uncalled* is load-bearing. `resolveFieldChain` resolves a chain **before** the caller knows whether trailing args follow, so it must not call a method that might still receive them. Returning the bound method is exactly what makes `{{.ctx.Get "key"}}` work — `resolveFieldChain` yields the bound `Get`, then `callMethodOrFieldWithArgs` applies `"key"` (covered by `TestStdlibParity_MethodCallOnMapValue`). Making `callMethod` error breaks that; making it *call* variadic methods breaks `{{.Join "a"}}` for `func(...string)` the same way.

**The real gap** — a *bare* `{{.Get}}` (no args) to an arg-requiring method should error like `text/template` instead of stringifying a func value — must be fixed at the **eval-node level**, where arg presence is known (`callMethod` only receives a `reflect.Value`, no AST context). Filed as **#459** with the full reasoning and test plan. The `callMethod` doc comment records the decision and points at #459.

## Testing

- `go test ./...` passes (full suite).
- `/simplify` run pre-commit: clean across reuse/simplification/efficiency/altitude.

Closes #202, #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)