### PR TITLE
fix(observe): wire livetemplate_publishes_sent_total to the dispatch path (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v0.15.0] - 2026-06-29
+### Fixed
+
+- `livetemplate_publishes_sent_total` now actually increments. From v0.11.0 through v0.15.0 the counter (and its predecessor `livetemplate_broadcasts_sent_total`) was defined but never wired to a production call site, so it always reported 0 — a footgun for operators with dashboards or alerts on peer-fan-out rate. It is now incremented once per receiving connection whenever a peer-fan-out dispatch is enqueued, covering `ctx.Publish`, `Session.TriggerAction`, and cross-instance group/topic re-fan-out. The count is per instance (each instance counts only its own local deliveries, so a clustered publish is not double-counted) and is recorded at enqueue time, so a downstream slow-client close can still drop the resulting WebSocket send. (#432)
 
 ### Added
 

--- a/broadcast_test.go
+++ b/broadcast_test.go
@@ -389,3 +389,82 @@ func TestPublish_ExplicitRefreshDispatchesToPeers(t *testing.T) {
 		t.Errorf("Expected 1 item 'buy milk', got %v", items)
 	}
 }
+
+// scrapePublishesSent reads the handler's Prometheus endpoint and returns the
+// current value of livetemplate_publishes_sent_total.
+func scrapePublishesSent(t *testing.T, handler LiveHandler) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	handler.MetricsHandler().ServeHTTP(rec, req)
+
+	const prefix = "livetemplate_publishes_sent_total "
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			var v int
+			if _, err := fmt.Sscanf(strings.TrimPrefix(line, prefix), "%d", &v); err != nil {
+				t.Fatalf("failed to parse counter line %q: %v", line, err)
+			}
+			return v
+		}
+	}
+	t.Fatalf("metric livetemplate_publishes_sent_total not found in:\n%s", rec.Body.String())
+	return 0
+}
+
+// TestPublish_IncrementsPublishesSentPerSubscriber verifies the fix for #432:
+// livetemplate_publishes_sent_total advances once per receiving connection when
+// an action fans out via ctx.Publish. Three tabs share a group and all subscribe
+// to SelfTopic in Mount; a Publish from one tab (the sender is excluded) reaches
+// the other two, so the counter must advance by exactly 2.
+func TestPublish_IncrementsPublishesSentPerSubscriber(t *testing.T) {
+	auth := &fixedGroupAuth{groupID: "metrics-group"}
+	tmpl, err := New("test", WithAuthenticator(auth))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Count}} - {{.Message}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&broadcastTestController{}, AsState(&broadcastTestState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	// Three tabs in the same group, each subscribed to SelfTopic in Mount.
+	var conns []*websocket.Conn
+	for i := 0; i < 3; i++ {
+		ws := connectWS(t, wsURL)
+		defer func(ws *websocket.Conn) {
+			if err := ws.Close(); err != nil {
+				t.Logf("ws close error: %v", err)
+			}
+		}(ws)
+		conns = append(conns, ws)
+	}
+
+	if before := scrapePublishesSent(t, handler); before != 0 {
+		t.Fatalf("precondition: expected 0 publishes before any action, got %d", before)
+	}
+
+	// Tab 0 publishes SyncMessage to SelfTopic; tabs 1 and 2 receive it.
+	msgBytes, _ := json.Marshal(map[string]interface{}{
+		"action": "set_message",
+		"data":   map[string]interface{}{"value": "hello"},
+	})
+	if err := conns[0].WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+		t.Fatalf("ws0 write failed: %v", err)
+	}
+
+	// Drain the sender's own response and both peers' broadcasts so the
+	// synchronous fan-out (which increments the counter) has completed.
+	readWSUpdate(t, conns[0], 3*time.Second)
+	readWSUpdate(t, conns[1], 3*time.Second)
+	readWSUpdate(t, conns[2], 3*time.Second)
+
+	if got := scrapePublishesSent(t, handler); got != 2 {
+		t.Errorf("expected publishes_sent to advance by 2 (one per peer subscriber), got %d", got)
+	}
+}

