### PR TITLE
docs(client-attributes): document lvt-on:click server-authoritative checkboxes

### DIFF
--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -811,7 +811,16 @@ User-toggled `checked` state on `<input type="checkbox">` and `<input type="radi
 <label><input type="checkbox" name="select" value="item-1"> Item 1</label>
 ```
 
-**Radio group caveat:** Browser mutual exclusion fires synchronously during the morphdom pass. If you need to force-reset a radio group from the server, add `data-lvt-force-update` to *all* radios in the group, not just the one being checked.
+**Exception — `lvt-on:click` controls are server-authoritative.** A checkbox or radio with an `lvt-on:click` handler routes its own toggle to the server, which echoes back the authoritative `checked` state in its re-render. There is no pending local-only selection to protect, so the server's rendered value wins automatically — without needing `data-lvt-force-update`. This is what makes a server-driven toggle (e.g. a todo checkbox) reflect correctly.
+
+```html
+<!-- Server owns the checked state; clicking routes the toggle to the server -->
+<input type="checkbox" {{if .Done}}checked{{end}} lvt-on:click="Toggle" data-id="{{.ID}}">
+```
+
+If instead you want the user's selection to win for a checkbox that *also* sends a click to the server (e.g. a click handler that only logs a side effect), use `lvt-on:change` — only `lvt-on:click` opts into server authority.
+
+**Radio group caveat:** Browser mutual exclusion fires synchronously during the morphdom pass. If you need to force-reset a radio group from the server, make the server send the authoritative state (via `lvt-on:click` or `data-lvt-force-update`) on *all* radios in the group, not just the one being checked.
 
 ### Dialog Open State
 
@@ -865,7 +874,7 @@ All automatic preservation behaviors can be overridden by adding `data-lvt-force
 
 | Preserved State | Mechanism | Override |
 |-----------|-------------|---------|
-| Checkbox/radio `checked` | Property copied to virtual DOM | `data-lvt-force-update` on the input |
+| Checkbox/radio `checked` | Property copied to virtual DOM | `data-lvt-force-update` on the input, or an `lvt-on:click` handler (auto server-authoritative) |
 | Dialog `open` | morphdom update skipped while dialog is open | `data-lvt-force-update` on the dialog |
 | Datalist dropdown | Entire morphdom pass deferred while datalist input focused | `data-lvt-force-update` on the connected `<input>` (overrides deferral for the entire pass) |
 | Focused input elements | morphdom update skipped | `data-lvt-force-update` on the input |


### PR DESCRIPTION
Documents the new behavior introduced in [livetemplate/client#135](https://github.com/livetemplate/client/pull/135): a checkbox/radio with an `lvt-on:click` handler is server-authoritative — the server's rendered `checked` state wins without needing `data-lvt-force-update`.

- New "Exception — `lvt-on:click` controls are server-authoritative" subsection under Checkbox/Radio preservation.
- Notes `lvt-on:change` as the user-wins escape hatch for side-effect-only click handlers.
- Updates the override summary table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)