### PR TITLE
feat(client): pin the wire-compatible client version + template helpers (#483 B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- `ClientVersion`, `ClientScriptURL`, and `ClientStyleURL` exported constants pin the `@livetemplate/client` browser bundle this LiveTemplate release is wire-compatible with, plus two framework-seeded template functions — `lvtClientScriptURL` and `lvtClientStyleURL` — that render those URLs. Templates can now reference `{{lvtClientScriptURL}}` / `{{lvtClientStyleURL}}` with no per-app wiring (the funcs are seeded into every template's FuncMap in `New`, before any parse path runs, so they resolve in full-HTML documents, fragments, and component templates alike; a user `Funcs` call still overrides them by key). This replaces the previous pattern of hardcoding an unpinned `@latest` CDN URL — which was unsafe because there is no runtime server↔client version handshake, so a client-only release could ship a wire-protocol change to browsers still talking to an older server. Pinning moves the client version only on a deliberate `go get -u`, in lockstep with the compatible server. `ClientVersion` is pinned to the release `@latest` resolves to today, so behavior is preserved. Self-hosters (offline / air-gapped / CSP-strict) vendor `@livetemplate/client@<ClientVersion>` and serve it from their own origin instead. (#483)
 
 ## [v0.17.0] - 2026-07-10
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ func main() {
     <button name="decrement">-</button>
 </form>
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/livetemplate.css">
-<script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/dist/livetemplate-client.browser.js"></script>
+<link rel="stylesheet" href="{{lvtClientStyleURL}}">
+<script defer src="{{lvtClientScriptURL}}"></script>
 ```
+
+`lvtClientStyleURL` / `lvtClientScriptURL` are framework-provided template functions that render the CDN URL for the `@livetemplate/client` release this LiveTemplate version is wire-compatible with — so the browser client stays pinned in lockstep with the server instead of drifting on `@latest`. To self-host, replace them with your own tag pointing at a vendored `@livetemplate/client@<version>`.
 
 **3. Run it**
 

--- a/client_assets.go
+++ b/client_assets.go
@@ -1,0 +1,56 @@
+package livetemplate
+
+import "html/template"
+
+// ClientVersion is the version of the @livetemplate/client browser bundle that
+// this release of livetemplate is wire-compatible with.
+//
+// It moves in lockstep with each livetemplate release, so applications never
+// hand-maintain a client version: upgrading the livetemplate dependency
+// (go get -u github.com/livetemplate/livetemplate) automatically selects the
+// matching client. Pinning to this version — rather than the CDN's "@latest"
+// tag — prevents a client-only release from silently shipping a wire-protocol
+// change to browsers that are still talking to an older server. There is no
+// runtime version handshake between server and client, so an unpinned client is
+// unsafe: see the @livetemplate/client CHANGELOG (e.g. the __navigate__ action,
+// which is a no-op on older servers).
+//
+// Maintainers: bump this in the same release that adopts a new client version.
+const ClientVersion = "0.16.5"
+
+// clientCDNBase is the jsdelivr base URL for the pinned client bundle. jsdelivr
+// serves the published npm package @livetemplate/client.
+const clientCDNBase = "https://cdn.jsdelivr.net/npm/@livetemplate/client@" + ClientVersion
+
+// ClientScriptURL is the pinned CDN URL for the browser client bundle, for use
+// as the src of a <script> tag:
+//
+//	<script src="{{ .ClientScriptURL }}" defer></script>
+//
+// To self-host (offline, air-gapped, or CSP-strict deployments), vendor
+// @livetemplate/client@<ClientVersion> and serve it from your own origin
+// instead of using this URL.
+const ClientScriptURL = clientCDNBase + "/dist/livetemplate-client.browser.js"
+
+// ClientStyleURL is the pinned CDN URL for the client stylesheet, for use as the
+// href of a <link rel="stylesheet"> tag. See ClientScriptURL for the
+// self-hosting note.
+const ClientStyleURL = clientCDNBase + "/livetemplate.css"
+
+// frameworkTemplateFuncs are the template functions livetemplate provides to
+// every template automatically (seeded into the FuncMap in New, before parsing,
+// so a full-HTML document can reference the pinned client bundle with no per-app
+// wiring — no State field, no manual Funcs registration):
+//
+//	<script src="{{ lvtClientScriptURL }}" defer></script>
+//	<link rel="stylesheet" href="{{ lvtClientStyleURL }}">
+//
+// They return the ClientScriptURL / ClientStyleURL constants, so the pinned
+// version stays single-sourced in Go. Self-hosters simply write their own tag
+// instead of calling these.
+func frameworkTemplateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"lvtClientScriptURL": func() string { return ClientScriptURL },
+		"lvtClientStyleURL":  func() string { return ClientStyleURL },
+	}
+}

--- a/client_assets_test.go
+++ b/client_assets_test.go
@@ -1,0 +1,131 @@
+package livetemplate_test
+
+import (
+	"bytes"
+	"html/template"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/livetemplate"
+)
+
+// TestClientVersionIsSemver guards against a malformed pin (e.g. a stray "v"
+// prefix or "latest"), which would produce a broken CDN URL.
+func TestClientVersionIsSemver(t *testing.T) {
+	if !regexp.MustCompile(`^\d+\.\d+\.\d+$`).MatchString(livetemplate.ClientVersion) {
+		t.Fatalf("ClientVersion %q is not a bare semver (want MAJOR.MINOR.PATCH, no leading v)", livetemplate.ClientVersion)
+	}
+}
+
+// TestClientURLsArePinned is the core regression guard for B2: the client URLs
+// must be HTTPS, carry the exact pinned ClientVersion, and never fall back to
+// the unpinned "@latest" tag (the wire-incompat footgun this constant replaces).
+func TestClientURLsArePinned(t *testing.T) {
+	for name, url := range map[string]string{
+		"ClientScriptURL": livetemplate.ClientScriptURL,
+		"ClientStyleURL":  livetemplate.ClientStyleURL,
+	} {
+		if !strings.HasPrefix(url, "https://") {
+			t.Errorf("%s = %q: must be HTTPS", name, url)
+		}
+		if strings.Contains(url, "@latest") {
+			t.Errorf("%s = %q: must not use the unpinned @latest tag", name, url)
+		}
+		if !strings.Contains(url, "@"+livetemplate.ClientVersion+"/") {
+			t.Errorf("%s = %q: must pin @%s", name, url, livetemplate.ClientVersion)
+		}
+	}
+}
+
+// TestClientURLsPointAtBundleFiles locks the specific artifact paths so a typo
+// (e.g. dropping the dist/ prefix, or pointing CSS at dist/) is caught here
+// rather than as a 404 in a browser.
+func TestClientURLsPointAtBundleFiles(t *testing.T) {
+	if !strings.HasSuffix(livetemplate.ClientScriptURL, "/dist/livetemplate-client.browser.js") {
+		t.Errorf("ClientScriptURL = %q: want suffix /dist/livetemplate-client.browser.js", livetemplate.ClientScriptURL)
+	}
+	// The stylesheet lives at the package root, not under dist/.
+	if !strings.HasSuffix(livetemplate.ClientStyleURL, "/livetemplate.css") {
+		t.Errorf("ClientStyleURL = %q: want suffix /livetemplate.css", livetemplate.ClientStyleURL)
+	}
+	if strings.Contains(livetemplate.ClientStyleURL, "/dist/") {
+		t.Errorf("ClientStyleURL = %q: stylesheet is at the package root, not under dist/", livetemplate.ClientStyleURL)
+	}
+}
+
+// TestClientURLTemplateFuncsRender is the end-to-end proof of the consumption
+// path: a full-HTML document can reference lvtClientScriptURL / lvtClientStyleURL
+// with no per-app State field or Funcs registration, and they render the pinned
+// URLs. It renders through a Clone because production renders through per-session
+// clones — a master-only render would pass even if Clone dropped the seeded funcs.
+func TestClientURLTemplateFuncsRender(t *testing.T) {
+	const doc = `<!DOCTYPE html><html><head>` +
+		`<link rel="stylesheet" href="{{lvtClientStyleURL}}">` +
+		`</head><body><script src="{{lvtClientScriptURL}}" defer></script></body></html>`
+
+	master, err := livetemplate.New("client-funcs-test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Parse must succeed: html/template rejects a template referencing an
+	// undefined func, so this fails loudly if the funcs were not seeded.
+	if _, err := master.Parse(doc); err != nil {
+		t.Fatalf("parse referencing framework funcs: %v", err)
+	}
+	clone, err := master.Clone()
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := clone.Execute(&buf, nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, livetemplate.ClientScriptURL) {
+		t.Errorf("rendered HTML missing ClientScriptURL %q:\n%s", livetemplate.ClientScriptURL, html)
+	}
+	if !strings.Contains(html, livetemplate.ClientStyleURL) {
+		t.Errorf("rendered HTML missing ClientStyleURL %q:\n%s", livetemplate.ClientStyleURL, html)
+	}
+}
+
+// TestClientURLTemplateFuncsAreOverridable locks the behavior documented on
+// (*Template).Funcs and in client_assets.go: because Funcs merges into the same
+// FuncMap by name, a user-registered func with the same name overrides the
+// framework-seeded one. A self-hoster who wants same-origin URLs uses this to
+// point lvtClientScriptURL at their own path without writing a new tag.
+func TestClientURLTemplateFuncsAreOverridable(t *testing.T) {
+	const doc = `<script src="{{lvtClientScriptURL}}"></script>`
+	const selfHosted = "/assets/livetemplate-client.js"
+
+	master, err := livetemplate.New("client-funcs-override-test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Register the override before parsing, so the parse-time FuncMap already
+	// carries the user value rather than the framework default.
+	master.Funcs(template.FuncMap{
+		"lvtClientScriptURL": func() string { return selfHosted },
+	})
+	if _, err := master.Parse(doc); err != nil {
+		t.Fatalf("parse with overridden func: %v", err)
+	}
+	clone, err := master.Clone()
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := clone.Execute(&buf, nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, selfHosted) {
+		t.Errorf("override did not win: want %q in rendered HTML:\n%s", selfHosted, html)
+	}
+	if strings.Contains(html, livetemplate.ClientScriptURL) {
+		t.Errorf("framework default leaked through despite override: %q in:\n%s", livetemplate.ClientScriptURL, html)
+	}
+}

--- a/docs/design/boilerplate-reduction.md
+++ b/docs/design/boilerplate-reduction.md
@@ -175,31 +175,60 @@ serve the bundle:
   come from a runtime **CDN fetch** (`unpkg.com`, `chrome.go:24`) — a network dependency baked
   into request serving.
 
-**prereview resolves the design fork for us.** It refuses the test helper and instead
-**vendors + embeds** the bundle: `internal/assets/assets.go:24-28`
-(`//go:embed client/livetemplate-client.browser.js` + `livetemplate.css`, synced by
-`make sync-client`), served as plain bytes at `server.go:247,251`. It does this because it
-must run offline over Tailscale — but that is exactly the production-grade shape every app
-wants, and no app should have to hand-vendor it.
+The finding is really **two smells**: (1) a *test* package imported into production, and
+(2) a runtime CDN fetch pinned to the unversioned `@latest` tag — and there is **no runtime
+version handshake** between server and client (grepped both; none), so `@latest` can serve a
+browser a client newer than the server it talks to. The `@livetemplate/client` CHANGELOG
+documents exactly this footgun: the `__navigate__` in-band action is *"a no-op on server
+versions before livetemplate#344 — deploy the server update before or simultaneously with this
+client version."* These are 0.x releases, where minors are allowed to break the wire.
 
-**Design sketch.**
+**Resolution: framework-owned version pin, no bundling.** The embed-the-bytes route was
+considered and rejected. prereview's `//go:embed` (`internal/assets/assets.go:24-28`, synced by
+`make sync-client`) is right *for an app* that must run offline over Tailscale, but wrong *for a
+library*: `go:embed` resolves against the module zip the proxy serves at a tag, so a gitignored
+bundle breaks every downstream `go get` build, and *committing* a ~140KB minified blob makes
+core stop being the zero-asset leaf it deliberately is (its `go.mod` depends on neither `lvt`
+nor `client`). Embedding solves a minority (offline) need at a cost every consumer pays.
+
+Instead, core owns the one thing it uniquely knows — **which client version is wire-compatible
+with it** — and nothing more (`client_assets.go`):
 
 ```go
-// ClientAssetsHandler serves the LiveTemplate client bundle (JS + CSS) from an
-// embedded copy — no runtime network fetch. Mount it once:
-//   mux.Handle("/livetemplate-client.js", livetemplate.ClientAssetsHandler())
-// or a small mux the app mounts under a prefix.
-func ClientAssetsHandler() http.Handler
+// Moves in lockstep with each livetemplate release, so apps never hand-maintain a
+// client version: `go get -u` bumps the server and its matching client together.
+const ClientVersion   = "0.16.5"
+const ClientScriptURL = "https://cdn.jsdelivr.net/npm/@livetemplate/client@" + ClientVersion + "/dist/livetemplate-client.browser.js"
+const ClientStyleURL  = "https://cdn.jsdelivr.net/npm/@livetemplate/client@" + ClientVersion + "/livetemplate.css"
 ```
 
