### PR TITLE
docs(serving): static assets alongside the app (Tier C · C9)

### DIFF
--- a/docs/design/boilerplate-reduction.md
+++ b/docs/design/boilerplate-reduction.md
@@ -342,11 +342,21 @@ example would return to its documented ~10 lines; checklistkit's 5 builders coll
   file tree drops to a standalone `html/template` injected as `template.HTML`
   (prereview `gitdiff/filetree.go:18-25`, noting *"the same native-`<details>` approach
   tinkerdown uses"*). → Propose recursive-partial support.
-- **C9. Static-asset passthrough alongside the `/` LiveHandler.** The SPA owns `/` and
-  `ServeMux` routes every unmatched GET to it, so relative asset paths inside rendered content
-  (`<img src="mockups/foo.png">`) receive the SPA HTML shell instead of bytes. prereview wraps
-  the LiveHandler with an allowlisted-extension, traversal-guarded static file server
-  (`server.go:447-524`, `staticFallback`). → Propose a framework static-passthrough wrapper.
+- **C9. Static-asset passthrough alongside the `/` LiveHandler.** ✅ **RESOLVED (docs, no new
+  API).** The original pitch was a framework static-passthrough wrapper. On audit the common
+  case — assets under a **known prefix** — is already handled by plain `net/http`:
+  `http.Handle("/assets/", http.StripPrefix(…, http.FileServer(http.Dir(…))))` +
+  `http.Handle("/", handler)`, and `ServeMux` longest-prefix-match routes them (shipped in the
+  `avatar-upload` example; `http.Dir` already supplies traversal safety). Two independent apps
+  confirm the prefix shape is the norm — tinkerdown routes everything under `/assets/` to its
+  own handler (`internal/server/server.go:504`), and each app hand-rolls its file handler only
+  for app-specific **policy** (embedded-first, extension allowlist, symlink eval), not for a
+  missing framework primitive. Only **prereview** needs the harder *arbitrary-path* fall-through
+  (`server.go:447-524`, `staticFallback`) because it serves user-authored content whose asset
+  paths collide with SPA routes — a single-consumer, code-review-tool-specific case. A generic
+  core wrapper would have to bake in one security policy that the two apps deliberately chose
+  differently, so the fall-through stays an app-`main` concern. → Shipped as a "Serving static
+  assets alongside the app" section in `controller-pattern.md`; no new API.
 
 ## Removal pass
 
@@ -381,9 +391,9 @@ real, used capability.
    production smell + the unpinned-`@latest` wire-incompat risk from *every* app and example.
 4. **B3 (Page / ListenAndServe)** — collapses the most raw lines; low conceptual risk.
 5. **Tier C** individually as they come up; **C4** rides along as a cheap removal, **C7**
-   resolves to a documented pattern (view-helper sub-struct) with a regression anchor, and
-   **C1** to a lifecycle callout — all three are docs/no-core-change, so they work on any
-   published release.
+   resolves to a documented pattern (view-helper sub-struct) with a regression anchor, **C1**
+   to a lifecycle callout, and **C9** to a static-assets composition note — all docs/no-core-
+   change, so they work on any published release.
 
 ## Shipped with this document (core `livetemplate` repo)
 
@@ -402,6 +412,11 @@ real, used capability.
 - **C7** — the view-helper arg-method boundary, documented in
   `docs/references/controller-pattern.md` and locked by `template_arg_methods_test.go` (nested
   works in both render phases; top-level errors). No API change.
+- **C9** — a "Serving static assets alongside the app" section in
+  `docs/references/controller-pattern.md`: the stdlib `ServeMux` prefix composition for the
+  common case, and why the arbitrary-path fall-through stays an app-`main` concern. No API
+  change (the static-passthrough wrapper was considered and rejected — one policy can't fit the
+  two apps' divergent choices).
 
 Sibling-repo companions (land as coordinated follow-up PRs, per the lockstep convention):
 

--- a/docs/references/controller-pattern.md
+++ b/docs/references/controller-pattern.md
@@ -546,6 +546,25 @@ handler := tmpl.Handle(controller, livetemplate.AsState(initialState))
 http.Handle("/", handler)
 ```
 
+### Serving static assets alongside the app
+
+The handler returned by `Handle` is mounted at `/`, where Go's `ServeMux` treats it as a **catch-all**: every request that doesn't match a more specific pattern falls through to it (including the WebSocket upgrade). To serve static files — images, CSS, downloads — next to your app, register them under a **more specific prefix** on the same mux. Longest-prefix-match routes those requests to the file server and everything else to the app:
+
+```go
+handler := tmpl.Handle(controller, livetemplate.AsState(initialState))
+
+// Files under /assets/… are served from ./assets. http.Dir already rejects
+// "../" traversal, so http.FileServer needs no extra guard.
+http.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("assets"))))
+
+// The app owns everything else.
+http.Handle("/", handler)
+```
+
+The prefix just has to be distinct from your app's own routes — `ServeMux` does the rest. This composition is plain `net/http`; the framework adds nothing here on purpose.
+
+**When a prefix isn't enough.** If your app renders content that references assets at **arbitrary top-level paths** — e.g. user-authored HTML with `<img src="diagram.png">` resolving to `/diagram.png` — those paths can collide with app routes, and `ServeMux` can't disambiguate them by prefix. That case needs a fall-through wrapper: *serve the file if it exists under a safe root, otherwise defer to the app handler.* Keep it a small wrapper in your own `main` rather than reaching for a framework primitive — the security-relevant policy (which extensions to serve, embedded vs. disk, symlink resolution) is app-specific, and `http.Dir` / `http.FileServer` already supply the traversal-safe file access it builds on.
+
 ## Upload Access
 
 For file upload configuration and handling, see [Upload Reference](uploads.md).


### PR DESCRIPTION
## What & why

Tier C item **C9** of the boilerplate-reduction pass (issue #483).

C9 was pitched as *"ship a first-class static-passthrough wrapper."* The audit found the capability already lives in `net/http`, so it resolves to **docs, no new API** (matching B1/C7/C1):

- **Common case — assets under a known prefix — is plain `ServeMux` composition.** `http.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("assets"))))` + `http.Handle("/", handler)`; longest-prefix-match routes assets to the file server and everything else (including the WS upgrade) to the app. `http.Dir` already supplies traversal safety. Shipped in the `avatar-upload` example; **taught nowhere** until now.
- **Two apps confirm the prefix shape is the norm** — tinkerdown routes `/assets/…` to its own handler (`internal/server/server.go:504`); each app hand-rolls its file handler only for app-specific *policy* (embedded-first, extension allowlist, symlink eval), not a missing primitive.
- **Only prereview needs the harder arbitrary-path fall-through** (`staticFallback`) — user-authored content whose asset paths collide with SPA routes. A single-consumer, code-review-tool-specific case whose security policy the two apps chose *differently*, so a generic core wrapper can't unify them. It stays an app-`main` concern.

The `WithStaticDir`/`StaticFallback` wrapper was **considered and rejected** (user-confirmed): one baked-in policy can't fit both apps.

## Change (docs-only)

- `docs/references/controller-pattern.md` — a "Serving static assets alongside the app" section under Registration: the prefix composition, the `http.Dir` traversal note, and when a prefix isn't enough.
- `docs/design/boilerplate-reduction.md` — records C9 ✅ resolved and adds it to the shipped list + sequencing note.

No API change. Full Go suite green via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)