### PR TITLE
perf(context): avoid reflect.New for value-receiver methods (#257)

### DIFF
--- a/internal/context/data.go
+++ b/internal/context/data.go
@@ -14,6 +14,11 @@ var errorInterface = reflect.TypeOf((*error)(nil)).Elem()
 type methodMeta struct {
 	Name  string
 	Index int
+	// ValueIndex is the method's index in the value type's method set, or -1 when
+	// the method has a pointer receiver (so it appears only in the pointer type's
+	// set). This lets value-input structs invoke value-receiver methods without
+	// allocating a pointer via reflect.New.
+	ValueIndex int
 	// HasError is true when the method returns (value, error).
 	HasError bool
 }
@@ -27,6 +32,7 @@ func getMethodMeta(ptrType reflect.Type) []methodMeta {
 	if cached, ok := methodMetaCache.Load(ptrType); ok {
 		return cached.([]methodMeta)
 	}
+	valType := ptrType.Elem()
 	var meta []methodMeta
 	for i := 0; i < ptrType.NumMethod(); i++ {
 		method := ptrType.Method(i)
@@ -38,12 +44,18 @@ func getMethodMeta(ptrType reflect.Type) []methodMeta {
 		if numIn != 1 {
 			continue
 		}
+		// A value-receiver method also appears in the value type's method set;
+		// a pointer-receiver method does not (ValueIndex stays -1).
+		valueIndex := -1
+		if vm, ok := valType.MethodByName(method.Name); ok {
+			valueIndex = vm.Index
+		}
 		switch mt.NumOut() {
 		case 1:
-			meta = append(meta, methodMeta{Name: method.Name, Index: i})
+			meta = append(meta, methodMeta{Name: method.Name, Index: i, ValueIndex: valueIndex})
 		case 2:
 			if mt.Out(1) == errorInterface {
-				meta = append(meta, methodMeta{Name: method.Name, Index: i, HasError: true})
+				meta = append(meta, methodMeta{Name: method.Name, Index: i, ValueIndex: valueIndex, HasError: true})
 			}
 		}
 	}
@@ -152,15 +164,32 @@ func buildDataMapWithContext(data interface{}, lvtContext *TemplateContext) inte
 		// on every render, even if the template doesn't reference them. Methods that
 		// return (T, error) are omitted with a warning when error is non-nil (unlike
 		// html/template which would stop execution with the error).
+		methods := getMethodMeta(reflect.PointerTo(typ))
+
+		// For value-type input, only allocate a pointer (reflect.New) if some
+		// qualifying method has a pointer receiver. When every method is a value
+		// receiver, call them directly on val and skip the per-render allocation.
 		if !ptrVal.IsValid() {
-			ptrVal = reflect.New(typ)
-			ptrVal.Elem().Set(val)
+			for _, m := range methods {
+				if m.ValueIndex < 0 {
+					ptrVal = reflect.New(typ)
+					ptrVal.Elem().Set(val)
+					break
+				}
+			}
 		}
-		for _, m := range getMethodMeta(ptrVal.Type()) {
+
+		for _, m := range methods {
 			if _, exists := dataMap[m.Name]; exists {
 				continue
 			}
-			results, panicked := safeMethodCall(ptrVal.Method(m.Index))
+			var method reflect.Value
+			if ptrVal.IsValid() {
+				method = ptrVal.Method(m.Index)
+			} else {
+				method = val.Method(m.ValueIndex)
+			}
+			results, panicked := safeMethodCall(method)
 			if panicked {
 				continue
 			}

--- a/internal/context/data_test.go
+++ b/internal/context/data_test.go
@@ -3,6 +3,7 @@ package context
 import (
 	"fmt"
 	"html/template"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -256,5 +257,47 @@ func TestBuildDataMap_MethodsWithPointerReceiverOnValueInput(t *testing.T) {
 	dm := dataMap.(map[string]interface{})
 	if _, ok := dm["Greeting"]; !ok {
 		t.Fatal("Pointer receiver method should be captured even when passed by value")
+	}
+}
+
+// MixedReceiverState has both a value-receiver and a pointer-receiver zero-arg
+// method, to exercise the receiver-kind bookkeeping in getMethodMeta.
+type MixedReceiverState struct {
+	Name string
+}
+
+func (s MixedReceiverState) ValueGreeting() string { return "value " + s.Name }
+
+func (s *MixedReceiverState) PtrGreeting() string { return "ptr " + s.Name }
+
+// TestGetMethodMeta_ValueIndexReceiverKinds locks the mechanism behind the
+// reflect.New optimization: value-receiver methods carry a real ValueIndex,
+// pointer-receiver methods carry -1.
+func TestGetMethodMeta_ValueIndexReceiverKinds(t *testing.T) {
+	meta := getMethodMeta(reflect.PointerTo(reflect.TypeOf(MixedReceiverState{})))
+	byName := make(map[string]methodMeta, len(meta))
+	for _, m := range meta {
+		byName[m.Name] = m
+	}
+
+	if vm, ok := byName["ValueGreeting"]; !ok || vm.ValueIndex < 0 {
+		t.Errorf("ValueGreeting should be value-receiver (ValueIndex >= 0), got %+v (ok=%v)", vm, ok)
+	}
+	if pm, ok := byName["PtrGreeting"]; !ok || pm.ValueIndex != -1 {
+		t.Errorf("PtrGreeting should be pointer-receiver (ValueIndex == -1), got %+v (ok=%v)", pm, ok)
+	}
+}
+
+// TestBuildDataMap_MixedReceiversOnValueInput is the correctness trap: a value
+// input that has at least one pointer-receiver method must allocate the pointer
+// and route ALL calls through it, so the value-receiver method still resolves.
+func TestBuildDataMap_MixedReceiversOnValueInput(t *testing.T) {
+	dm := BuildDataMap(MixedReceiverState{Name: "x"}, nil, false, nil).(map[string]interface{})
+
+	if got := dm["ValueGreeting"]; got != "value x" {
+		t.Errorf("ValueGreeting: got %v, want %q", got, "value x")
+	}
+	if got := dm["PtrGreeting"]; got != "ptr x" {
+		t.Errorf("PtrGreeting: got %v, want %q", got, "ptr x")
 	}
 }


### PR DESCRIPTION
Implements **#257** (a PR #254 follow-up). The sibling **#255** is deferred — see note below.

## #257 — skip the per-render `reflect.New` for value-receiver-only structs

`BuildDataMap` eagerly precomputes a struct's zero-arg methods on every render. For a **value-type** input it previously *always* allocated a pointer (`reflect.New(typ)` + a struct copy) so pointer-receiver methods were reachable — even when every qualifying method had a value receiver.

Now each method's receiver kind is recorded **once**, at cache-fill time in `getMethodMeta`: `methodMeta.ValueIndex` is the method's index in the value type's method set, or `-1` for a pointer receiver. `buildDataMapWithContext` allocates the pointer only when a value input has at least one pointer-receiver method; otherwise it calls value-receiver methods directly on the value — eliminating the per-render allocation + copy for the common value-receiver-only case.

**Invariants preserved:**
- Pointer inputs → unchanged (always routed through the pointer).
- Value input with a **mixed** receiver set (≥1 pointer-receiver method) → still allocates and routes *all* calls through the pointer, so value-receiver methods still resolve. This is the correctness trap, covered by a dedicated test.

The receiver-kind lookup (`MethodByName` on the value type) runs once per type (memoized via the existing `sync.Map`), so the per-render path adds no allocation; `reflect.PointerTo(typ)` replaces `ptrVal.Type()` and is a free, cached type-level op.

## Tests

- `TestGetMethodMeta_ValueIndexReceiverKinds` — locks the mechanism (`ValueIndex >= 0` for value-receiver, `-1` for pointer-receiver).
- `TestBuildDataMap_MixedReceiversOnValueInput` — the correctness trap.
- Existing precompute tests (value-only, pointer-only, error, panic, field-precedence) all still pass.

Per the advisor's guidance I did **not** assert with `testing.AllocsPerOp` — `BuildDataMap` boxes every field via `.Interface()` each call, so a single saved `reflect.New` is lost in the noise and a hard alloc-count assert would flake. The tests lock the mechanism + behavior instead.

## #255 — deferred (design issue #462)

#255 asked for a `lvt:"-"` tag to opt a method out of eager precompute. That mechanism is **infeasible** — Go struct tags apply to fields, not methods. Rather than commit to a stringly-typed opt-out API on an alpha with no users, the design (interface opt-out vs registration, and the deeper question of whether precompute should be lazy like `html/template` at all) is captured in **#462**. #255 stays open pending that decision.

## Testing

- `go test ./...` passes (full suite).
- `/simplify` run pre-commit: clean across reuse/simplification/efficiency/altitude.

Closes #257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)