-The bundle is embedded into the `livetemplate` module via a `go generate` / `make` step that
-syncs the built artifact from the separate `client` repo (the module boundary that made it a
-test helper in the first place) — the same `make sync-client` mechanism prereview already
-proved out.
+So templates can reference the pinned URL with **zero per-app wiring**, the framework seeds two
+template functions into every `Template`'s `FuncMap` at `New` (before parse), returning those
+constants:
 
-**Open question (residual):** the vendoring/build mechanism and how the embedded bundle
-version is pinned/updated relative to `client` releases. The *approach* (embed, no CDN fetch)
-is settled by prereview's precedent.
+```html
+<link rel="stylesheet" href="{{ lvtClientStyleURL }}">
+<script src="{{ lvtClientScriptURL }}" defer></script>
+```
+
+This kills both smells: examples use those funcs and drop the `e2etest` import + the two
+serving routes entirely — pinned, no test-package-in-prod, no bytes anywhere, no per-app State
+field, zero per-app version maintenance. It also *removes* the toil `@latest` appeared to save:
+the version moves only when you deliberately upgrade the Go dependency, in lockstep with the
+compatible server. Offline / air-gapped / CSP-strict deployments self-host (vendor
+`@livetemplate/client@<ClientVersion>`, serve same-origin, write their own tag instead of
+calling the funcs) — exactly what prereview keeps doing. Pinned to `0.16.5` because that is what
+`@latest` resolves to today, so the switch is behavior-preserving.
+
+The `lvt/testing` helpers (`ServeClientLibrary`/`ServeCSS`) **stay** — real E2E tests keep
+using them; we only stop shipping them in production examples.
+
+**Follow-ups (separate, greenlightable on their own):** the framework already owns full-HTML
+wrapper injection (`compat.InjectWrapperDiv` in `template.go`), so it *could* later auto-inject
+the pinned
+`<script>`/`<link>` (opt-out) so apps drop even the tag — a bigger win with real design surface
+(CSP, opt-out, dev/prod placement), left out of this minimal change. SRI-hash pinning is another
+optional hardening.
 
 #### B3. Boot + route ceremony copy-pasted per app and per route
 
