### PR TITLE
docs(lifecycle): a published action is not a re-Mount (Tier C · C1)

### DIFF
--- a/docs/design/boilerplate-reduction.md
+++ b/docs/design/boilerplate-reduction.md
@@ -270,12 +270,21 @@ example would return to its documented ~10 lines; checklistkit's 5 builders coll
 
 ### Tier C — noted, lower priority / needs a decision
 
-- **C1. `Mount`/`OnConnect`/`Refresh` stub duplication** across ~15 controllers
-  (checklistkit `ui/*.go`, devbox-dash `*_controller.go`) — each hand-writes stubs bridging
-  the two lifecycle hooks to one load function. **Partly pattern-guidance**: `Mount` already
-  runs on WS connect, and `IsInitialMount`/`IsReconnect`/`IsNewConnect` exist to discriminate,
-  so much of this is avoidable today. A unified `Load(state, ctx)` hook would formalize it.
-  → Propose the hook *and* document the existing pattern.
+- **C1. `Mount`/`OnConnect`/`Refresh` stub duplication.** ✅ **RESOLVED (docs, no core
+  change).** Original claim was ~15 controllers across checklistkit + devbox-dash hand-writing
+  a lifecycle triple. On re-audit the signal had **collapsed to one un-migrated app**:
+  checklistkit uses a different notifier (0 triples), tinkerdown/prereview are `Mount`-only or
+  use a distinct `OnConnect`, and devbox-dash's own triple is the **pre-B1 pattern** — half of
+  it (`OnConnect{ hub.register(ctx.Session()) }` + the hub) is exactly the sync.Map handle
+  registry that [B1 / livetemplate#485](https://github.com/livetemplate/livetemplate/pull/485)
+  already retired. The residual boilerplate is just `Refresh(){ return c.Mount() }`, and that
+  turned out to be an **anti-pattern, not a primitive to bless**: `Mount` does connect-time work
+  (`Subscribe`, `IsInitialMount`-guarded setup) that must not repeat on every fan-out tick, so a
+  push-refresh action must reload data *only* — as the shipped `live-dashboard` example already
+  demonstrates (`Mount` subscribes+snapshots; `Refresh` snapshots only). A `Load(state, ctx)`
+  hook was considered and **rejected**: merging `Mount` (load) with `OnConnect` (subscribe)
+  conflates two genuinely different jobs. → Shipped as a "the published action is not a
+  re-Mount" callout in `controller-pattern.md`; no new API.
 - **C2. Guard→mutate→error-into-state→reload** action shape — checklistkit prototyped its own
   `mutate()` helper (`ui/editor.go:185-201`); devbox-dash open-codes it
   (`approvals_controller.go`). Hard to generalize without imposing an opinion → propose only.
@@ -389,6 +398,9 @@ real, used capability.
 - **C7** — the view-helper arg-method boundary, documented in
   `docs/references/controller-pattern.md` and locked by `template_arg_methods_test.go` (nested
   works in both render phases; top-level errors). No API change.
+- **C1** — the "published action is not a re-Mount" lifecycle callout in
+  `docs/references/controller-pattern.md` (fan-out section): `Mount` = subscribe + load; the
+  published action = load only. No API change (the `Load` hook was considered and rejected).
 
 Sibling-repo companions (land as coordinated follow-up PRs, per the lockstep convention):
 

--- a/docs/design/boilerplate-reduction.md
+++ b/docs/design/boilerplate-reduction.md
@@ -380,9 +380,10 @@ real, used capability.
    pinned `ClientScriptURL`/`ClientStyleURL`, **no bundling**). Removes a test-package-in-
    production smell + the unpinned-`@latest` wire-incompat risk from *every* app and example.
 4. **B3 (Page / ListenAndServe)** — collapses the most raw lines; low conceptual risk.
-5. **Tier C** individually as they come up; **C4** rides along as a cheap removal, and **C7**
-   resolves to a documented pattern (view-helper sub-struct) with a regression anchor — no
-   core change, so it works on any published release.
+5. **Tier C** individually as they come up; **C4** rides along as a cheap removal, **C7**
+   resolves to a documented pattern (view-helper sub-struct) with a regression anchor, and
+   **C1** to a lifecycle callout — all three are docs/no-core-change, so they work on any
+   published release.
 
 ## Shipped with this document (core `livetemplate` repo)
 
