### PR TITLE
fix(parse): strip HTML comments to match html/template (#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- HTML comments (`<!-- ... -->`) are now stripped from template output, matching `html/template` (which removes them during its escape pass). LiveTemplate builds statics by walking the raw parse tree, which never triggers that pass, so developer/internal comments previously shipped verbatim to the client (visible in view-source) and over WebSocket tree updates. Stripping uses the HTML tokenizer, so comment-like text in attribute values is preserved and comments inside `<script>`/`<style>`/`<textarea>` are left verbatim. See `docs/references/template-support-matrix.md` for residual divergences. (#468)
 - `NewGorillaUpgrader` now gives each upgrader its own write-buffer `sync.Pool` instead of sharing a package-level global, so upgraders configured with different `WriteBufferSize` values can no longer draw mismatched buffers from a shared pool.
 
 ## [v0.14.0] - 2026-06-13

--- a/comment_strip_test.go
+++ b/comment_strip_test.go
@@ -1,0 +1,118 @@
+package livetemplate
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestExecuteUpdates_StripsHTMLComments is the regression test for #468: HTML
+// comments must not survive into the static segments shipped to the client,
+// matching html/template (which strips them during its escape pass). This is
+// the issue's own repro promoted to an assertion.
+func TestExecuteUpdates_StripsHTMLComments(t *testing.T) {
+	const src = `<div><!-- SECRET-HTML-COMMENT -->{{.X}}{{/* SECRET-TMPL-COMMENT */}}</div>`
+
+	tmpl := Must(New("cmt"))
+	if _, err := tmpl.Parse(src); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteUpdates(&buf, map[string]any{"X": "hi"}); err != nil {
+		t.Fatalf("ExecuteUpdates() failed: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "SECRET-HTML-COMMENT") {
+		t.Errorf("HTML comment leaked into wire output (should be stripped like html/template):\n%s", out)
+	}
+	if !strings.Contains(out, "hi") {
+		t.Errorf("dynamic value missing from output:\n%s", out)
+	}
+}
+
+// TestExecuteUpdates_PreservesCommentLikeAttributeValue guards against the
+// over-eager-regex failure mode: comment-like text inside an attribute value is
+// real content and must be preserved.
+func TestExecuteUpdates_PreservesCommentLikeAttributeValue(t *testing.T) {
+	const src = `<div title="<!-- not a comment -->">{{.X}}</div>`
+
+	tmpl := Must(New("attr"))
+	if _, err := tmpl.Parse(src); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteUpdates(&buf, map[string]any{"X": "hi"}); err != nil {
+		t.Fatalf("ExecuteUpdates() failed: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "not a comment") {
+		t.Errorf("comment-like attribute value was wrongly stripped:\n%s", buf.String())
+	}
+}
+
+// TestParse_FullHTMLMarkerOnlyInComment_StillWraps guards the regression where
+// isFullHTML was computed on the pre-strip text: a `<!DOCTYPE`/`<html` marker
+// living only inside a comment made the full-document path run on what becomes
+// a bare fragment after stripping, skipping the data-lvt-id wrapper and
+// breaking client update targeting.
+func TestParse_FullHTMLMarkerOnlyInComment_StillWraps(t *testing.T) {
+	const src = `<!-- <!DOCTYPE html> --><div>{{.X}}</div>`
+
+	tmpl := Must(New("dt"))
+	if _, err := tmpl.Parse(src); err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, map[string]any{"X": "hi"}); err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "data-lvt-id") {
+		t.Errorf("fragment (after comment strip) missing data-lvt-id wrapper:\n%s", buf.String())
+	}
+}
+
+// TestParse_DefineInsideComment_NotResolved confirms a {{define}} living inside
+// an HTML comment is removed (like html/template strips it) rather than resolved
+// during composition. Comments are stripped before parsing, so the {{template}}
+// call that references it is left undefined and parsing fails — instead of
+// silently inlining the commented-out define. Regression for #468.
+func TestParse_DefineInsideComment_NotResolved(t *testing.T) {
+	const src = `<!-- {{define "footer"}}© Corp{{end}} -->{{template "footer" .}}`
+
+	tmpl := Must(New("dc"))
+	if _, err := tmpl.Parse(src); err == nil {
+		t.Fatal("expected an error: a {{define}} inside a comment should be stripped, leaving template \"footer\" undefined")
+	}
+}
+
+// TestExecuteUpdates_CommentMarkerInsideAction guards the regression where a
+// literal `<!--` inside a {{...}} action was mistaken for an HTML comment: the
+// first form silently dropped the action's output, the latter two failed to
+// parse. All must round-trip like html/template (which never strips inside an
+// action).
+func TestExecuteUpdates_CommentMarkerInsideAction(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"literal comment in action output", `<div>{{"<!-- x -->"}}</div>`},
+		{"comment marker in template comment", `<div>{{/* <!-- */}}{{.X}}</div>`},
+		{"comment marker in string literal", `{{if eq .Sep "<!--"}}yes{{end}}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tmpl := Must(New("act"))
+			if _, err := tmpl.Parse(c.src); err != nil {
+				t.Fatalf("Parse() failed (should be valid like on stdlib): %v", err)
+			}
+			var buf bytes.Buffer
+			if err := tmpl.ExecuteUpdates(&buf, map[string]any{"X": "hi", "Sep": "<!--"}); err != nil {
+				t.Fatalf("ExecuteUpdates() failed: %v", err)
+			}
+		})
+	}
+}

--- a/docs/references/template-support-matrix.md
+++ b/docs/references/template-support-matrix.md
@@ -26,9 +26,35 @@ This document provides a comprehensive matrix of Go template patterns and their 
 |---------|--------|-------|---------|-------|
 | Simple field output | ✅ | Baseline | `{{.Name}}` | Core feature |
 | Nested field access | ✅ | Baseline | `{{.User.Name}}` | Tested in multiple contexts |
-| Comments | ✅ | Phase 5 | `{{/* comment */}}` | Properly ignored during parsing |
+| Template comments | ✅ | Phase 5 | `{{/* comment */}}` | Properly ignored during parsing |
+| HTML comments | ✅ | Phase 1 | `<!-- comment -->` | Stripped to match `html/template` (see note below) |
 | Empty templates | ✅ | Phase 5 | `` (empty string) | Handles gracefully |
 | Comment-only templates | ✅ | Phase 5 | `{{/* only comment */}}` | Valid template |
+
+#### HTML comment stripping
+
+`html/template` removes HTML comments (`<!-- ... -->`) during its escape pass.
+LiveTemplate builds its static segments by walking the raw parse tree, which
+never triggers that pass, so comments are stripped explicitly at parse time
+(`render.StripHTMLComments`, applied in `parseInternal`) to keep output
+consistent with `html/template` and to avoid leaking developer/internal
+comments to the client. A comment that wraps an action (`<!-- {{.X}} -->`) is
+removed in full, action included — matching `html/template`.
+
+Stripping uses the HTML tokenizer (not a regex), so it is context-aware:
+
+- A literal `<!--` inside a `{{...}}` action (e.g. `{{"<!--"}}`, a
+  `{{/* <!-- */}}` template comment, or a quoted argument) is **preserved** and
+  never mistaken for an HTML comment — action spans are masked out before
+  stripping, matching `html/template`, which never strips inside an action.
+- Comment-like text inside an attribute value (`title="<!-- x -->"`) is real
+  content and is **preserved**.
+- Comment markup inside `<script>`, `<style>`, and `<textarea>` (RAWTEXT /
+  RCDATA) is **left verbatim**, since the tokenizer does not treat it as a
+  comment there. Note two residual divergences from `html/template` in these
+  contexts (both pre-existing, unchanged by the stripping): in `<script>`,
+  `html/template` rejects `<!--` outright; in `<textarea>`/RCDATA it escapes
+  `<!--` to `&lt;!--`. LiveTemplate preserves both verbatim.
 
 ### 2. Whitespace Handling
 

--- a/internal/compat/comments.go
+++ b/internal/compat/comments.go
@@ -1,0 +1,205 @@
+package compat
+
+import (
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// maskUnit is the building block for the placeholder delimiter that stands in
+// for a `{{...}}` action span while HTML comments are stripped. It is a Unicode
+// private-use-area rune, which the HTML tokenizer treats as ordinary text.
+// StripHTMLComments repeats it until the resulting delimiter is absent from the
+// source, so placeholders can never collide with literal template text.
+const maskUnit = "\ue000"
+
+// StripHTMLComments removes HTML comments (`<!-- ... -->`) from a template
+// source string, matching the comment-stripping that html/template performs
+// during its escape pass. Like NormalizeTemplateSpacing, it is a pre-parse
+// source transform applied before the template is parsed.
+//
+// LiveTemplate builds its static segments by walking the raw parse tree, which
+// never triggers html/template's escape pass — so without this, developer/
+// internal HTML comments survive verbatim into the statics and ship to the
+// client (visible in view-source). Template comments (`{{/* ... */}}`) are
+// already removed at parse time and are unaffected.
+//
+// `{{...}}` action spans are masked out before stripping so that a literal
+// `<!--` appearing *inside* an action (e.g. `{{"<!--"}}`, a `{{/* <!-- */}}`
+// template comment, or a `"<!--"` string argument) is never mistaken for the
+// start of an HTML comment — matching html/template, which never strips inside
+// an action. The masking scanner respects Go template lexing (string, raw
+// string, char literals, and `/* */` comments) so the closing `}}` is found
+// correctly even when `}}` appears inside a quote or comment.
+//
+// Stripping uses the x/net/html tokenizer (rather than a regex) on the masked
+// string, so it is context-aware:
+//   - comment-like text inside attribute values (e.g.
+//     `title="<!-- not a comment -->"`) is preserved, not mistaken for a comment;
+//   - comment markup inside RAWTEXT/RCDATA elements (`<script>`, `<style>`,
+//     `<textarea>`) is left verbatim, since the tokenizer does not treat it as a
+//     comment there.
+//
+// A comment that wraps an action (`<!-- {{.X}} -->`) is removed in full,
+// action included — matching html/template.
+//
+// Residual divergences from html/template (both unchanged from prior behavior,
+// i.e. not regressions): in `<script>` context html/template rejects `<!--`
+// entirely, and in `<textarea>`/RCDATA context it escapes `<!--` to `&lt;!--`;
+// here both are preserved verbatim.
+func StripHTMLComments(s string) string {
+	// Fast path: no comment markers anywhere means nothing to strip.
+	if !strings.Contains(s, "<!--") {
+		return s
+	}
+
+	// Grow the placeholder delimiter until it is absent from the source, so a
+	// masked action can never be confused with literal text on restore.
+	mask := maskUnit
+	for strings.Contains(s, mask) {
+		mask += maskUnit
+	}
+
+	masked, actions := maskActions(s, mask)
+	if !strings.Contains(masked, "<!--") {
+		// Every `<!--` was inside a `{{...}}` action, so there is no real HTML
+		// comment to strip. Return the source untouched.
+		return s
+	}
+
+	stripped := stripCommentTokens(masked)
+	return restoreActions(stripped, actions, mask)
+}
+
+// stripCommentTokens rebuilds the input from tokenizer Raw() output, dropping
+// only CommentTokens. RAWTEXT/RCDATA comment-like content is not tokenized as a
+// comment, so it is left verbatim by construction.
+func stripCommentTokens(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	z := html.NewTokenizer(strings.NewReader(s))
+	for {
+		// strings.Reader never returns a read error, so ErrorToken here only
+		// signals EOF — never a mid-stream tokenization failure that would
+		// truncate output.
+		switch z.Next() {
+		case html.ErrorToken:
+			return b.String()
+		case html.CommentToken:
+		default:
+			b.Write(z.Raw())
+		}
+	}
+}
+
+// maskActions replaces every {{...}} span with mask+index+mask;
+// restoreActions reverses it.
+func maskActions(s, mask string) (string, []string) {
+	var b strings.Builder
+	b.Grow(len(s))
+	var actions []string
+	i := 0
+	for i < len(s) {
+		start := strings.Index(s[i:], "{{")
+		if start < 0 {
+			b.WriteString(s[i:])
+			break
+		}
+		start += i
+		b.WriteString(s[i:start])
+
+		end := actionEnd(s, start)
+		if end < 0 {
+			// Unterminated action: emit the remainder verbatim and let the
+			// template parser report the error downstream.
+			b.WriteString(s[start:])
+			break
+		}
+
+		b.WriteString(mask)
+		b.WriteString(strconv.Itoa(len(actions)))
+		b.WriteString(mask)
+		actions = append(actions, s[start:end])
+		i = end
+	}
+	return b.String(), actions
+}
+
+// restoreActions reinstates the original action spans. Placeholders that were
+// inside a stripped comment are simply absent, so their actions drop out too —
+// matching html/template's removal of a comment-wrapped action.
+func restoreActions(s string, actions []string, mask string) string {
+	if len(actions) == 0 {
+		return s
+	}
+	pairs := make([]string, 0, len(actions)*2)
+	for i, action := range actions {
+		pairs = append(pairs, mask+strconv.Itoa(i)+mask, action)
+	}
+	return strings.NewReplacer(pairs...).Replace(s)
+}
+
+// actionEnd returns the index just past the `}}` that closes the action
+// beginning at start (where s[start:] begins with "{{"), or -1 if unterminated.
+// It skips over string, raw-string, char literals, and `/* */` comments so a
+// `}}` inside any of them does not end the action prematurely.
+func actionEnd(s string, start int) int {
+	for i := start + 2; i < len(s); {
+		switch {
+		case strings.HasPrefix(s[i:], "}}"):
+			return i + 2
+		case s[i] == '"':
+			i = skipQuoted(s, i, '"')
+		case s[i] == '\'':
+			i = skipQuoted(s, i, '\'')
+		case s[i] == '`':
+			i = skipRawString(s, i)
+		case strings.HasPrefix(s[i:], "/*"):
+			i = skipActionComment(s, i)
+		default:
+			i++
+		}
+		if i < 0 {
+			return -1
+		}
+	}
+	return -1
+}
+
+// skipQuoted returns the index just past the closing quote q (with backslash
+// escapes), where s[i] == q opens the literal, or -1 if unterminated.
+func skipQuoted(s string, i int, q byte) int {
+	for i++; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			i++ // skip the escaped byte
+			if i >= len(s) {
+				return -1 // trailing backslash: unterminated
+			}
+		case q:
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// skipRawString returns the index just past the closing backtick (raw strings
+// have no escapes), where s[i] == '`', or -1 if unterminated.
+func skipRawString(s string, i int) int {
+	for i++; i < len(s); i++ {
+		if s[i] == '`' {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// skipActionComment returns the index just past the `*/` closing the action
+// comment opened by `/*` at i, or -1 if unterminated.
+func skipActionComment(s string, i int) int {
+	if end := strings.Index(s[i+2:], "*/"); end >= 0 {
+		return i + 2 + end + 2
+	}
+	return -1
+}

--- a/internal/compat/comments_test.go
+++ b/internal/compat/comments_test.go
@@ -1,0 +1,48 @@
+package compat
+
+import "testing"
+
+func TestStripHTMLComments(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no comments untouched", `<div>{{.X}}</div>`, `<div>{{.X}}</div>`},
+		{"simple comment stripped", `<div><!-- secret -->{{.X}}</div>`, `<div>{{.X}}</div>`},
+		{"comment with action stripped wholesale", `<!-- {{.X}} -->after`, `after`},
+		{"action in attribute preserved", `<div class="{{.C}}">{{.X}}</div>`, `<div class="{{.C}}">{{.X}}</div>`},
+		{
+			"comment-like text in attribute preserved",
+			`<div title="<!-- not a comment -->">x</div>`,
+			`<div title="<!-- not a comment -->">x</div>`,
+		},
+		{
+			"template comment preserved (parser strips it later)",
+			`<div><!-- html -->{{/* tmpl */}}</div>`,
+			`<div>{{/* tmpl */}}</div>`,
+		},
+		{"IE conditional comment stripped", `<div><!--[if IE]>x<![endif]--></div>`, `<div></div>`},
+		// RAWTEXT/RCDATA: tokenizer does not treat <!-- --> as a comment inside
+		// these elements, so it is left verbatim (matches html/template keeping
+		// <style> comments; <script>/<textarea> are documented residuals).
+		{"style comment kept (RAWTEXT)", `<style>/* x */<!-- d -->.a{}</style>`, `<style>/* x */<!-- d -->.a{}</style>`},
+		{"script comment kept (RAWTEXT)", `<script>var a=1;<!-- c --></script>`, `<script>var a=1;<!-- c --></script>`},
+		{"textarea comment kept (RCDATA)", `<textarea><!-- keep --></textarea>`, `<textarea><!-- keep --></textarea>`},
+		// `<!--` inside a {{...}} action must NOT be treated as an HTML comment:
+		// the action span is masked before stripping, matching html/template
+		// (which never strips inside an action).
+		{"comment marker in action string preserved", `<div>{{"<!-- x -->"}}</div>`, `<div>{{"<!-- x -->"}}</div>`},
+		{"comment marker in template comment preserved", `<div>{{/* <!-- */}}{{.X}}</div>`, `<div>{{/* <!-- */}}{{.X}}</div>`},
+		{"comment marker in string literal preserved", `{{if eq .Sep "<!--"}}y{{end}}`, `{{if eq .Sep "<!--"}}y{{end}}`},
+		{"action with }} in string preserved while stripping comment", `<div>{{"a}}b"}}<!-- c --></div>`, `<div>{{"a}}b"}}</div>`},
+		{"real comment stripped, action-internal marker kept", `<!-- gone -->{{"<!-- kept -->"}}`, `{{"<!-- kept -->"}}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StripHTMLComments(tc.in); got != tc.want {
+				t.Errorf("StripHTMLComments(%q)\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/template.go
+++ b/template.go
@@ -1070,8 +1070,10 @@ func (t *Template) Parse(text string) (*Template, error) {
 	// This prevents issues when formatters add spaces like "{{ range" instead of "{{range"
 	text = compat.NormalizeTemplateSpacing(text)
 
-	// Determine if this is a full HTML document
-	isFullHTML := strings.Contains(text, "<!DOCTYPE") || strings.Contains(text, "<html")
+	// Strip HTML comments before parsing so they match html/template (which
+	// drops them in its escape pass) and so a {{define}}/{{block}} living inside
+	// a comment is removed rather than resolved during composition. See #468.
+	text = compat.StripHTMLComments(text)
 
 	// Always generate wrapper ID for consistent update targeting
 	t.wrapperID = compat.GenerateRandomID()
@@ -1086,12 +1088,12 @@ func (t *Template) Parse(text string) (*Template, error) {
 		return nil, fmt.Errorf("template '%s' parse error: %w", t.name, err)
 	}
 
-	return t.parseInternal(text, tmpl, isFullHTML)
+	return t.parseInternal(text, tmpl)
 }
 
 // parseInternal handles the common logic for parsing templates:
 // flattening, wrapper injection, final parsing, and validation.
-func (t *Template) parseInternal(text string, baseTemplate *template.Template, isFullHTML bool) (*Template, error) {
+func (t *Template) parseInternal(text string, baseTemplate *template.Template) (*Template, error) {
 	// Check if template uses composition features and flatten if needed
 	if parse.HasTemplateComposition(baseTemplate) {
 		// Flatten the template to resolve all {{define}}/{{template}}/{{block}}
@@ -1104,6 +1106,13 @@ func (t *Template) parseInternal(text string, baseTemplate *template.Template, i
 		// This ensures updates use the flattened template
 		text = flattenedStr
 	}
+
+	// Determine if this is a full HTML document. Computed here (after any
+	// flattening) on the already comment-stripped text — callers strip before
+	// parsing (see #468) — so a `<!DOCTYPE`/`<html` marker that existed only
+	// inside a removed comment cannot route a bare fragment through the
+	// full-document wrapper path.
+	isFullHTML := strings.Contains(text, "<!DOCTYPE") || strings.Contains(text, "<html")
 
 	// Expand multi-action bracket syntax before parsing.
 	// e.g. lvt-el:addClass:on:[save,delete]:pending="X" → individual attributes.
@@ -1185,8 +1194,8 @@ func (t *Template) ParseFiles(filenames ...string) (*Template, error) {
 	// Normalize template spacing
 	text := compat.NormalizeTemplateSpacing(string(content))
 
-	// Determine if this is a full HTML document
-	isFullHTML := strings.Contains(text, "<!DOCTYPE") || strings.Contains(text, "<html")
+	// Strip HTML comments before parsing (see #468).
+	text = compat.StripHTMLComments(text)
 
 	// Always generate wrapper ID for consistent update targeting
 	t.wrapperID = compat.GenerateRandomID()
@@ -1223,14 +1232,15 @@ func (t *Template) ParseFiles(filenames ...string) (*Template, error) {
 			}
 
 			// Parse additional templates into the same template set
-			_, err = tmpl.Parse(string(content))
+			// (comments stripped first — see #468).
+			_, err = tmpl.Parse(compat.StripHTMLComments(string(content)))
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse file %s: %w", filename, err)
 			}
 		}
 	}
 
-	return t.parseInternal(text, tmpl, isFullHTML)
+	return t.parseInternal(text, tmpl)
 }
 
 // ParseGlob parses the template definitions from the files identified by the pattern.
@@ -1290,7 +1300,8 @@ func (t *Template) parseComponentTemplates(sets []*TemplateSet) error {
 			}
 
 			// Parse the template content - this adds any {{define}} blocks to the template set
-			_, err = t.tmpl.Parse(string(content))
+			// (comments stripped first to match html/template — see #468).
+			_, err = t.tmpl.Parse(compat.StripHTMLComments(string(content)))
 			if err != nil {
 				return fmt.Errorf("component %q: failed to parse %q: %w", set.Namespace, match, err)
 			}


### PR DESCRIPTION
Closes #468.

## Problem

`html/template` strips HTML comments (`<!-- ... -->`) during its escape pass. LiveTemplate parses via `html/template` but builds its static segments by walking the **raw** parse tree (`internal/parse/flatten.go`), which never triggers that pass — so HTML comments survived verbatim into the statics and shipped to the client (visible in view-source) and over WebSocket tree updates. Template comments (`{{/* ... */}}`) were already stripped at parse time.

This is both a **leak** (internal comments reach the client) and a **migration surprise** (an app moving from `html/template` silently starts emitting comments it used to drop — `html/template` strips them partly as hardening against IE conditional-comment injection).

## Fix

Strip HTML comments at the source level in `parseInternal`, before bracket expansion (so directives inside soon-to-be-deleted comments aren't expanded). This single point feeds both the HTTP render path (`t.tmpl`) and the WS tree path (`t.templateStr`), so they stay consistent.

`render.StripHTMLComments` uses the `x/net/html` tokenizer rather than a regex, which makes it context-aware:
- comment-like text inside attribute values (`title="<!-- x -->"`) is **preserved**;
- comment markup inside `<script>`/`<style>`/`<textarea>` (RAWTEXT/RCDATA) is **left verbatim**;
- a comment wrapping an action (`<!-- {{.X}} -->`) is removed in full, matching `html/template`.

Reconstruction concatenates each token's raw bytes except comment tokens, so `{{...}}` actions and all other content (including `<!DOCTYPE html>`) round-trip losslessly. A `strings.Contains(s, "<!--")` fast path skips tokenization for comment-free templates.

## Residual divergences (documented, pre-existing — not regressions)

In `docs/references/template-support-matrix.md`: `<script>` (html/template rejects `<!--` outright) and `<textarea>`/RCDATA (html/template escapes `<!--` to `&lt;!--`) are kept verbatim here. Both were already the behavior before this change.

## Tests

- `internal/render`: unit table for `StripHTMLComments` covering attribute values, RAWTEXT/RCDATA, IE conditionals, action-wrapping comments.
- Root package: the issue's own repro promoted to an assertion (certified **red** on current behavior, **green** with the fix), plus a comment-like-attribute-value guard.
- Full suite green (golden-template test and build-layer comment-decoy tests unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)