### PR TITLE
docs(tier-c): resolve C6 + record C2/C3/C5 dispositions (Tier C batch)

### DIFF
--- a/docs/design/boilerplate-reduction.md
+++ b/docs/design/boilerplate-reduction.md
@@ -285,30 +285,44 @@ example would return to its documented ~10 lines; checklistkit's 5 builders coll
   hook was considered and **rejected**: merging `Mount` (load) with `OnConnect` (subscribe)
   conflates two genuinely different jobs. → Shipped as a "the published action is not a
   re-Mount" callout in `controller-pattern.md`; no new API.
-- **C2. Guard→mutate→error-into-state→reload** action shape — checklistkit prototyped its own
-  `mutate()` helper (`ui/editor.go:185-201`); devbox-dash open-codes it
-  (`approvals_controller.go`). Hard to generalize without imposing an opinion → propose only.
+- **C2. Guard→mutate→error-into-state→reload** action shape. ✅ **RESOLVED (no change).** The
+  underlying mechanism — return a `FieldError`/`MultiError` and the framework surfaces it into
+  state for the re-render — is already documented in `error-handling.md`. checklistkit's
+  `mutate()` helper (the cited evidence) has since been **removed** from the app, so even the
+  one prototype is gone. Generalizing the shape into a framework primitive would bake in an
+  opinion about *when* to reload and *how* to structure the guard; the primitives it composes
+  (`FieldError`, `Mount`-reload) are already first-class. → No primitive; mechanism already
+  documented.
 - **C3. Self-sync idiom** `ctx.Subscribe(ctx.SelfTopic())` + `ctx.Publish(ctx.SelfTopic(),
-  "Refresh", nil)` (todos, tinkerdown examples). Common but not universal → propose an opt-in
-  `WithSelfSync()` / auto-broadcast flag.
-- **C4. Removal candidate — duplicate session-store option.** Two ways to set the store:
-  `WithSessionStore` (a `New` Option) and `WithStore` (a `HandleOption`) — both defined in
-  `template.go`. Neither is used by any scanned example or app. They operate at different
-  levels (construction vs per-handler), so this is a genuine API decision, not a mechanical
-  dedup → **pick one to keep** (see Removal pass).
+  "Refresh", nil)`. ✅ **RESOLVED (no change).** The idiom is already taught in **three**
+  reference docs (`controller-pattern.md` fan-out section, `session.md` "Explicit Peer
+  Refresh", `error-handling.md`). A `WithSelfSync()` auto-broadcast flag was considered and
+  **rejected**: the explicit two-line idiom is discoverable and self-documenting, whereas an
+  implicit "everything fans out" flag hides the opt-in boundary the framework deliberately
+  makes explicit (see CLAUDE.md "peer fan-out is opt-in"). → No flag; idiom already documented.
+- **C4. Removal candidate — duplicate session-store option.** ✅ **RESOLVED (shipped, #488).**
+  Removed the `WithStore` `HandleOption`; the store now binds only at construction via
+  `WithSessionStore`. See the Removal pass and "Shipped" list below.
 - **C5. e2e harness capture gap** — checklistkit rebuilt a 276-line harness
   (`e2e_harness_test.go`) over the low-level `e2etest` primitives to get WS-frame + browser
-  console + server-log capture that the shared `e2etest.Setup` lacks. → Enrich the shared
-  harness with capture hooks.
+  console + server-log capture that the shared `e2etest.Setup` lacks. ⏭️ **DEFERRED to the
+  `lvt` repo.** The shared harness lives in `github.com/livetemplate/lvt` (`lvt/testing/`), not
+  in core livetemplate — enriching it with capture hooks is an `lvt`-repo change, out of scope
+  for this core-repo pass. → Track as an `lvt` follow-up.
 
 **Surfaced by the prereview scan (new):**
 
-- **C6. Disk-durable store distinct from `lvt:"persist"`.** The default in-memory
-  cookie-keyed SessionStore resets on every process relaunch, so a constantly-relaunched CLI
-  loses all persisted UI state: prereview `internal/review/uiprefs.go:11-27` writes prefs to
-  disk and reloads them every Mount/OnConnect (`controller.go:258`), and `controller.go:240-245`
-  does the same reload-from-disk-every-Mount for comments ("the CSV is the source of truth").
-  → Propose a disk-backed durable store, separate from session-continuity persistence.
+- **C6. Disk-durable store distinct from `lvt:"persist"`.** ✅ **RESOLVED (docs, no new API).**
+  The pitch was a disk-backed `SessionStore`. On audit the prereview evidence points the other
+  way: prereview *keeps* its session-continuity state (Base, SelectedFile, DraftBody) on
+  `lvt:"persist"` and moves **only** durable, per-user-global view prefs to a disk file
+  (`internal/review/uiprefs.go`) — by its own design an **app-domain preference store, not a
+  session-store gap**. And the `SessionStore` is keyed by cookie-derived `groupID`, so a disk
+  `SessionStore` couldn't serve per-user prefs (different device → different cookie → different
+  group) without re-keying. No app has hand-rolled a disk `SessionStore` — a speculative third
+  impl with zero demonstrated consumers. The real gap was that the *boundary* (session
+  continuity vs. durable app data) wasn't documented. → Shipped a "What the session store is
+  not for" section in `session.md`; no new API.
 - **C7. Template methods that accept arguments. ✅ RESOLVED (pattern, no core change).**
   The finding: prereview precomputes predicate results into `map[string]…` that the template
   looks up by key (`state.go:806-808,868-873`: `LineDisplay`, `BlockDiffStatus`,
@@ -390,10 +404,12 @@ real, used capability.
    pinned `ClientScriptURL`/`ClientStyleURL`, **no bundling**). Removes a test-package-in-
    production smell + the unpinned-`@latest` wire-incompat risk from *every* app and example.
 4. **B3 (Page / ListenAndServe)** — collapses the most raw lines; low conceptual risk.
-5. **Tier C** individually as they come up; **C4** rides along as a cheap removal, **C7**
-   resolves to a documented pattern (view-helper sub-struct) with a regression anchor, **C1**
-   to a lifecycle callout, and **C9** to a static-assets composition note — all docs/no-core-
-   change, so they work on any published release.
+5. **Tier C** individually as they come up. Most resolved to docs/no-core-change: **C4** a
+   cheap removal, **C7** a documented view-helper pattern with a regression anchor, **C1** a
+   lifecycle callout, **C9** a static-assets composition note, **C6** a session-durability
+   boundary note; **C2** and **C3** needed nothing (mechanism/idiom already documented); **C5**
+   is an `lvt`-repo follow-up. **C8** (recursive `{{template}}`) is the one remaining item with
+   a genuine cross-app capability gap — reserved for its own full treatment.
 
 ## Shipped with this document (core `livetemplate` repo)
 
@@ -417,6 +433,11 @@ real, used capability.
   common case, and why the arbitrary-path fall-through stays an app-`main` concern. No API
   change (the static-passthrough wrapper was considered and rejected — one policy can't fit the
   two apps' divergent choices).
+- **C6** — a "What the session store is not for" section in `docs/references/session.md`: the
+  session-continuity vs. durable-app-data boundary (the store resets on relaunch and is
+  cookie-keyed, so durable/per-user data belongs in your own store). No API change (a disk
+  `SessionStore` was considered and rejected — zero demonstrated consumers, and it wouldn't
+  serve prereview's actual per-user need anyway).
 
 Sibling-repo companions (land as coordinated follow-up PRs, per the lockstep convention):
 

--- a/docs/references/session.md
+++ b/docs/references/session.md
@@ -66,6 +66,15 @@ Fields tagged with `lvt:"persist"` follow this persistence schedule. Untagged fi
 
 This matches the pre-`lvt:"persist"` behavior where a path change always meant fresh state. Treat `lvt:"persist"` as "survives refresh," not "survives navigation."
 
+### What the session store is not for
+
+`lvt:"persist"` and the `SessionStore` provide **session continuity** — carrying UI state across a refresh or reconnect within a session group. They are not a durable application datastore:
+
+- The default `MemorySessionStore` is in-process. A **server relaunch loses every session**; the browser's cookie survives but now misses the fresh empty store, so persist fields fall back to their zero values and `Mount()` repopulates them. `RedisSessionStore` survives a relaunch, but its purpose is shared continuity across instances, not per-user durable storage.
+- Persistence is keyed by the cookie-derived `groupID`. State stored there is scoped to *that browser session*, not to a user — the same person on a second device (a different cookie) gets a different group.
+
+So data that must **outlive a process relaunch** or mean the same thing **across a user's sessions and devices** — durable user preferences, saved documents, anything you'd call "app data" — belongs in your own store (a file, your database), loaded in `Mount()`. Keep only genuine session-continuity state (filters, pagination, an in-progress draft) on `lvt:"persist"`. Mixing the two is the trap: a preference parked in the session silently resets on the next relaunch. The framework deliberately owns session continuity and leaves durable app data to the app.
+
 ### Explicit Peer Refresh
 
 ```go