@@ -393,14 +394,14 @@ real, used capability.
   reference example now threads `ctx` into its DB calls). No new API surface: `*Context`
   already embeds `context.Context`, so an explicit `ctx.Context()` accessor was deliberately
   *not* added (redundant).
+- **C1** — the "published action is not a re-Mount" lifecycle callout in
+  `docs/references/controller-pattern.md` (fan-out section): `Mount` = subscribe + load; the
+  published action = load only. No API change (the `Load` hook was considered and rejected).
 - **C4** — removed the duplicate `WithStore` `HandleOption`; the session store now binds only
   at construction via `WithSessionStore` (`template.go`; sweep tests in `handle_test.go` updated).
 - **C7** — the view-helper arg-method boundary, documented in
   `docs/references/controller-pattern.md` and locked by `template_arg_methods_test.go` (nested
   works in both render phases; top-level errors). No API change.
-- **C1** — the "published action is not a re-Mount" lifecycle callout in
-  `docs/references/controller-pattern.md` (fan-out section): `Mount` = subscribe + load; the
-  published action = load only. No API change (the `Load` hook was considered and rejected).
 
 Sibling-repo companions (land as coordinated follow-up PRs, per the lockstep convention):
 

--- a/docs/references/controller-pattern.md
+++ b/docs/references/controller-pattern.md
@@ -482,7 +482,7 @@ func (c *ChatController) RefreshMessages(state ChatState, ctx *livetemplate.Cont
 }
 ```
 
-`Mount` does **connect-time** work on top of loading: it `Subscribe`s to topics and runs any `IsInitialMount()`/`IsReconnect()`/`IsNewConnect()`-guarded setup (analytics, background goroutines, presence). A fan-out dispatch is an *action* — its connect-kind is `ConnectKindAction`, so all three of those helpers return `false`. Delegating the action to `Mount` therefore does the wrong thing on **both** halves: the unguarded `Subscribe` re-runs on every single broadcast (re-hitting the topic ACL each tick), while any connect-kind-guarded setup silently never runs. Keep the two jobs separate:
+`Mount` does **connect-time** work on top of loading: it `Subscribe`s to topics and runs any `IsInitialMount()`/`IsReconnect()`/`IsNewConnect()`-guarded setup (analytics, background goroutines, presence). A fan-out dispatch is an *action* — its connect-kind is `ConnectKindAction`, so all three of those helpers return `false`. Delegating the action to `Mount` therefore means any connect-kind-guarded setup **silently never runs**, and the unguarded `Subscribe` re-runs on every single broadcast — a cheap no-op for `ctx.SelfTopic()` (ACL-exempt and idempotent, as here), but a real per-tick ACL re-check for a developer topic like `Subscribe("room/" + id)`. Keep the two jobs separate:
 
 - **`Mount`** — subscribe + load. Runs on HTTP GET/POST, WS connect, WS reconnect.
 - **The published action** (`RefreshMessages`) — load only. Runs on every fan-out tick.

--- a/docs/references/controller-pattern.md
+++ b/docs/references/controller-pattern.md
@@ -473,6 +473,22 @@ func (c *ChatController) RefreshMessages(state ChatState, ctx *livetemplate.Cont
 }
 ```
 
+**The published action reloads data only — it is not a re-Mount.** Notice `RefreshMessages` re-reads the messages and nothing else. Reach for the tempting shortcut and it bites you:
+
+```go
+// ❌ Don't do this. A fan-out tick is neither a page load nor a connect.
+func (c *ChatController) RefreshMessages(state ChatState, ctx *livetemplate.Context) (ChatState, error) {
+    return c.Mount(state, ctx)
+}
+```
+
+`Mount` does **connect-time** work on top of loading: it `Subscribe`s to topics and runs any `IsInitialMount()`/`IsReconnect()`/`IsNewConnect()`-guarded setup (analytics, background goroutines, presence). A fan-out dispatch is an *action* — its connect-kind is `ConnectKindAction`, so all three of those helpers return `false`. Delegating the action to `Mount` therefore does the wrong thing on **both** halves: the unguarded `Subscribe` re-runs on every single broadcast (re-hitting the topic ACL each tick), while any connect-kind-guarded setup silently never runs. Keep the two jobs separate:
+
+- **`Mount`** — subscribe + load. Runs on HTTP GET/POST, WS connect, WS reconnect.
+- **The published action** (`RefreshMessages`) — load only. Runs on every fan-out tick.
+
+The shortcut *appears* to work when `Mount` is a pure data-load with no `Subscribe` or guarded setup (its fields just get re-set to the same values) — which is exactly why it's a trap: it breaks silently the day `Mount` grows a connect-time concern. The runnable [`live-dashboard`](https://github.com/livetemplate/docs/tree/main/examples/live-dashboard) example follows the split from the start: `Mount` subscribes then snapshots; its `Refresh` action snapshots only.
+
 **Ordering.** `Publish` queues onto a per-action drain. Call it **after** every `ctx.With*()` shallow-copy mutation; publishes queued before a `With*()` are stranded on the pre-copy Context and won't propagate.
 
 **Cap.** A single action can enqueue at most `MaxPublishesPerAction` (declared in `topic_context.go`) `Publish` calls before subsequent calls become hard errors.