--- a/docs/guides/OBSERVABILITY.md
+++ b/docs/guides/OBSERVABILITY.md
@@ -79,7 +79,7 @@ mux.Handle("/metrics", handler.MetricsHandler()) // Prometheus text format
 - `livetemplate_templates_executed_total`
 - `livetemplate_trees_built_total`
 - `livetemplate_trees_diffed_total`
-- `livetemplate_publishes_sent_total` (peer-fan-out publishes via `ctx.Publish`)
+- `livetemplate_publishes_sent_total` (peer-fan-out dispatches, counted once per receiving connection — covers `ctx.Publish`, `Session.TriggerAction`, and cross-instance group/topic re-fan-out; counted at enqueue time, so a downstream slow-client close can still drop the resulting send)
 - `livetemplate_errors_total`
 - `livetemplate_connections_rejected_total`
 - `livetemplate_websocket_buffer_full_total`
@@ -111,7 +111,7 @@ v0.11.0 renames the broadcast metric family to reflect the new `ctx.Publish`/`ct
 |---|---|
 | `livetemplate_broadcasts_sent_total` | `livetemplate_publishes_sent_total` |
 
-> **Note:** `livetemplate_publishes_sent_total` currently reports 0 in production — the call site will be wired in a follow-up PR. Dashboards querying this metric will show 0 until that lands; this is expected.
+> **Note:** From v0.11.0 through v0.15.0, `livetemplate_publishes_sent_total` (and its predecessor `livetemplate_broadcasts_sent_total`) always reported 0 — the counter was defined but never incremented by any production call site (issue #432). The call site is wired in the first release published after v0.15.0; dashboards and alerts on this metric only produce meaningful data on that version or later. See the CHANGELOG "Fixed" entry referencing #432 for the exact release.
 
 The `livetemplate_websocket_dispatch_dropped_total` name is unchanged; only its help text was updated to use "publish dispatch" instead of "broadcast dispatch".
 

--- a/internal/observe/metrics.go
+++ b/internal/observe/metrics.go
@@ -85,7 +85,10 @@ func (m *Metrics) TreeDiffed(duration time.Duration) {
 	m.diffDurations.Record(duration)
 }
 
-// PublishSent increments the publishes-sent counter (peer-fan-out via ctx.Publish).
+// PublishSent increments the publishes-sent counter. It is called once per
+// receiving connection each time a peer-fan-out dispatch is enqueued —
+// covering ctx.Publish, Session.TriggerAction, and cross-instance group/topic
+// re-fan-out.
 func (m *Metrics) PublishSent() {
 	m.publishesSent.Add(1)
 }

--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -95,7 +95,7 @@ func (e *PrometheusExporter) WriteMetrics(w io.Writer) error {
 		e.metrics.treesDiffed.Load())
 
 	e.writeCounter(&sb, "livetemplate_publishes_sent_total",
-		"Total number of peer-fan-out publishes sent (ctx.Publish)",
+		"Total peer-fan-out dispatches enqueued for delivery, counted once per receiving connection (ctx.Publish, Session.TriggerAction, and cross-instance group/topic re-fan-out)",
 		e.metrics.publishesSent.Load())
 
 	e.writeCounter(&sb, "livetemplate_errors_total",

--- a/internal/session/dispatch_test.go
+++ b/internal/session/dispatch_test.go
@@ -60,9 +60,10 @@ func TestEnqueueDispatch_DropsWhenFull(t *testing.T) {
 	}
 }
 
-// mockMetrics is a MetricsRecorder that counts dispatch drops for assertion.
+// mockMetrics is a MetricsRecorder that counts dispatch outcomes for assertion.
 type mockMetrics struct {
 	dispatchDropped int
+	publishSent     int
 }
 
 func (m *mockMetrics) WSBufferFull()           {}
@@ -70,6 +71,7 @@ func (m *mockMetrics) WSSlowClientClose()      {}
 func (m *mockMetrics) WSWriteError()           {}
 func (m *mockMetrics) WSAddBufferSize(_ int64) {}
 func (m *mockMetrics) WSDispatchDropped()      { m.dispatchDropped++ }
+func (m *mockMetrics) PublishSent()            { m.publishSent++ }
 
 func TestEnqueueDispatch_DropIncrementsMetric(t *testing.T) {
 	metrics := &mockMetrics{}
@@ -88,6 +90,31 @@ func TestEnqueueDispatch_DropIncrementsMetric(t *testing.T) {
 
 	if metrics.dispatchDropped != 1 {
 		t.Errorf("expected WSDispatchDropped to be called once, got %d", metrics.dispatchDropped)
+	}
+	if metrics.publishSent != 1 {
+		t.Errorf("expected PublishSent to be called once (for the delivered first enqueue), got %d", metrics.publishSent)
+	}
+}
+
+func TestEnqueueDispatch_SuccessIncrementsPublishSent(t *testing.T) {
+	metrics := &mockMetrics{}
+	conn := &Connection{
+		GroupID:      "group-1",
+		DispatchChan: make(chan *DispatchRequest, 4),
+		metrics:      metrics,
+	}
+
+	// Each delivered enqueue represents one peer-fan-out dispatch and must
+	// bump PublishSent exactly once.
+	conn.EnqueueDispatch(&DispatchRequest{Action: "First"})
+	conn.EnqueueDispatch(&DispatchRequest{Action: "Second"})
+	conn.EnqueueDispatch(&DispatchRequest{Action: "Third"})
+
+	if metrics.publishSent != 3 {
+		t.Errorf("expected PublishSent to be called 3 times, got %d", metrics.publishSent)
+	}
+	if metrics.dispatchDropped != 0 {
+		t.Errorf("expected no drops, got %d", metrics.dispatchDropped)
 	}
 }
 

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -110,6 +110,9 @@ func (c *Connection) EnqueueDispatch(req *DispatchRequest) {
 	}
 	select {
 	case c.DispatchChan <- req:
+		if c.metrics != nil {
+			c.metrics.PublishSent()
+		}
 	case <-c.done:
 		return // connection closed between checks
 	default:
@@ -323,6 +326,7 @@ type MetricsRecorder interface {
 	WSWriteError()
 	WSAddBufferSize(delta int64)
 	WSDispatchDropped()
+	PublishSent()
 }
 
 // ConnectionRegistry tracks all active WebSocket connections with dual indexing.


### PR DESCRIPTION
## What & why

Fixes #432. The `livetemplate_publishes_sent_total` counter (renamed from `broadcasts_sent_total` in #431) was defined but **never incremented by any production call site** — the only caller was a unit test. It reported `0` in every deployment from v0.11.0 through v0.15.0, a footgun for operators with dashboards or alerts on peer-fan-out rate.

## The fix

All four peer-fan-out paths — `ctx.Publish`, `Session.TriggerAction`, and the two cross-instance Redis handlers (`handleGroupActionMessage`, `handleTopicActionMessage`) — funnel through one method: `Connection.EnqueueDispatch`. Incrementing `PublishSent()` on its successful-enqueue branch is a single choke point, symmetric with the existing `WSDispatchDropped()` on the drop branch (together they partition every enqueue into delivered vs dropped).

### Semantics (documented in help text / godoc / OBSERVABILITY.md)
- Counted **once per receiving connection**.
- **Per instance** — each instance counts only its own local deliveries, so a clustered publish is not double-counted (Redis filters own-instance echoes).
- Recorded at **enqueue time**, so a downstream slow-client close can still drop the resulting WebSocket send.

Note: cross-instance *server actions* (`handleServerActionMessage`) are **not** counted — that path processes actions directly and does not route through `EnqueueDispatch`. The docs say "group/topic re-fan-out" for this reason.

## Changes
- `internal/session/registry.go` — add `PublishSent()` to the `MetricsRecorder` interface + increment on the success branch.
- `internal/observe/{metrics,prometheus}.go` — broaden help text and godoc.
- `docs/guides/OBSERVABILITY.md` — replace the stale "reports 0, follow-up PR" note; describe real semantics.
- `CHANGELOG.md` — `[Unreleased]` Fixed entry.

## Tests
- **Unit** (`dispatch_test.go`): `EnqueueDispatch` success path bumps the counter once per delivered enqueue.
- **E2E** (`broadcast_test.go`): 3 tabs subscribed to `SelfTopic`; one publishes; a real `/metrics` scrape via `MetricsHandler()` confirms the counter advances by **exactly 2** (sender excluded, two peers) — validating both placement and the per-connection semantic.

Full suite + pre-commit (lint + tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)