### PR TITLE
perf(context): cap pooled render buffer capacity (#226)

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -21,6 +21,27 @@ var bufferPool = sync.Pool{
 	New: func() interface{} { return new(bytes.Buffer) },
 }
 
+// maxPooledBufferBytes caps the capacity of a bytes.Buffer we are willing to
+// return to bufferPool. A single very large template render grows a buffer to
+// that size; without a cap, sync.Pool would retain it (for up to two GC cycles)
+// and bloat idle memory for apps that mix tiny and huge templates.
+const maxPooledBufferBytes = 256 << 10 // 256 KB
+
+// bufferReusable reports whether buf is small enough to be worth returning to
+// bufferPool. Buffers grown past maxPooledBufferBytes by a large render are
+// dropped so sync.Pool cannot pin their capacity.
+func bufferReusable(buf *bytes.Buffer) bool {
+	return buf.Cap() <= maxPooledBufferBytes
+}
+
+// putBuffer returns buf to bufferPool unless it has grown too large to be worth
+// retaining, in which case it is dropped for the GC to reclaim.
+func putBuffer(buf *bytes.Buffer) {
+	if bufferReusable(buf) {
+		bufferPool.Put(buf)
+	}
+}
+
 // TemplateContext provides utility functions for templates via the lvt namespace.
 //
 // It provides two separate message systems via a unified messages map:
@@ -412,11 +433,11 @@ func executeWithBuffer(tmpl *template.Template, data interface{}) ([]byte, error
 	buf.Reset()
 	err := tmpl.Execute(buf, data)
 	if err != nil {
-		bufferPool.Put(buf)
+		putBuffer(buf)
 		return nil, err
 	}
 	result := make([]byte, buf.Len())
 	copy(result, buf.Bytes())
-	bufferPool.Put(buf)
+	putBuffer(buf)
 	return result, nil
 }

--- a/internal/context/pool_test.go
+++ b/internal/context/pool_test.go
@@ -1,0 +1,44 @@
+package context
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestBufferReusable verifies the capacity gate that keeps oversized buffers out
+// of bufferPool: buffers up to maxPooledBufferBytes are reusable, anything larger
+// is dropped so a single huge render cannot pin memory in the pool.
+func TestBufferReusable(t *testing.T) {
+	cases := []struct {
+		name string
+		cap  int
+		want bool
+	}{
+		{"empty", 0, true},
+		{"typical", 8 << 10, true},
+		{"at limit", maxPooledBufferBytes, true},
+		{"over limit", maxPooledBufferBytes + 1, false},
+		{"huge", 10 << 20, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			buf.Grow(tc.cap)
+			if got := bufferReusable(buf); got != tc.want {
+				t.Errorf("bufferReusable(cap=%d) = %v, want %v", buf.Cap(), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPutBuffer_DropsOversized confirms putBuffer never returns an oversized
+// buffer to the pool. This assertion is race-detector safe: a buffer that is
+// never Put can never be handed back by Get, regardless of scheduling.
+func TestPutBuffer_DropsOversized(t *testing.T) {
+	big := new(bytes.Buffer)
+	big.Grow(maxPooledBufferBytes + 1)
+	putBuffer(big)
+	if got := bufferPool.Get().(*bytes.Buffer); got == big {
+		t.Fatalf("oversized buffer (cap %d) was retained in the pool", big.Cap())
+	}
+}


### PR DESCRIPTION
## What

`executeWithBuffer` (`internal/context/context.go`) recycles `bytes.Buffer`s through a package-wide `sync.Pool`. A single very large template render grows a buffer, and without a cap `sync.Pool` retains that oversized buffer for up to two GC cycles — bloating idle memory for apps that mix tiny and huge templates.

This routes both `Put` sites through a new `putBuffer`, which drops buffers grown past **256 KB** (`maxPooledBufferBytes`) rather than returning them. Mirrors stdlib precedent (`fmt` `ppFree`, `encoding/json` encoder pool).

## Design notes

- The size gate is a pure `bufferReusable(buf)` predicate, so **both** branches (reuse small / drop oversized) are tested deterministically. The pool's recycle path can't be asserted under `-race` (`sync.Pool` degrades its fast path there), so the behavioral test only asserts the race-safe direction — an oversized buffer that is never `Put` can never be returned by `Get`.
- 256 KB keeps the pool useful for the large-list/table renders this library targets, while dropping only genuinely huge renders (exports, big dashboards) — the upper bound floated in #226.

## Tests

- `TestBufferReusable` — table test across the capacity boundary (empty / typical / at-limit / over-limit / huge).
- `TestPutBuffer_DropsOversized` — behavioral, race-safe.
- Full suite + `-race` on `internal/context` green; pre-commit hook passed.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)