### PR TITLE
fix(mount): PRG fallback emits relative self-reference under StripPrefix (#444)

### DIFF
--- a/context.go
+++ b/context.go
@@ -369,16 +369,10 @@ func relativeSelfReference(r *http.Request) string {
 // writeRelativeRedirect emits target RAW in the Location header so the client
 // resolves it against its effective (un-stripped) request URI — http.Redirect
 // would instead resolve it server-side against the http.StripPrefix-stripped
-// path, the bug this avoids. It mirrors http.Redirect's method-aware tail so
-// behaviour matches the absolute-path branch apart from URL resolution: a short
-// HTML body plus Content-Type for GET, Content-Type only for HEAD, neither for
-// POST (the action / PRG path), unless the caller already set a Content-Type.
+// path, the bug this avoids. It mirrors http.Redirect's method-aware tail.
 func writeRelativeRedirect(w http.ResponseWriter, r *http.Request, target string, code int) {
 	h := w.Header()
 	_, hadCT := h["Content-Type"]
-	// Percent-encode non-ASCII bytes so the Location stays within HTTP's ASCII
-	// header constraint — http.Redirect does this for the absolute branch via
-	// its own (unexported) helper.
 	h.Set("Location", hexEscapeNonASCII(target))
 	if !hadCT && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
 		h.Set("Content-Type", "text/html; charset=utf-8")

--- a/context.go
+++ b/context.go
@@ -357,10 +357,12 @@ func (c *Context) Redirect(url string, code int) error {
 }
 
 // relativeSelfReference returns "./<last-segment>", a relative reference a
-// browser resolves back to the request's own (un-stripped) URL. It is the
-// StripPrefix-safe "reload self" target shared by ctx.Redirect("") and the
-// progressive-enhancement POST-Redirect-GET fallback (mount.go), neither of
-// which can see the prefix http.StripPrefix removed from r.URL.Path.
+// browser resolves back to the request's own URL under a trailing-slash mount.
+// It is the StripPrefix-safe "reload self" target shared by ctx.Redirect("") and
+// the progressive-enhancement POST-Redirect-GET fallback (mount.go), neither of
+// which can see the prefix http.StripPrefix removed from r.URL.Path. Under an
+// exact-match mount without a trailing slash a browser resolves "./" to the
+// parent path; see Context.Redirect's doc for that caveat.
 func relativeSelfReference(r *http.Request) string {
 	_, last := path.Split(r.URL.EscapedPath())
 	return "./" + last

--- a/context.go
+++ b/context.go
@@ -345,36 +345,52 @@ func (c *Context) Redirect(url string, code int) error {
 		// breaks clients) and resolves back to the current URL.
 		target := url
 		if target == "" {
-			_, last := path.Split(c.r.URL.EscapedPath())
-			target = "./" + last
+			target = relativeSelfReference(c.r)
 		}
-		// Mirror http.Redirect's method-aware tail so the two branches behave
-		// identically apart from URL resolution: a short HTML body plus
-		// Content-Type for GET, Content-Type only for HEAD, neither for POST
-		// (the action / PRG path), unless the caller already set a Content-Type.
-		h := c.w.Header()
-		_, hadCT := h["Content-Type"]
-		// Percent-encode non-ASCII bytes so the Location stays within HTTP's
-		// ASCII header constraint — http.Redirect does this for the absolute
-		// branch via its own (unexported) helper.
-		h.Set("Location", hexEscapeNonASCII(target))
-		if !hadCT && (c.r.Method == http.MethodGet || c.r.Method == http.MethodHead) {
-			h.Set("Content-Type", "text/html; charset=utf-8")
-		}
-		c.w.WriteHeader(code)
-		if !hadCT && c.r.Method == http.MethodGet {
-			if _, err := fmt.Fprintf(c.w, "<a href=\"%s\">%s</a>.\n", html.EscapeString(target), http.StatusText(code)); err != nil {
-				slog.Warn("Failed to write redirect body",
-					slog.String("component", "context"),
-					slog.Any("error", err))
-			}
-		}
+		writeRelativeRedirect(c.w, c.r, target, code)
 	}
 
 	if c.redirected != nil {
 		*c.redirected = true
 	}
 	return nil
+}
+
+// relativeSelfReference returns "./<last-segment>", a relative reference a
+// browser resolves back to the request's own (un-stripped) URL. It is the
+// StripPrefix-safe "reload self" target shared by ctx.Redirect("") and the
+// progressive-enhancement POST-Redirect-GET fallback (mount.go), neither of
+// which can see the prefix http.StripPrefix removed from r.URL.Path.
+func relativeSelfReference(r *http.Request) string {
+	_, last := path.Split(r.URL.EscapedPath())
+	return "./" + last
+}
+
+// writeRelativeRedirect emits target RAW in the Location header so the client
+// resolves it against its effective (un-stripped) request URI — http.Redirect
+// would instead resolve it server-side against the http.StripPrefix-stripped
+// path, the bug this avoids. It mirrors http.Redirect's method-aware tail so
+// behaviour matches the absolute-path branch apart from URL resolution: a short
+// HTML body plus Content-Type for GET, Content-Type only for HEAD, neither for
+// POST (the action / PRG path), unless the caller already set a Content-Type.
+func writeRelativeRedirect(w http.ResponseWriter, r *http.Request, target string, code int) {
+	h := w.Header()
+	_, hadCT := h["Content-Type"]
+	// Percent-encode non-ASCII bytes so the Location stays within HTTP's ASCII
+	// header constraint — http.Redirect does this for the absolute branch via
+	// its own (unexported) helper.
+	h.Set("Location", hexEscapeNonASCII(target))
+	if !hadCT && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
+		h.Set("Content-Type", "text/html; charset=utf-8")
+	}
+	w.WriteHeader(code)
+	if !hadCT && r.Method == http.MethodGet {
+		if _, err := fmt.Fprintf(w, "<a href=\"%s\">%s</a>.\n", html.EscapeString(target), http.StatusText(code)); err != nil {
+			slog.Warn("Failed to write redirect body",
+				slog.String("component", "context"),
+				slog.Any("error", err))
+		}
+	}
 }
 
 // hexEscapeNonASCII percent-encodes bytes >= 0x80 so a relative Location value

--- a/context.go
+++ b/context.go
@@ -357,12 +357,11 @@ func (c *Context) Redirect(url string, code int) error {
 }
 
 // relativeSelfReference returns "./<last-segment>", a relative reference a
-// browser resolves back to the request's own URL under a trailing-slash mount.
-// It is the StripPrefix-safe "reload self" target shared by ctx.Redirect("") and
-// the progressive-enhancement POST-Redirect-GET fallback (mount.go), neither of
-// which can see the prefix http.StripPrefix removed from r.URL.Path. Under an
-// exact-match mount without a trailing slash a browser resolves "./" to the
-// parent path; see Context.Redirect's doc for that caveat.
+// browser resolves back to the request's own URL under a trailing-slash mount —
+// the StripPrefix-safe "reload self" target for a handler that cannot see the
+// prefix http.StripPrefix removed from r.URL.Path. Under an exact-match mount
+// without a trailing slash a browser resolves "./" to the parent path; see
+// Context.Redirect's doc for that caveat.
 func relativeSelfReference(r *http.Request) string {
 	_, last := path.Split(r.URL.EscapedPath())
 	return "./" + last

--- a/handle_test.go
+++ b/handle_test.go
@@ -3390,14 +3390,13 @@ func (prgFallbackController) Save(s prgFallbackState, ctx *Context) (prgFallback
 	return s, nil
 }
 
-// TestPRGFallback_RelativeSelf_UnderStripPrefix is the regression guard for
-// issue #444: the non-JS POST-Redirect-GET fallback (mount.go), like ctx.Redirect
-// (#434/#443), must redirect a form POST back to its own mount when mounted behind
-// http.StripPrefix. Before the fix the fallback redirected to the stripped
-// r.URL.Path ("/"), landing the client at the wrong location. The framework now
-// emits a relative Location the client resolves against the full (un-stripped)
-// request URL. ProgressiveEnhancement defaults to true, and Accept: text/html
-// makes the client a non-JSON client, so the fallback runs.
+// Regression guard for #444 (cf. #434/#443 for ctx.Redirect): the non-JS
+// POST-Redirect-GET fallback (mount.go) must redirect a form POST back to its
+// own mount when mounted behind http.StripPrefix. Before the fix it redirected
+// to the stripped r.URL.Path (here ""), emitting an empty Location. The
+// framework now emits a relative Location the client resolves against the full
+// (un-stripped) request URL. ProgressiveEnhancement defaults to true, and
+// Accept: text/html makes this a non-JSON client, so the fallback runs.
 func TestPRGFallback_RelativeSelf_UnderStripPrefix(t *testing.T) {
 	tmpl, err := New("test")
 	if err != nil {

--- a/handle_test.go
+++ b/handle_test.go
@@ -3396,56 +3396,73 @@ func (prgFallbackController) Save(s prgFallbackState, ctx *Context) (prgFallback
 // to the stripped r.URL.Path (here ""), emitting an empty Location. The
 // framework now emits a relative Location the client resolves against the full
 // (un-stripped) request URL. ProgressiveEnhancement defaults to true, and
-// Accept: text/html makes this a non-JSON client, so the fallback runs.
+// Accept: text/html makes this a non-JSON client, so the fallback runs. The
+// query sub-case guards the separate branch that re-appends r.URL.Query() to the
+// relative reference, so dropping it can't pass silently.
 func TestPRGFallback_RelativeSelf_UnderStripPrefix(t *testing.T) {
-	tmpl, err := New("test")
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-	tmpl, err = tmpl.Parse(`<div>hits {{.Hits}}</div>`)
-	if err != nil {
-		t.Fatalf("Parse failed: %v", err)
-	}
-	handler := tmpl.Handle(&prgFallbackController{}, AsState(&prgFallbackState{}))
-
 	const prefix = "/apps/login/"
-	mux := http.NewServeMux()
-	mux.Handle(prefix, http.StripPrefix(prefix, handler))
-	ts := httptest.NewServer(mux)
-	defer ts.Close()
-
-	var followed []*http.Request
-	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		followed = append(followed, req) // req.URL is the client-resolved Location
-		if len(via) >= 10 {
-			return errors.New("too many redirects")
-		}
-		return nil
-	}}
-
-	form := url.Values{}
-	form.Set("lvt-action", "Save")
-	req, err := http.NewRequest("POST", ts.URL+prefix, strings.NewReader(form.Encode()))
-	if err != nil {
-		t.Fatalf("NewRequest failed: %v", err)
+	cases := []struct {
+		name         string
+		query        string // appended to the POST URL, including leading "?"
+		wantRawQuery string
+	}{
+		{name: "no query", query: "", wantRawQuery: ""},
+		{name: "preserves query", query: "?plan=pro&ref=x", wantRawQuery: "plan=pro&ref=x"},
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Accept", "text/html")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl, err := New("test")
+			if err != nil {
+				t.Fatalf("New failed: %v", err)
+			}
+			tmpl, err = tmpl.Parse(`<div>hits {{.Hits}}</div>`)
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			handler := tmpl.Handle(&prgFallbackController{}, AsState(&prgFallbackState{}))
 
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("client.Do failed: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+			mux := http.NewServeMux()
+			mux.Handle(prefix, http.StripPrefix(prefix, handler))
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
 
-	if len(followed) == 0 {
-		t.Fatal("expected a PRG self-redirect, got none (relative Location not emitted)")
-	}
-	if got := followed[0].URL.Path; got != prefix {
-		t.Errorf("redirect resolved to %q, want %q", got, prefix)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("final status = %d, want 200", resp.StatusCode)
+			var followed []*http.Request
+			client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				followed = append(followed, req) // req.URL is the client-resolved Location
+				if len(via) >= 10 {
+					return errors.New("too many redirects")
+				}
+				return nil
+			}}
+
+			form := url.Values{}
+			form.Set("lvt-action", "Save")
+			req, err := http.NewRequest("POST", ts.URL+prefix+tc.query, strings.NewReader(form.Encode()))
+			if err != nil {
+				t.Fatalf("NewRequest failed: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("Accept", "text/html")
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("client.Do failed: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if len(followed) == 0 {
+				t.Fatal("expected a PRG self-redirect, got none (relative Location not emitted)")
+			}
+			if got := followed[0].URL.Path; got != prefix {
+				t.Errorf("redirect resolved to %q, want %q", got, prefix)
+			}
+			if got := followed[0].URL.RawQuery; got != tc.wantRawQuery {
+				t.Errorf("redirect query = %q, want %q", got, tc.wantRawQuery)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("final status = %d, want 200", resp.StatusCode)
+			}
+		})
 	}
 }
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -440,8 +440,14 @@ func TestProgressiveEnhancement_FlashCookieConsumed(t *testing.T) {
 		t.Fatal("Expected lvt-flash cookie in POST response")
 	}
 
-	// Step 2: Follow redirect GET with flash cookie
-	req = httptest.NewRequest("GET", rec.Header().Get("Location"), nil)
+	// Step 2: Follow redirect GET with flash cookie. The PRG Location is a
+	// relative reference ("./"), so resolve it against the original request URL
+	// the way a browser would before issuing the follow-up request.
+	loc, err := req.URL.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect Location: %v", err)
+	}
+	req = httptest.NewRequest("GET", loc.String(), nil)
 	if sessionCookie != nil {
 		req.AddCookie(sessionCookie)
 	}
@@ -3360,6 +3366,81 @@ func TestRedirect_RelativeSelf_UnderStripPrefix(t *testing.T) {
 
 	if len(followed) == 0 {
 		t.Fatal("expected a self-redirect, got none (relative Location not emitted)")
+	}
+	if got := followed[0].URL.Path; got != prefix {
+		t.Errorf("redirect resolved to %q, want %q", got, prefix)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("final status = %d, want 200", resp.StatusCode)
+	}
+}
+
+type prgFallbackController struct{}
+type prgFallbackState struct{ Hits int }
+
+func (prgFallbackController) Mount(s prgFallbackState, ctx *Context) (prgFallbackState, error) {
+	return s, nil
+}
+
+// Save succeeds WITHOUT calling ctx.Redirect, so the progressive-enhancement
+// POST-Redirect-GET fallback in mount.go is the code path that produces the
+// redirect — the subject under test.
+func (prgFallbackController) Save(s prgFallbackState, ctx *Context) (prgFallbackState, error) {
+	s.Hits++
+	return s, nil
+}
+
+// TestPRGFallback_RelativeSelf_UnderStripPrefix is the regression guard for
+// issue #444: the non-JS POST-Redirect-GET fallback (mount.go), like ctx.Redirect
+// (#434/#443), must redirect a form POST back to its own mount when mounted behind
+// http.StripPrefix. Before the fix the fallback redirected to the stripped
+// r.URL.Path ("/"), landing the client at the wrong location. The framework now
+// emits a relative Location the client resolves against the full (un-stripped)
+// request URL. ProgressiveEnhancement defaults to true, and Accept: text/html
+// makes the client a non-JSON client, so the fallback runs.
+func TestPRGFallback_RelativeSelf_UnderStripPrefix(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>hits {{.Hits}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	handler := tmpl.Handle(&prgFallbackController{}, AsState(&prgFallbackState{}))
+
+	const prefix = "/apps/login/"
+	mux := http.NewServeMux()
+	mux.Handle(prefix, http.StripPrefix(prefix, handler))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	var followed []*http.Request
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		followed = append(followed, req) // req.URL is the client-resolved Location
+		if len(via) >= 10 {
+			return errors.New("too many redirects")
+		}
+		return nil
+	}}
+
+	form := url.Values{}
+	form.Set("lvt-action", "Save")
+	req, err := http.NewRequest("POST", ts.URL+prefix, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("NewRequest failed: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "text/html")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if len(followed) == 0 {
+		t.Fatal("expected a PRG self-redirect, got none (relative Location not emitted)")
 	}
 	if got := followed[0].URL.Path; got != prefix {
 		t.Errorf("redirect resolved to %q, want %q", got, prefix)

--- a/mount.go
+++ b/mount.go
@@ -1630,8 +1630,13 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Success: redirect to prevent duplicate submissions on refresh (PRG pattern)
-		redirectURL := r.URL.Path
+		// Success: redirect to prevent duplicate submissions on refresh (PRG pattern).
+		// Emit a relative self-reference rather than r.URL.Path — under
+		// http.StripPrefix the latter is the stripped path ("/" or ""), which would
+		// redirect the non-JS client to the wrong location. The browser resolves the
+		// relative reference against its own un-stripped URL. (#444; mirrors #443's
+		// fix for ctx.Redirect.)
+		redirectURL := relativeSelfReference(r)
 		if encoded := r.URL.Query().Encode(); encoded != "" {
 			redirectURL += "?" + encoded
 		}
@@ -1648,7 +1653,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
-		http.Redirect(w, r, redirectURL, http.StatusSeeOther) // 303 See Other
+		writeRelativeRedirect(w, r, redirectURL, http.StatusSeeOther) // 303 See Other
 		return
 	}
 

--- a/mount.go
+++ b/mount.go
@@ -1634,7 +1634,8 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		// Emit a relative self-reference rather than r.URL.Path — under
 		// http.StripPrefix the latter is the stripped path ("/" or ""), which would
 		// redirect the non-JS client to the wrong location. The browser resolves the
-		// relative reference against its own un-stripped URL.
+		// relative reference against its own un-stripped URL. This assumes a
+		// trailing-slash mount; see relativeSelfReference for the exact-match caveat.
 		redirectURL := relativeSelfReference(r)
 		if encoded := r.URL.Query().Encode(); encoded != "" {
 			redirectURL += "?" + encoded

--- a/mount.go
+++ b/mount.go
@@ -1653,7 +1653,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
-		writeRelativeRedirect(w, r, redirectURL, http.StatusSeeOther) // 303 See Other
+		writeRelativeRedirect(w, r, redirectURL, http.StatusSeeOther)
 		return
 	}
 

--- a/mount.go
+++ b/mount.go
@@ -1634,8 +1634,7 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		// Emit a relative self-reference rather than r.URL.Path — under
 		// http.StripPrefix the latter is the stripped path ("/" or ""), which would
 		// redirect the non-JS client to the wrong location. The browser resolves the
-		// relative reference against its own un-stripped URL. (#444; mirrors #443's
-		// fix for ctx.Redirect.)
+		// relative reference against its own un-stripped URL.
 		redirectURL := relativeSelfReference(r)
 		if encoded := r.URL.Query().Encode(); encoded != "" {
 			redirectURL += "?" + encoded


### PR DESCRIPTION
## Problem

The progressive-enhancement **POST-Redirect-GET (PRG)** fallback for non-JS clients (`mount.go`) built its 303 redirect from `r.URL.Path` — which `http.StripPrefix` has already stripped:

```go
redirectURL := r.URL.Path // stripped to "/" or "" under http.StripPrefix
http.Redirect(w, r, redirectURL, http.StatusSeeOther)
```

Mounted behind `http.StripPrefix("/apps/login/", …)`, a non-JS form POST was redirected to the wrong location. In the canonical trailing-slash case the path strips to `""`, producing an **empty `Location` header** that most clients ignore entirely — so the user's submission silently failed to navigate.

This is the same bug class #434/#443 fixed for `ctx.Redirect`. It was flagged out-of-scope during the #443 review and deferred here.

## Fix

Mirrors #443: emit a **relative self-reference** (`"./<last-segment>"`) raw in the `Location` header so the **browser** resolves it against its own un-stripped URL, instead of the server building an absolute URL from the stripped path.

The relative-emit machinery is extracted from `ctx.Redirect` into two shared, unexported helpers in `context.go` — `relativeSelfReference(r)` and `writeRelativeRedirect(w, r, target, code)` — so both call sites use one source of truth. `ctx.Redirect`'s behaviour is a pure, behaviour-preserving extraction (guarded by the existing `TestRedirect_RelativeSelf_UnderStripPrefix` #434 test).

### Behaviour notes for reviewers

- **PRG `Location` is now relative for *all* mounts, not just stripped ones.** There's no clean way to detect StripPrefix at the handler, and for a root mount `./` resolves identically to `/` for a real client — keeping it universal matches what `ctx.Redirect` already ships and avoids a fragile conditional.
- Because of that, `TestProgressiveEnhancement_FlashCookieConsumed` (mounted at root) needed an update: it reused the redirect `Location` directly in `httptest.NewRequest`, which rejects relative URIs. It now resolves the `Location` browser-style via `req.URL.Parse` before the follow-up GET. This test edit is a consequence of the universal relative `Location`, not unrelated churn.
- Query handling is byte-identical (`r.URL.Query().Encode()`); the flash-cookie block is unchanged.

## Scope

Swept all `http.Redirect` sites in the library: `context.go` (the #443 fix) and `mount.go` (this bug) are the only two. `mount.go`'s `path.Clean(r.URL.Path)` cache-invalidation compares the stripped path against itself (self-consistent, not a redirect). **#444 is the last instance of this bug class.**

## Tests

- Adds `TestPRGFallback_RelativeSelf_UnderStripPrefix` — mirrors the #434 test but exercises the PRG fallback (action returns `s, nil`, no `ctx.Redirect`). **Red-before-green verified**: reverting the `mount.go` change makes it fail (empty `Location` under the trailing-slash mount).
- Existing #434 test still passes → the `ctx.Redirect` extraction is behaviour-preserving.
- Full suite green; pre-commit hook (fmt + golangci-lint + tests) passed.

Ref: #434, PR #443. Closes #444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)