### PR TITLE
refactor(formvalidation): unify FormRule optional-bound sentinels (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (`FormRule`):** unified the optional-bound sentinels. `MinLength`/`MaxLength` no longer use `-1` to mean "not set"; all four numeric bounds are now gated by paired `Has*` booleans — new `HasMinLength`/`HasMaxLength` join the existing `HasMin`/`HasMax`. Code that constructed a `FormRule` with `MinLength: -1` (or read it expecting the `-1` sentinel) must switch to the `Has*` flags. Callers using `ExtractFormSchema`/`ValidateForm` normally are unaffected.
 - **Breaking (pubsub):** renamed broadcaster handler-registration methods to use the `Register*Handler` convention, disambiguating one-time handler registration from the per-entity, reference-counted `SubscribeTo*` subscription methods. Implementers and callers of these `pubsub` interfaces must update:
   - `Broadcaster.SubscribeServerActions` → `Broadcaster.RegisterServerActionHandler`
   - `GroupActionBroadcaster.SubscribeGroupActions` → `GroupActionBroadcaster.RegisterGroupActionHandler`

--- a/formvalidation.go
+++ b/formvalidation.go
@@ -11,18 +11,22 @@ import (
 )
 
 // FormRule represents a validation rule inferred from HTML input attributes.
+// Optional numeric bounds use a paired Has* boolean to signal "set" (the zero
+// value is a valid bound, so a sentinel won't do).
 type FormRule struct {
-	Field     string
-	Required  bool
-	InputType string // "email", "url", "number", "tel"
-	MinLength int    // -1 if not set
-	MaxLength int    // -1 if not set
-	Min       float64
-	Max       float64
-	HasMin    bool
-	HasMax    bool
-	Pattern   string         // raw pattern string
-	PatternRe *regexp.Regexp // pre-compiled pattern (nil if invalid or absent)
+	Field        string
+	Required     bool
+	InputType    string // "email", "url", "number", "tel"
+	MinLength    int
+	MaxLength    int
+	Min          float64
+	Max          float64
+	HasMinLength bool
+	HasMaxLength bool
+	HasMin       bool
+	HasMax       bool
+	Pattern      string         // raw pattern string
+	PatternRe    *regexp.Regexp // pre-compiled pattern (nil if invalid or absent)
 }
 
 // FormSchema holds validation rules inferred from template statics.
@@ -71,11 +75,7 @@ func ExtractFormSchema(statics []string) *FormSchema {
 			continue
 		}
 
-		rule := FormRule{
-			Field:     name,
-			MinLength: -1,
-			MaxLength: -1,
-		}
+		rule := FormRule{Field: name}
 
 		if _, ok := attrs["required"]; ok {
 			rule.Required = true
@@ -88,12 +88,14 @@ func ExtractFormSchema(statics []string) *FormSchema {
 		if v, ok := attrs["minlength"]; ok {
 			if n, err := strconv.Atoi(v); err == nil {
 				rule.MinLength = n
+				rule.HasMinLength = true
 			}
 		}
 
 		if v, ok := attrs["maxlength"]; ok {
 			if n, err := strconv.Atoi(v); err == nil {
 				rule.MaxLength = n
+				rule.HasMaxLength = true
 			}
 		}
 
@@ -118,7 +120,7 @@ func ExtractFormSchema(statics []string) *FormSchema {
 		}
 
 		if rule.Required || rule.InputType == "email" || rule.InputType == "url" ||
-			rule.MinLength >= 0 || rule.MaxLength >= 0 || rule.HasMin || rule.HasMax || rule.Pattern != "" {
+			rule.HasMinLength || rule.HasMaxLength || rule.HasMin || rule.HasMax || rule.Pattern != "" {
 			schema.Rules = append(schema.Rules, rule)
 		}
 	}
@@ -180,11 +182,11 @@ func (s *FormSchema) Validate(data map[string]interface{}) error {
 		}
 
 		// Use rune count for minlength/maxlength (HTML counts Unicode code points, not bytes)
-		if rule.MinLength >= 0 && utf8.RuneCountInString(strVal) < rule.MinLength {
+		if rule.HasMinLength && utf8.RuneCountInString(strVal) < rule.MinLength {
 			errs = append(errs, FieldError{Field: toSnakeCase(rule.Field), Message: fmt.Sprintf("%s must be at least %d characters", fieldName, rule.MinLength)})
 		}
 
-		if rule.MaxLength >= 0 && utf8.RuneCountInString(strVal) > rule.MaxLength {
+		if rule.HasMaxLength && utf8.RuneCountInString(strVal) > rule.MaxLength {
 			errs = append(errs, FieldError{Field: toSnakeCase(rule.Field), Message: fmt.Sprintf("%s must be at most %d characters", fieldName, rule.MaxLength)})
 		}
 

--- a/formvalidation_test.go
+++ b/formvalidation_test.go
@@ -36,11 +36,11 @@ func TestExtractFormSchema_BasicAttributes(t *testing.T) {
 	if email.InputType != "email" {
 		t.Errorf("Email type = %q, want email", email.InputType)
 	}
-	if email.MinLength != 5 {
-		t.Errorf("Email minlength = %d, want 5", email.MinLength)
+	if !email.HasMinLength || email.MinLength != 5 {
+		t.Errorf("Email minlength = %v/%d, want true/5", email.HasMinLength, email.MinLength)
 	}
-	if email.MaxLength != 100 {
-		t.Errorf("Email maxlength = %d, want 100", email.MaxLength)
+	if !email.HasMaxLength || email.MaxLength != 100 {
+		t.Errorf("Email maxlength = %v/%d, want true/100", email.HasMaxLength, email.MaxLength)
 	}
 
 	// Age rule
@@ -87,7 +87,7 @@ func TestExtractFormSchema_NoNameAttr(t *testing.T) {
 func TestFormSchema_Validate_Required(t *testing.T) {
 	schema := &FormSchema{
 		Rules: []FormRule{
-			{Field: "Title", Required: true, MinLength: -1, MaxLength: -1},
+			{Field: "Title", Required: true},
 		},
 	}
 
@@ -110,7 +110,7 @@ func TestFormSchema_Validate_Required(t *testing.T) {
 func TestFormSchema_Validate_Email(t *testing.T) {
 	schema := &FormSchema{
 		Rules: []FormRule{
-			{Field: "Email", InputType: "email", MinLength: -1, MaxLength: -1},
+			{Field: "Email", InputType: "email"},
 		},
 	}
 
@@ -128,7 +128,7 @@ func TestFormSchema_Validate_Email(t *testing.T) {
 func TestFormSchema_Validate_MinMaxLength(t *testing.T) {
 	schema := &FormSchema{
 		Rules: []FormRule{
-			{Field: "Name", MinLength: 3, MaxLength: 10},
+			{Field: "Name", MinLength: 3, HasMinLength: true, MaxLength: 10, HasMaxLength: true},
 		},
 	}
 
@@ -151,7 +151,7 @@ func TestFormSchema_Validate_MinMaxLength(t *testing.T) {
 func TestFormSchema_Validate_MinMax(t *testing.T) {
 	schema := &FormSchema{
 		Rules: []FormRule{
-			{Field: "Age", HasMin: true, Min: 18, HasMax: true, Max: 120, MinLength: -1, MaxLength: -1},
+			{Field: "Age", HasMin: true, Min: 18, HasMax: true, Max: 120},
 		},
 	}
 
@@ -174,7 +174,7 @@ func TestFormSchema_Validate_MinMax(t *testing.T) {
 func TestFormSchema_Validate_Pattern(t *testing.T) {
 	schema := &FormSchema{
 		Rules: []FormRule{
-			{Field: "Code", Pattern: "[A-Z]{3}", PatternRe: regexp.MustCompile("^(?:[A-Z]{3})$"), MinLength: -1, MaxLength: -1},
+			{Field: "Code", Pattern: "[A-Z]{3}", PatternRe: regexp.MustCompile("^(?:[A-Z]{3})$")},
 		},
 	}
 
@@ -192,8 +192,8 @@ func TestFormSchema_Validate_Pattern(t *testing.T) {
 func TestFormSchema_Validate_MultipleErrors(t *testing.T) {
 	schema := &FormSchema{
 		Rules: []FormRule{
-			{Field: "Name", Required: true, MinLength: -1, MaxLength: -1},
-			{Field: "Email", Required: true, InputType: "email", MinLength: -1, MaxLength: -1},
+			{Field: "Name", Required: true},
+			{Field: "Email", Required: true, InputType: "email"},
 		},
 	}
 
@@ -222,7 +222,7 @@ func TestFormSchema_Validate_NilSchema(t *testing.T) {
 func TestContext_ValidateForm(t *testing.T) {
 	schema := &FormSchema{
 		Rules: []FormRule{
-			{Field: "Title", Required: true, MinLength: 3, MaxLength: -1},
+			{Field: "Title", Required: true, MinLength: 3, HasMinLength: true},
 		},
 	}
 


### PR DESCRIPTION
Implements **#241**. The sibling **#239** is intentionally out of scope — see note below.

## #241 — consistent sentinel design in `FormRule`

`FormRule` mixed two "not set" conventions:
- `MinLength`/`MaxLength`: `-1` sentinel
- `Min`/`Max`: `HasMin`/`HasMax` booleans

Unified on the `Has*` pattern already present in the struct: dropped the `-1` sentinel and added `HasMinLength`/`HasMaxLength`, so all four numeric bounds read uniformly. (The zero value is a *valid* bound, so an int sentinel was unsound to begin with.)

**Why `Has*` and not pointers** (the issue's other option): the struct already used `HasMin`/`HasMax`, so extending that follows the existing pattern (CLAUDE.md) and keeps reads as plain value comparisons. Pointers would force nil-deref at every read site and either leave the struct half-pointer/half-bool or churn `Min`/`Max` too.

- `ExtractFormSchema` sets the paired flag where it parses each value; the construction collapses to `FormRule{Field: name}`.
- The eligibility gate and `Validate`'s length checks switch from `>= 0` to the flag.
- All read/write sites switched in lockstep; no `-1`/`>= 0` sentinel references remain.

**Breaking:** `FormRule` is exported, so code constructing it with `MinLength: -1` or reading the `-1` sentinel must switch to the `Has*` flags. CHANGELOG `### Changed` entry added. Callers using `ExtractFormSchema`/`ValidateForm` normally are unaffected. (Pre-1.0/alpha, so no deprecation shim.)

## #239 — scoped separately (not in this PR)

#239 (server-side `formnovalidate` in `ValidateForm`) is a **cross-repo** change: the `livetemplate/client` must send a `_formnovalidate` flag for the submitter, the server checks it, plus docs/example + a client release. It's being handled as its own effort rather than bundled with this server-only refactor. #239 stays open.

## Testing

- `go test ./...` passes; form-validation suite updated for the new flags (including a strengthened `ExtractFormSchema` assertion that checks `HasMinLength`/`HasMaxLength`).
- `/simplify` run pre-commit: clean across reuse/simplification/efficiency/altitude.

Closes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)