--- a/docs/references/controller-pattern.md
+++ b/docs/references/controller-pattern.md
@@ -487,7 +487,7 @@ func (c *ChatController) RefreshMessages(state ChatState, ctx *livetemplate.Cont
 - **`Mount`** — subscribe + load. Runs on HTTP GET/POST, WS connect, WS reconnect.
 - **The published action** (`RefreshMessages`) — load only. Runs on every fan-out tick.
 
-The shortcut *appears* to work when `Mount` is a pure data-load with no `Subscribe` or guarded setup (its fields just get re-set to the same values) — which is exactly why it's a trap: it breaks silently the day `Mount` grows a connect-time concern. The runnable [`live-dashboard`](https://github.com/livetemplate/docs/tree/main/examples/live-dashboard) example follows the split from the start: `Mount` subscribes then snapshots; its `Refresh` action snapshots only.
+The shortcut *appears* to work when `Mount` is a pure data-load with no `Subscribe` or guarded setup (its fields just get re-set to the same values) — which is exactly why it's a trap: it breaks silently the day `Mount` grows a connect-time concern. So split them unconditionally, even while `Mount` is still a plain load; don't wait for the break. The runnable [`live-dashboard`](https://github.com/livetemplate/docs/tree/main/examples/live-dashboard) example follows the split from the start: `Mount` subscribes then snapshots; its `Refresh` action snapshots only.
 
 **Ordering.** `Publish` queues onto a per-action drain. Call it **after** every `ctx.With*()` shallow-copy mutation; publishes queued before a `With*()` are stranded on the pre-copy Context and won't propagate.
 


### PR DESCRIPTION
## What & why

Tier C item **C1** of the boilerplate-reduction pass (issue #483).

C1 was originally scoped as *"`Mount`/`OnConnect`/`Refresh` stub duplication across ~15 controllers → maybe a unified `Load` hook."* On re-audit the universality signal had **collapsed to one un-migrated app**:

- **checklistkit** uses a different notifier (0 lifecycle triples)
- **tinkerdown / prereview** are `Mount`-only or use a distinct `OnConnect` (not a refresh stub)
- **devbox-dash** is the only app with the triple — and half of it (`OnConnect{ hub.register(ctx.Session()) }` + the hub) is exactly the sync.Map handle-registry pattern that **B1 (#485) already retired**

The only residual boilerplate is `Refresh(){ return c.Mount() }` — and that turned out to be an **anti-pattern, not a primitive to bless**. `Mount` does connect-time work (`Subscribe`, `IsInitialMount`-guarded setup) that must not repeat on a fan-out tick. A fan-out dispatch is a `ConnectKindAction`, so delegating it to `Mount` re-runs the unguarded `Subscribe` on every broadcast while any connect-kind-guarded setup silently never fires. The shipped `live-dashboard` example already demonstrates the correct split (`Mount` subscribes+snapshots; `Refresh` snapshots only).

A `Load(state, ctx)` hook was **considered and rejected**: it conflates `Mount`'s load job with `OnConnect`'s subscribe job.

## Change (docs-only)

- `docs/references/controller-pattern.md` — a "the published action is not a re-Mount" callout in the fan-out section, with the ❌ shortcut, the precise failure mode, and the Mount-vs-action split.
- `docs/design/boilerplate-reduction.md` — records C1 as ✅ resolved (docs, no core change) and adds it to the shipped list.

No API change. Full Go suite green via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)