### PR TITLE
fix(parse): error on bare arg-requiring method reference like text/template (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `livetemplate_publishes_sent_total` now actually increments. From v0.11.0 through v0.15.0 the counter (and its predecessor `livetemplate_broadcasts_sent_total`) was defined but never wired to a production call site, so it always reported 0 — a footgun for operators with dashboards or alerts on peer-fan-out rate. It is now incremented once per receiving connection whenever a peer-fan-out dispatch is enqueued, covering `ctx.Publish`, `Session.TriggerAction`, and cross-instance group/topic re-fan-out. The count is per instance (each instance counts only its own local deliveries, so a clustered publish is not double-counted) and is recorded at enqueue time, so a downstream slow-client close can still drop the resulting WebSocket send. (#432)
+- A bare template reference to an argument-requiring method (e.g. `{{.Get}}` where `Get(key string) string`) now errors like `text/template` (`wrong number of args for Get: want 1 got 0`) instead of silently stringifying the uncalled method as a Go func value. A bare reference to a *variadic* method (`{{.Tags}}` for `Tags(...string)`) is now called with no arguments, also matching `text/template`. The with-args method path (`{{.ctx.Get "key"}}`) is unchanged. The fix lives at the eval-node altitude in `internal/parse/eval.go`, where the presence of trailing args is known — `callMethod`/`resolveFieldChain` run before that and so cannot distinguish "awaiting args" from "bare reference". (#203, #459)
 
 ### Added
 

--- a/internal/parse/eval.go
+++ b/internal/parse/eval.go
@@ -407,19 +407,30 @@ type uncalledMethod struct {
 }
 
 // callBare evaluates the method as a bare reference (no trailing args). A
-// variadic method is called with an empty variadic ({{.Tags}} calls Tags());
-// a method that genuinely requires arguments returns a ParseError matching
-// text/template's "wrong number of args for X: want N got 0".
+// variadic method with only its variadic parameter is called with an empty
+// variadic ({{.Tags}} calls Tags()); a method that genuinely requires arguments
+// returns a ParseError matching text/template's "wrong number of args" text —
+// "want N" for a fixed arity, "want at least N" for a variadic one.
 func (m uncalledMethod) callBare() (interface{}, error) {
 	mt := m.fn.Type()
-	if mt.IsVariadic() && mt.NumIn() == 1 {
-		return invokeNoArgs(m.fn)
+	if mt.IsVariadic() {
+		fixed := mt.NumIn() - 1 // drop the trailing variadic slot
+		if fixed == 0 {
+			return invokeNoArgs(m.fn)
+		}
+		return nil, m.argCountError(fmt.Sprintf("want at least %d", fixed))
 	}
-	return nil, &ParseError{
+	return nil, m.argCountError(fmt.Sprintf("want %d", mt.NumIn()))
+}
+
+// argCountError builds the bare-reference "wrong number of args" ParseError,
+// mirroring text/template's message ("...: <want> got 0") for method X.
+func (m uncalledMethod) argCountError(want string) error {
+	return &ParseError{
 		Phase:    "eval",
 		NodeType: "method",
 		Expr:     m.name,
-		Msg:      fmt.Sprintf("wrong number of args for %s: want %d got 0", m.name, mt.NumIn()),
+		Msg:      fmt.Sprintf("wrong number of args for %s: %s got 0", m.name, want),
 	}
 }
 

--- a/internal/parse/eval.go
+++ b/internal/parse/eval.go
@@ -124,7 +124,7 @@ func (e *evaluator) evalFieldNode(dot interface{}, node *parse.FieldNode, args [
 		}
 		return e.callMethodOrFieldWithArgs(val, args, dot, varCtx, pipeArg)
 	}
-	return val, nil
+	return finalizeBareValue(val)
 }
 
 // evalChainNode evaluates a chain: (pipeline).Field1.Field2
@@ -153,7 +153,7 @@ func (e *evaluator) evalChainNode(dot interface{}, node *parse.ChainNode, args [
 	if len(args) > 0 || pipeArg != sentinel {
 		return e.callMethodOrFieldWithArgs(val, args, dot, varCtx, pipeArg)
 	}
-	return val, nil
+	return finalizeBareValue(val)
 }
 
 // evalVariableNode evaluates a variable reference: $var, $var.Field
@@ -194,7 +194,7 @@ func (e *evaluator) evalVariableNode(node *parse.VariableNode, args []parse.Node
 	if len(args) > 0 || pipeArg != sentinel {
 		return e.callMethodOrFieldWithArgs(val, args, dot, varCtx, pipeArg)
 	}
-	return val, nil
+	return finalizeBareValue(val)
 }
 
 // evalFunctionCall evaluates a function call: funcName arg1 arg2 ...
@@ -237,7 +237,11 @@ func (e *evaluator) evalArg(node parse.Node, dot interface{}, varCtx *varContext
 	case *parse.DotNode:
 		return dot, nil
 	case *parse.FieldNode:
-		return resolveFieldChain(dot, n.Ident)
+		val, err := resolveFieldChain(dot, n.Ident)
+		if err != nil {
+			return nil, err
+		}
+		return finalizeBareValue(val)
 	case *parse.VariableNode:
 		return e.evalVariableNode(n, nil, dot, varCtx, sentinel)
 	case *parse.StringNode:
@@ -265,7 +269,12 @@ func (e *evaluator) evalArg(node parse.Node, dot interface{}, varCtx *varContext
 // callMethodOrFieldWithArgs handles the case where a field/variable result
 // is followed by arguments — meaning it's a method call.
 func (e *evaluator) callMethodOrFieldWithArgs(val interface{}, args []parse.Node, dot interface{}, varCtx *varContext, pipeArg interface{}) (interface{}, error) {
+	// An uncalledMethod (a method resolveFieldChain left uncalled because it
+	// needs args) carries the bound method to invoke with these trailing args.
 	fn := reflect.ValueOf(val)
+	if um, ok := val.(uncalledMethod); ok {
+		fn = um.fn
+	}
 	if fn.Kind() != reflect.Func {
 		return nil, &ParseError{Phase: "eval", NodeType: "call", Msg: fmt.Sprintf("can't call non-function value of type %T", val)}
 	}
@@ -284,10 +293,22 @@ func (e *evaluator) callMethodOrFieldWithArgs(val interface{}, args []parse.Node
 func resolveFieldChain(value interface{}, fields []string) (interface{}, error) {
 	v := reflect.ValueOf(value)
 	for _, field := range fields {
+		// A prior field resolved to a method that needs args (uncalledMethod).
+		// Taking a further field on it forces evaluation now: a variadic method
+		// calls with no args (text/template parity), any other errors.
+		if um, ok := value.(uncalledMethod); ok {
+			called, err := um.callBare()
+			if err != nil {
+				return nil, err
+			}
+			value = called
+			v = reflect.ValueOf(value)
+		}
+
 		// Try method on pre-deref value first (for pointer receivers)
 		if v.IsValid() {
 			if method := v.MethodByName(field); method.IsValid() {
-				result, err := callMethod(method)
+				result, err := callMethod(method, field)
 				if err != nil {
 					return nil, err
 				}
@@ -305,7 +326,7 @@ func resolveFieldChain(value interface{}, fields []string) (interface{}, error) 
 
 		// Try method on dereferenced value
 		if method := v.MethodByName(field); method.IsValid() {
-			result, err := callMethod(method)
+			result, err := callMethod(method, field)
 			if err != nil {
 				return nil, err
 			}
@@ -352,17 +373,19 @@ func resolveFieldChain(value interface{}, fields []string) (interface{}, error) 
 	return value, nil
 }
 
-// callMethod calls a zero-argument method and returns its result. A method that
-// requires arguments is returned UNCALLED so the caller can still apply trailing
-// args (e.g. the {{.ctx.Get "key"}} chain): resolveFieldChain resolves the method
-// before arg presence is known, so it must not invoke one that may receive args.
-// A bare reference to an arg-requiring method therefore yields the uncalled value
-// rather than erroring like text/template; the eval-node-level fix is tracked in #459.
-func callMethod(method reflect.Value) (interface{}, error) {
-	mt := method.Type()
-	if mt.NumIn() != 0 {
-		return method.Interface(), nil
+// callMethod invokes a zero-argument method and returns its result. A method
+// that requires arguments is returned wrapped as an [uncalledMethod] rather than
+// invoked — see that type for why, and for how the caller finalizes it.
+func callMethod(method reflect.Value, name string) (interface{}, error) {
+	if method.Type().NumIn() != 0 {
+		return uncalledMethod{fn: method, name: name}, nil
 	}
+	return invokeNoArgs(method)
+}
+
+// invokeNoArgs calls method with no arguments and unpacks a T or (T, error)
+// return, mapping a non-nil trailing error to a Go error.
+func invokeNoArgs(method reflect.Value) (interface{}, error) {
 	results := method.Call(nil)
 	if len(results) == 0 {
 		return nil, nil
@@ -371,6 +394,43 @@ func callMethod(method reflect.Value) (interface{}, error) {
 		return nil, results[1].Interface().(error)
 	}
 	return results[0].Interface(), nil
+}
+
+// uncalledMethod holds a bound method that resolveFieldChain resolved but did
+// not call because it requires arguments. Wrapping it (rather than returning the
+// raw reflect method value) lets the eval nodes tell a method awaiting trailing
+// args apart from a genuinely bare reference, and keeps such a value from
+// leaking to valueToString as a stringified func.
+type uncalledMethod struct {
+	fn   reflect.Value
+	name string
+}
+
+// callBare evaluates the method as a bare reference (no trailing args). A
+// variadic method is called with an empty variadic ({{.Tags}} calls Tags());
+// a method that genuinely requires arguments returns a ParseError matching
+// text/template's "wrong number of args for X: want N got 0".
+func (m uncalledMethod) callBare() (interface{}, error) {
+	mt := m.fn.Type()
+	if mt.IsVariadic() && mt.NumIn() == 1 {
+		return invokeNoArgs(m.fn)
+	}
+	return nil, &ParseError{
+		Phase:    "eval",
+		NodeType: "method",
+		Expr:     m.name,
+		Msg:      fmt.Sprintf("wrong number of args for %s: want %d got 0", m.name, mt.NumIn()),
+	}
+}
+
+// finalizeBareValue converts a bare (no-trailing-args) resolution result into a
+// final value: an uncalledMethod is evaluated via callBare, anything else is
+// returned unchanged.
+func finalizeBareValue(val interface{}) (interface{}, error) {
+	if um, ok := val.(uncalledMethod); ok {
+		return um.callBare()
+	}
+	return val, nil
 }
 
 // isErrorResult checks if a reflect.Value contains a non-nil error.

--- a/internal/parse/stdlib_parity_test.go
+++ b/internal/parse/stdlib_parity_test.go
@@ -756,3 +756,98 @@ func TestStdlibParity_MethodCallOnMapValue(t *testing.T) {
 		})
 	}
 }
+
+// methodArgHelper exercises the three method-arity shapes for bare-reference
+// parity: a zero-arg method, an argument-requiring method, and a variadic method.
+type methodArgHelper struct{}
+
+func (methodArgHelper) Name() string             { return "zero-arg" }
+func (methodArgHelper) Get(k string) string      { return "got:" + k }
+func (methodArgHelper) Tags(xs ...string) string { return "tags:" + strings.Join(xs, ",") }
+
+// lvtRenderErr renders through LiveTemplate returning any parse/build error
+// instead of failing the test, so error-path parity can be asserted.
+func lvtRenderErr(tmplStr string, data interface{}) (string, error) {
+	tmpl, err := Parse(tmplStr, nil)
+	if err != nil {
+		return "", err
+	}
+	tree, err := BuildTree(tmpl, data, &Context{IncludeStatics: true})
+	if err != nil {
+		return "", err
+	}
+	return flatTreeToHTML(tree), nil
+}
+
+// stdlibRenderErr renders through html/template returning any error.
+func stdlibRenderErr(tmplStr string, data interface{}) (string, error) {
+	tmpl, err := template.New("test").Parse(tmplStr)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// TestStdlibParity_BareMethodArgs locks the fix for #203/#459: a bare reference
+// to an argument-requiring method must error like text/template rather than
+// stringifying the uncalled method as a func value, while a bare variadic method
+// is called with no args and the with-args method-call path is unaffected.
+func TestStdlibParity_BareMethodArgs(t *testing.T) {
+	h := methodArgHelper{}
+	nested := map[string]interface{}{"ctx": h}
+
+	t.Run("output parity", func(t *testing.T) {
+		cases := []struct {
+			name string
+			tmpl string
+			data interface{}
+		}{
+			{"zero-arg method is called", `<span>{{.Name}}</span>`, h},
+			{"bare variadic method calls empty", `<span>{{.Tags}}</span>`, h},
+			{"variadic method with args", `<span>{{.Tags "a" "b"}}</span>`, h},
+			{"arg method with arg", `<span>{{.Get "key"}}</span>`, h},
+			{"nested arg method with arg", `<span>{{.ctx.Get "key"}}</span>`, nested},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				std := stdlibRender(t, tc.tmpl, tc.data, nil)
+				lvt := lvtRender(t, tc.tmpl, tc.data, nil)
+				if std != lvt {
+					t.Errorf("output mismatch:\n  stdlib: %q\n  lvt:    %q", std, lvt)
+				}
+			})
+		}
+	})
+
+	t.Run("error parity", func(t *testing.T) {
+		cases := []struct {
+			name string
+			tmpl string
+			data interface{}
+		}{
+			{"bare arg-requiring method", `{{.Get}}`, h},
+			{"bare arg-requiring method as function arg", `{{printf "%s" .Get}}`, h},
+			{"bare arg-requiring method in conditional", `{{if .Get}}x{{end}}`, h},
+			{"nested bare arg-requiring method", `{{.ctx.Get}}`, nested},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, stdErr := stdlibRenderErr(tc.tmpl, tc.data)
+				if stdErr == nil {
+					t.Fatalf("precondition: stdlib should error on %q but did not", tc.tmpl)
+				}
+				_, lvtErr := lvtRenderErr(tc.tmpl, tc.data)
+				if lvtErr == nil {
+					t.Fatalf("livetemplate did not error on %q (stdlib error: %v)", tc.tmpl, stdErr)
+				}
+				if !strings.Contains(lvtErr.Error(), "Get") {
+					t.Errorf("error should name the method Get, got: %v", lvtErr)
+				}
+			})
+		}
+	})
+}

--- a/internal/parse/stdlib_parity_test.go
+++ b/internal/parse/stdlib_parity_test.go
@@ -765,6 +765,12 @@ func (methodArgHelper) Name() string             { return "zero-arg" }
 func (methodArgHelper) Get(k string) string      { return "got:" + k }
 func (methodArgHelper) Tags(xs ...string) string { return "tags:" + strings.Join(xs, ",") }
 
+// Log mixes a fixed leading arg with a variadic tail, so a bare reference must
+// report "want at least 1" (not "want 2"), matching text/template.
+func (methodArgHelper) Log(level string, args ...interface{}) string {
+	return level + ":" + fmt.Sprint(args...)
+}
+
 // lvtRenderErr renders through LiveTemplate returning any parse/build error
 // instead of failing the test, so error-path parity can be asserted.
 func lvtRenderErr(tmplStr string, data interface{}) (string, error) {
@@ -833,6 +839,7 @@ func TestStdlibParity_BareMethodArgs(t *testing.T) {
 			{"bare arg-requiring method as function arg", `{{printf "%s" .Get}}`, h},
 			{"bare arg-requiring method in conditional", `{{if .Get}}x{{end}}`, h},
 			{"nested bare arg-requiring method", `{{.ctx.Get}}`, nested},
+			{"bare mixed fixed+variadic method", `{{.Log}}`, h},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -844,8 +851,14 @@ func TestStdlibParity_BareMethodArgs(t *testing.T) {
 				if lvtErr == nil {
 					t.Fatalf("livetemplate did not error on %q (stdlib error: %v)", tc.tmpl, stdErr)
 				}
-				if !strings.Contains(lvtErr.Error(), "Get") {
-					t.Errorf("error should name the method Get, got: %v", lvtErr)
+				// Assert message parity on the "wrong number of args..." core,
+				// which stdlib wraps in positional prefixes lvt does not emit.
+				core := stdErr.Error()
+				if i := strings.Index(core, "wrong number of args"); i >= 0 {
+					core = core[i:]
+				}
+				if !strings.Contains(lvtErr.Error(), core) {
+					t.Errorf("error message parity mismatch:\n  stdlib core: %q\n  lvt:         %q", core, lvtErr.Error())
 				}
 			})
 		}


### PR DESCRIPTION
## Summary

Closes #203. Also closes #459 (the eval-node-altitude fix that #203 was split into).

A **bare** template reference to an argument-requiring method — e.g. `{{.Get}}` where `Get(key string) string` — previously resolved the *uncalled* bound method as a value, which then flowed into `valueToString` and rendered as a stringified Go func value (a confusing `0x…`-style output). `text/template` instead errors: `wrong number of args for Get: want 1 got 0`.

## Why the fix is at the eval-node altitude, not `callMethod`

`resolveFieldChain` resolves (and, for zero-arg methods, *calls*) each method **before** the caller knows whether trailing args follow. The uncalled-method return is **load-bearing** for the with-args path — `{{.ctx.Get "key"}}` works precisely because `resolveFieldChain` yields the bound `Get` method, which `callMethodOrFieldWithArgs` then invokes with `"key"`. So making `callMethod` error on `NumIn() != 0` would break `{{.ctx.Get "key"}}`, and eagerly calling variadic methods there would break `{{.Tags "a"}}`. The bare-vs-with-args distinction is known only at the eval nodes, which see `len(args)`.

#203 shipped its documentation option in PR #460 and split this behavioral fix into #459; this PR implements #459.

## Change

- `callMethod` now wraps an argument-requiring method in a small `uncalledMethod{fn, name}` rather than returning the raw reflect method value. This lets the eval nodes distinguish "method awaiting trailing args" from "genuinely bare reference," and keeps such a value from leaking to `valueToString`.
- The three eval-node bare branches (`evalFieldNode` / `evalChainNode` / `evalVariableNode`) and `evalArg` finalize the wrapper via `finalizeBareValue`:
  - a **variadic** method (`{{.Tags}}` for `Tags(...string)`) is **called with no args**, matching `text/template`;
  - a method that **genuinely requires args** returns a descriptive `ParseError` naming the method.
- The **with-args path** (`{{.ctx.Get "key"}}`, `{{.Tags "a" "b"}}`) unwraps the method and invokes it — unchanged.
- `resolveFieldChain` finalizes a pending `uncalledMethod` at the top of the loop, so a further field on an arg-requiring method (`{{.Get.Foo}}`) errors instead of silently returning nil.

## Testing

`TestStdlibParity_BareMethodArgs` locks behavior against `html/template` for both directions, derived from an empirical probe of stdlib:

| Template | Behavior (both engines) |
|---|---|
| `{{.Name}}` zero-arg method | called |
| `{{.Tags}}` bare variadic method | called with empty variadic |
| `{{.Tags "a" "b"}}` | called with args |
| `{{.Get "key"}}` / `{{.ctx.Get "key"}}` | called with args (unchanged) |
| `{{.Get}}` bare arg-requiring method | **errors**, naming `Get` |
| `{{printf "%s" .Get}}`, `{{if .Get}}…{{end}}`, `{{.ctx.Get}}` | **errors** |

Full repo suite + `go vet` green. `/simplify` pass applied (one redundant comment trimmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)