### PR DESCRIPTION
## What & why

Batches the remaining **docs/no-code Tier C** items from the boilerplate-reduction pass (issue #483). Per maintainer decision, C8 (recursive `{{template}}`) is reserved for its own full treatment; everything else is recorded here.

### C6 — disk-durable store → ✅ RESOLVED (docs, no new API)
Pitched as a disk-backed `SessionStore`. The audit points the other way: prereview *keeps* its session-continuity state (Base, SelectedFile, DraftBody) on `lvt:"persist"` and moves **only** durable per-user-global view prefs to a disk file (`uiprefs.go`) — by its own design an app-domain preference store, not a session-store gap. The `SessionStore` is cookie-keyed (`groupID`), so a disk impl couldn't serve per-user prefs across devices anyway, and **no app hand-rolled one**. The real gap was that the *boundary* wasn't documented.
→ Adds a **"What the session store is not for"** section to `session.md` (continuity vs. durable app data).

### C2 — guard→mutate→reload → ✅ RESOLVED (no change)
`FieldError`/`MultiError` already document the error-into-state mechanism in `error-handling.md`; checklistkit's `mutate()` helper (the cited evidence) has since been **removed**. Generalizing would bake in an opinion; the composed primitives are already first-class.

### C3 — self-sync idiom → ✅ RESOLVED (no change)
`Subscribe(SelfTopic)` + `Publish(SelfTopic, …)` is taught in **three** reference docs. A `WithSelfSync()` flag was rejected — the explicit opt-in is deliberate (CLAUDE.md "peer fan-out is opt-in").

### C5 — e2e harness → ⏭️ DEFERRED to the `lvt` repo
The shared harness lives in `github.com/livetemplate/lvt` (`lvt/testing/`), not core. An `lvt`-repo follow-up.

Also marks C4's stale Tier-C list entry resolved (shipped in #488) for consistency.

## Change (docs-only)
- `docs/references/session.md` — new "What the session store is not for" section.
- `docs/design/boilerplate-reduction.md` — C2/C3/C4/C5/C6 entries updated + C6 added to Shipped list + sequencing note.

No API change. Full Go suite green via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)