### PR TITLE
ci(cross-repo): explicit cache-dependency-path on setup-go (#405)

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -163,8 +163,8 @@ jobs:
         # go.sum auto-detection can key the cache off the wrong module.
         cache-dependency-path: |
           livetemplate/go.sum
-          lvt/go.sum
           docs/go.sum
+          lvt/go.sum
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -41,6 +41,11 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.26'
+        # Explicit paths: with multiple Go modules checked out, setup-go's
+        # go.sum auto-detection can key the cache off the wrong module.
+        cache-dependency-path: |
+          livetemplate/go.sum
+          lvt/go.sum
 
     - name: Install sqlc
       run: |
@@ -154,6 +159,12 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.26'
+        # Explicit paths: with multiple Go modules checked out, setup-go's
+        # go.sum auto-detection can key the cache off the wrong module.
+        cache-dependency-path: |
+          livetemplate/go.sum
+          lvt/go.sum
+          docs/go.sum
 
     - name: Set up Node.js
       uses: actions/setup-node@v4
@@ -224,6 +235,12 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.26'
+        # Explicit paths: with multiple Go modules checked out, setup-go's
+        # go.sum auto-detection can key the cache off the wrong module.
+        cache-dependency-path: |
+          livetemplate/go.sum
+          tinkerdown/go.sum
+          lvt/go.sum
 
     - name: Set up Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
Implements **#405**. The sibling **#404 is obsolete** — see note below.

## #405 — explicit `cache-dependency-path` on `setup-go`

Each cross-repo job checks out several Go modules (`livetemplate` + `lvt`/`docs`/`tinkerdown`), so `actions/setup-go@v5`'s `go.sum` auto-detection can key the module cache off the wrong module → unpredictable cache behavior. Each `setup-go` step now pins the exact `go.sum` files that job checks out:

| Job | `cache-dependency-path` |
|---|---|
| `test-lvt` | `livetemplate/go.sum`, `lvt/go.sum` |
| `test-docs-examples` | `livetemplate/go.sum`, `lvt/go.sum`, `docs/go.sum` |
| `test-tinkerdown` | `livetemplate/go.sum`, `tinkerdown/go.sum`, `lvt/go.sum` |

Verified that every listed `go.sum` is checked out (at the listed `path:`) **before** its `setup-go` step, so the cache step resolves them — and the client checkouts are intentionally absent (TS-only, Node-cached at `setup-node`). This PR's own cross-repo run exercises the change end-to-end.

## #404 — obsolete (recommend closing)

#404 asks to collapse three near-verbatim `test-docs-*` recipe jobs into a reusable workflow. **Those jobs no longer exist** — `livetemplate/docs` PR #35 dissolved them into the single `test-docs-examples` job (see the comment at the top of that job). The three remaining cross-repo jobs (`test-lvt`/`test-docs-examples`/`test-tinkerdown`) differ substantially — different downstream repos, checkouts, and test steps — so a reusable workflow would add indirection for little gain. The specific duplication #404 targeted is gone; recommending it be closed rather than implemented.

## Notes

- YAML-only change; no Go code touched. `/simplify` run pre-commit: clean (per-job duplication is idiomatic for GHA — no clean cross-job DRY short of #404's reusable workflow).

Closes #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)