@@ -308,14 +337,15 @@ real, used capability.
 
 ## Recommended sequencing
 
-1. **Ship A1 + A2** (this change) — highest ratio of pain removed to risk taken.
-2. **B2 (client-asset handler)** next — the design is settled by prereview's precedent, only
-   the vendoring mechanism remains; it removes a test-package-in-production smell from *every*
-   app and example.
-3. **B3 (Page / ListenAndServe)** — collapses the most raw lines; low conceptual risk.
-4. **B1 (fanout)** — **done** (docs + example + regression test, no new API): the proof
-   showed the primitive already exists, so this became a discoverability fix. See the B1
-   resolution above.
+1. **A1 + A2** — **done** (`WithParseFS`; `ctx` request-context guidance). Highest ratio of
+   pain removed to risk taken.
+2. **B1 (fanout)** — **done** (docs + example + regression test, **no new API**): the fanout
+   capability already existed (`ctx.Subscribe` in Mount + out-of-band `handler.Publish`); the
+   gap was discoverability. Shipped as livetemplate#485 + docs#103.
+3. **B2 (client version pin)** — **in progress** (`client_assets.go`: `ClientVersion` +
+   pinned `ClientScriptURL`/`ClientStyleURL`, **no bundling**). Removes a test-package-in-
+   production smell + the unpinned-`@latest` wire-incompat risk from *every* app and example.
+4. **B3 (Page / ListenAndServe)** — collapses the most raw lines; low conceptual risk.
 5. **Tier C** individually as they come up; **C4** rides along as a cheap removal.
 
 ## Shipped with this document (core `livetemplate` repo)

