### PR TITLE
feat(mount): WithEphemeralSweepTTL + persistent Mount-on-POST test (#304 #305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `WithEphemeralSweepTTL(ttl)` `HandleOption` to tune how long idle HTTP template cache entries survive in ephemeral mode (state with no `lvt:"persist"` fields) before the sweep loop evicts them. Defaults to 30 minutes; no effect in persistent mode (eviction follows the SessionStore there). A short TTL also tightens the sweep interval (floored at 1 minute) so the value is actually honored.
+
 ### Changed
 
 - **Breaking (pubsub):** renamed broadcaster handler-registration methods to use the `Register*Handler` convention, disambiguating one-time handler registration from the per-entity, reference-counted `SubscribeTo*` subscription methods. Implementers and callers of these `pubsub` interfaces must update:

--- a/handle_test.go
+++ b/handle_test.go
@@ -784,6 +784,136 @@ func TestWebSocketDisabled_StatePersistsAcrossRequests(t *testing.T) {
 	}
 }
 
+// mountObsState/mountObsController record the Count that Mount observes on each
+// request, to verify the persistent-mode HTTP ordering: load from SessionStore →
+// Mount → action.
+type mountObsState struct {
+	Count int `lvt:"persist"`
+}
+
+type mountObsController struct {
+	mountCounts []int // Count seen at the start of each Mount (calls are sequential in tests)
+}
+
+func (c *mountObsController) Mount(s mountObsState, _ *Context) (mountObsState, error) {
+	c.mountCounts = append(c.mountCounts, s.Count)
+	return s, nil
+}
+
+func (c *mountObsController) Increment(s mountObsState, _ *Context) (mountObsState, error) {
+	s.Count++
+	return s, nil
+}
+
+func TestPersistentMode_MountOnPostReceivesPersistedState(t *testing.T) {
+	ctrl := &mountObsController{}
+	tmpl, err := New("test", WithWebSocketDisabled())
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>Count: {{.Count}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	handler := tmpl.Handle(ctrl, AsState(&mountObsState{}))
+
+	// GET creates the session (Mount sees the initial Count=0).
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	cookie := extractSessionCookie(rec)
+	if cookie == nil {
+		t.Fatal("expected session cookie to be set")
+	}
+
+	// postIncrement issues an Increment action. In progressive-enhancement mode this
+	// is a POST-Redirect-GET, so the POST response is a 303 with no rendered body —
+	// state is observed via a follow-up GET (and via the recording Mount).
+	postIncrement := func() {
+		form := url.Values{}
+		form.Set("lvt-action", "Increment")
+		r := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.Header.Set("Accept", "text/html")
+		r.AddCookie(cookie)
+		handler.ServeHTTP(httptest.NewRecorder(), r)
+	}
+
+	getCount := func() string {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.AddCookie(cookie)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		return w.Body.String()
+	}
+
+	// First POST increments to 1 and persists it.
+	postIncrement()
+	idxBeforeSecondPost := len(ctrl.mountCounts)
+
+	// Second POST: Mount must receive the persisted Count=1 (load → Mount → action),
+	// not a fresh clone with Count=0. This is the core ordering assertion.
+	postIncrement()
+	if idxBeforeSecondPost >= len(ctrl.mountCounts) {
+		t.Fatalf("expected Mount to run during the second POST; mountCounts=%v", ctrl.mountCounts)
+	}
+	if got := ctrl.mountCounts[idxBeforeSecondPost]; got != 1 {
+		t.Errorf("Mount on second POST should receive persisted Count=1, got %d (all observed: %v)", got, ctrl.mountCounts)
+	}
+
+	// Both increments persisted end-to-end.
+	if body := getCount(); !strings.Contains(body, "Count: 2") {
+		t.Errorf("after two increments, expected 'Count: 2', got: %s", body)
+	}
+}
+
+func TestWithEphemeralSweepTTL(t *testing.T) {
+	build := func(opts ...HandleOption) *liveHandler {
+		tmpl, err := New("test")
+		if err != nil {
+			t.Fatalf("New failed: %v", err)
+		}
+		tmpl, err = tmpl.Parse("<div>{{.Count}}</div>")
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		return tmpl.Handle(&wsDisabledController{}, AsState(&wsDisabledState{}), opts...).(*liveHandler)
+	}
+
+	if got := build().ephemeralSweepTTL; got != defaultEphemeralSweepTTL {
+		t.Errorf("unset: ephemeralSweepTTL = %v, want default %v", got, defaultEphemeralSweepTTL)
+	}
+	if got := build(WithEphemeralSweepTTL(5 * time.Minute)).ephemeralSweepTTL; got != 5*time.Minute {
+		t.Errorf("custom: ephemeralSweepTTL = %v, want 5m", got)
+	}
+	if got := build(WithEphemeralSweepTTL(0)).ephemeralSweepTTL; got != defaultEphemeralSweepTTL {
+		t.Errorf("zero: ephemeralSweepTTL = %v, want default %v", got, defaultEphemeralSweepTTL)
+	}
+	if got := build(WithEphemeralSweepTTL(-time.Second)).ephemeralSweepTTL; got != defaultEphemeralSweepTTL {
+		t.Errorf("negative: ephemeralSweepTTL = %v, want default %v", got, defaultEphemeralSweepTTL)
+	}
+}
+
+func TestSweepInterval(t *testing.T) {
+	tests := []struct {
+		name      string
+		ephemeral bool
+		ttl       time.Duration
+		want      time.Duration
+	}{
+		{"persistent keeps default", false, 2 * time.Minute, defaultSweepInterval},
+		{"ephemeral long TTL keeps default", true, 30 * time.Minute, defaultSweepInterval},
+		{"ephemeral short TTL shrinks to TTL", true, 3 * time.Minute, 3 * time.Minute},
+		{"ephemeral tiny TTL floored", true, 5 * time.Second, minSweepInterval},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sweepInterval(tt.ephemeral, tt.ttl); got != tt.want {
+				t.Errorf("sweepInterval(%v, %v) = %v, want %v", tt.ephemeral, tt.ttl, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWebSocketDisabled_SessionIsolation(t *testing.T) {
 	handler := newWSDisabledHandler(t)
 

--- a/mount.go
+++ b/mount.go
@@ -137,11 +137,21 @@ type LiveHandler interface {
 	Publish(topic, action string, data map[string]interface{}) error
 }
 
-// ephemeralSweepTTL is how long idle HTTP template cache entries survive in ephemeral
-// mode before being evicted by the sweep loop. 30 minutes balances memory reclamation
-// for abandoned sessions vs keeping diff baselines alive for active users between
-// interactions (e.g., reading a page before submitting a form).
-const ephemeralSweepTTL = 30 * time.Minute
+// defaultEphemeralSweepTTL is how long idle HTTP template cache entries survive in
+// ephemeral mode before being evicted by the sweep loop, unless overridden via
+// WithEphemeralSweepTTL. 30 minutes balances memory reclamation for abandoned
+// sessions vs keeping diff baselines alive for active users between interactions
+// (e.g., reading a page before submitting a form).
+const defaultEphemeralSweepTTL = 30 * time.Minute
+
+// defaultSweepInterval is how often the sweep loop runs. In ephemeral mode the
+// interval is reduced to the configured TTL (floored) so a short TTL is actually
+// honored rather than rounded up to the next sweep.
+const defaultSweepInterval = 10 * time.Minute
+
+// minSweepInterval bounds how fast the ephemeral sweep goroutine can spin when a
+// very short TTL is configured.
+const minSweepInterval = 1 * time.Minute
 
 // mountConfig configures the mount handler (internal only)
 type mountConfig struct {
@@ -176,6 +186,11 @@ type liveHandler struct {
 	needsStreaming  bool     // true if any field needs the streaming multipart path: Proxied or Volume-with-Dir (static, computed at Handle)
 	httpTemplates   sync.Map // groupID → *httpTemplateCacheEntry (cached for HTTP POST diff optimization)
 	httpLastPaths   sync.Map // groupID → string (last served request path, for detecting URL changes)
+
+	// ephemeralSweepTTL is the idle TTL for HTTP template cache entries in
+	// ephemeral mode (no persist fields). Resolved at Handle: WithEphemeralSweepTTL
+	// or defaultEphemeralSweepTTL.
+	ephemeralSweepTTL time.Duration
 
 	// Graceful shutdown state
 	shutdownOnce sync.Once
@@ -1907,12 +1922,24 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 	}
 }
 
+// sweepInterval picks how often the sweep loop runs. In ephemeral mode it shrinks
+// the interval toward the TTL (floored at minSweepInterval) so a short TTL is
+// honored instead of rounded up to the default interval. Persistent mode keeps the
+// default interval (its eviction is SessionStore-driven, not TTL-driven, so a
+// tighter interval would only add SessionStore.List load).
+func sweepInterval(ephemeral bool, ttl time.Duration) time.Duration {
+	if !ephemeral || ttl >= defaultSweepInterval {
+		return defaultSweepInterval
+	}
+	return max(ttl, minSweepInterval)
+}
+
 // httpTemplateSweepLoop periodically removes cached HTTP templates to prevent
 // unbounded memory growth. In persistent mode, evicts entries whose session no
 // longer exists in the SessionStore. In ephemeral mode (no SessionStore), evicts
-// entries idle for longer than ephemeralSweepTTL.
+// entries idle for longer than the configured ephemeralSweepTTL.
 func (h *liveHandler) httpTemplateSweepLoop() {
-	ticker := time.NewTicker(10 * time.Minute)
+	ticker := time.NewTicker(sweepInterval(h.persistable == nil, h.ephemeralSweepTTL))
 	defer ticker.Stop()
 
 	for {
@@ -1929,8 +1956,8 @@ func (h *liveHandler) sweepStaleHTTPTemplates() {
 	sweptSessions := make(map[string]struct{})
 
 	if h.persistable == nil {
-		// No persist fields: no SessionStore to check. Evict entries idle for >30 minutes.
-		cutoff := time.Now().Add(-ephemeralSweepTTL).Unix()
+		// No persist fields: no SessionStore to check. Evict entries idle longer than the TTL.
+		cutoff := time.Now().Add(-h.ephemeralSweepTTL).Unix()
 		h.httpTemplates.Range(func(key, value any) bool {
 			groupID := key.(string)
 			entry := value.(*httpTemplateCacheEntry)

--- a/mount.go
+++ b/mount.go
@@ -151,7 +151,7 @@ const defaultSweepInterval = 10 * time.Minute
 
 // minSweepInterval bounds how fast the ephemeral sweep goroutine can spin when a
 // very short TTL is configured.
-const minSweepInterval = 1 * time.Minute
+const minSweepInterval = time.Minute
 
 // mountConfig configures the mount handler (internal only)
 type mountConfig struct {
@@ -188,8 +188,8 @@ type liveHandler struct {
 	httpLastPaths   sync.Map // groupID → string (last served request path, for detecting URL changes)
 
 	// ephemeralSweepTTL is the idle TTL for HTTP template cache entries in
-	// ephemeral mode (no persist fields). Resolved at Handle: WithEphemeralSweepTTL
-	// or defaultEphemeralSweepTTL.
+	// ephemeral mode (no persist fields). Always positive; defaults to
+	// defaultEphemeralSweepTTL.
 	ephemeralSweepTTL time.Duration
 
 	// Graceful shutdown state

--- a/template.go
+++ b/template.go
@@ -1658,15 +1658,21 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 		ps = p
 	}
 
+	sweepTTL := config.ephemeralSweepTTL
+	if sweepTTL <= 0 {
+		sweepTTL = defaultEphemeralSweepTTL
+	}
+
 	handler := &liveHandler{
-		config:          mountCfg,
-		persistable:     ps,
-		registry:        session.NewConnectionRegistry(),
-		limits:          limits,
-		metricsExporter: metricsExporter,
-		tempFileManager: tempFileManager,
-		needsStreaming:  uploadConfigsNeedStreaming(t.config.UploadConfigs),
-		shutdownChan:    make(chan struct{}),
+		config:            mountCfg,
+		persistable:       ps,
+		registry:          session.NewConnectionRegistry(),
+		limits:            limits,
+		metricsExporter:   metricsExporter,
+		tempFileManager:   tempFileManager,
+		needsStreaming:    uploadConfigsNeedStreaming(t.config.UploadConfigs),
+		ephemeralSweepTTL: sweepTTL,
+		shutdownChan:      make(chan struct{}),
 	}
 
 	// Wire up metrics to registry for WebSocket observability
@@ -1728,7 +1734,8 @@ func (t *Template) Handle(controller interface{}, state State, opts ...HandleOpt
 type HandleOption func(*handleConfig)
 
 type handleConfig struct {
-	sessionStore SessionStore
+	sessionStore      SessionStore
+	ephemeralSweepTTL time.Duration
 }
 
 // WithStore sets the session store for state persistence.
@@ -1736,6 +1743,19 @@ type handleConfig struct {
 func WithStore(store SessionStore) HandleOption {
 	return func(c *handleConfig) {
 		c.sessionStore = store
+	}
+}
+
+// WithEphemeralSweepTTL sets how long an idle HTTP template cache entry survives
+// in ephemeral mode (state with no lvt:"persist" fields) before the sweep loop
+// evicts it. Defaults to 30 minutes when unset or non-positive. Has no effect in
+// persistent mode, where eviction follows the SessionStore instead.
+//
+// Eviction runs on a periodic sweep, so an entry may persist up to one sweep
+// interval beyond the TTL; very short TTLs are floored to keep the sweep cheap.
+func WithEphemeralSweepTTL(ttl time.Duration) HandleOption {
+	return func(c *handleConfig) {
+		c.ephemeralSweepTTL = ttl
 	}
 }
 


### PR DESCRIPTION
Bundles the two PR #301 follow-ups.

## #305 — `WithEphemeralSweepTTL` (new option)

Makes the ephemeral HTTP-template-cache sweep TTL configurable:

```go
tmpl.Handle(ctrl, livetemplate.AsState(&State{}),
    livetemplate.WithEphemeralSweepTTL(10*time.Minute))
```

- Defaults to **30 minutes** when unset or non-positive.
- **No effect in persistent mode** (state with `lvt:"persist"` fields) — there, eviction follows the SessionStore, not a TTL.
- A short TTL also **tightens the sweep interval**: `sweepInterval()` caps the ticker to the TTL (floored at 1m) in ephemeral mode, so a 2m TTL is actually honored rather than rounded up to the 10m default. Persistent mode keeps the 10m interval (its eviction is `SessionStore.List`-driven, and a tighter interval would only add load).
- Renames the const `ephemeralSweepTTL` → `defaultEphemeralSweepTTL`; extracts `defaultSweepInterval` / `minSweepInterval`.

**Note on the issue's example:** #305 shows `WithEphemeralState()`, which **no longer exists** — ephemeral mode is now automatic when the state has no `lvt:"persist"` fields. This PR adds only `WithEphemeralSweepTTL`.

## #304 — persistent-mode Mount-on-POST ordering test

`TestPersistentMode_MountOnPostReceivesPersistedState` uses a `Mount`-recording controller to verify the load → Mount → action ordering: on the **second** POST, `Mount` receives the persisted `Count=1`, not a fresh clone with `Count=0`. The assertion captures the Mount-call index *before* the second POST and checks that specific call (robust to extra Mount calls), with an end-to-end `Count: 2` backstop.

## Tests

- `TestPersistentMode_MountOnPostReceivesPersistedState` — the ordering invariant.
- `TestWithEphemeralSweepTTL` — option resolution (default / custom / zero / negative → default).
- `TestSweepInterval` — interval capping/flooring (persistent keeps default; ephemeral long-TTL keeps default; short-TTL shrinks to TTL; tiny-TTL floored).
- `go test ./...` passes; `/simplify` clean across reuse/simplification/efficiency/altitude.

Closes #304, #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)