--- a/template.go
+++ b/template.go
@@ -249,6 +249,10 @@ type Template struct {
 }
 
 // Funcs registers a template.FuncMap that will be applied to all template parsing and execution.
+//
+// Funcs merge into the map by name, so a func registered here overrides any
+// framework-seeded func with the same name (e.g. lvtClientScriptURL /
+// lvtClientStyleURL, which New seeds by default — see client_assets.go).
 func (t *Template) Funcs(funcMap template.FuncMap) *Template {
 	if len(funcMap) == 0 {
 		return t
@@ -1039,6 +1043,11 @@ func New(name string, opts ...Option) (*Template, error) {
 		name:   name,
 		config: config,
 	}
+
+	// Seed framework-provided template functions (e.g. lvtClientScriptURL) before
+	// any parse path runs — html/template requires referenced funcs to exist at
+	// parse time. User funcs from (*Template).Funcs merge on top of these.
+	tmpl.funcs = frameworkTemplateFuncs()
 
 	// Parse component templates first (before project templates)
 	// This establishes a base layer of templates that project templates can override


### PR DESCRIPTION
## What

**B2 of the boilerplate-reduction work (#483).** Every shipped example (15 of them) plus real apps import a *test* package — `e2etest "github.com/livetemplate/lvt/testing"` — into their production `main.go` to serve the browser client bundle, and that helper fetches from `unpkg.com/@livetemplate/client@latest` at runtime. Two smells:

1. A **test package in production** serving.
2. An **unpinned client version** (`@latest`) with **no server↔client version handshake** — so a browser can load a client *newer* than the server it talks to. The client's own CHANGELOG documents this footgun: the `__navigate__` action is *"a no-op on server versions before livetemplate#344 — deploy the server update before or simultaneously with this client version."* These are 0.x releases, where minors are allowed to break the wire.

## Approach: pin the version, don't bundle

Embedding the ~140KB bundle into core was considered and rejected: for a **library**, a gitignored `//go:embed` target breaks every downstream `go get`, and *committing* the blob sheds core's deliberate zero-asset-leaf identity (its `go.mod` depends on neither `lvt` nor `client`). That pays a cost on every consumer to serve a minority offline need that prereview already self-solves by vendoring.

Instead core owns the one thing it uniquely knows — **which client version is wire-compatible with it**:

```go
const ClientVersion   = "0.16.5"   // moves in lockstep per release
const ClientScriptURL = "https://cdn.jsdelivr.net/npm/@livetemplate/client@" + ClientVersion + "/dist/livetemplate-client.browser.js"
const ClientStyleURL  = "https://cdn.jsdelivr.net/npm/@livetemplate/client@" + ClientVersion + "/livetemplate.css"
```

Pinned to `0.16.5` because that is what `@latest` resolves to today — **behavior-preserving**. This also *removes* the toil `@latest` appeared to save: the version now moves only when you deliberately `go get -u`, in lockstep with the compatible server.

To let templates consume the pinned URL with **zero per-app wiring** (no State field, no manual `Funcs` registration), `New` seeds two framework template funcs into every `Template`'s `FuncMap` before parse:

```html
<link rel="stylesheet" href="{{ lvtClientStyleURL }}">
<script src="{{ lvtClientScriptURL }}" defer></script>
```

Offline / air-gapped / CSP-strict deployments self-host (vendor `@livetemplate/client@<ClientVersion>`, serve same-origin, write their own tag). The `lvt/testing` helpers **stay** — real E2E tests keep using them; we only stop shipping them in production examples.

## Tests (offline — a network assertion would flake whenever the client publishes ahead of core)

- `ClientVersion` is bare semver.
- URLs are HTTPS, carry the pinned version, and **never** fall back to `@latest` (the regression guard that locks the decision).
- URLs point at the correct artifact paths (`/dist/...browser.js`; CSS at package root).
- End-to-end render **through a Clone** (production renders via per-session clones) proving the funcs parse and emit the URLs.

## Scope

**Core-only.** The visible payoff — converting the 15 examples off `e2etest` and the browser/wire-compat verification — is **release-gated**: the docs repo pins a *published* livetemplate, so examples can't reference `ClientVersion`/the funcs until this ships in a release. That conversion is the follow-up PR, exactly like A1 (`WithParseFS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
