### PR TITLE
docs(proposal): recursive {{template}} support design (Tier C · C8)

### DIFF
--- a/docs/design/boilerplate-reduction.md
+++ b/docs/design/boilerplate-reduction.md
@@ -351,11 +351,17 @@ example would return to its documented ~10 lines; checklistkit's 5 builders coll
   `{{.lvt.AriaInvalid "field"}}` is exactly this pattern (`.lvt` is a struct value in the map).
   → **Resolution: document the view-helper pattern (guide + example), keep a regression anchor.
   No core API change.**
-- **C8. Recursive `{{template}}` support (cross-app: prereview + tinkerdown).** livetemplate
-  flattens `{{template}}` calls at parse time, which overflows on recursion, so a recursive
-  file tree drops to a standalone `html/template` injected as `template.HTML`
-  (prereview `gitdiff/filetree.go:18-25`, noting *"the same native-`<details>` approach
-  tinkerdown uses"*). → Propose recursive-partial support.
+- **C8. Recursive `{{template}}` support (cross-app: prereview + tinkerdown).** 📝 **DESIGN
+  PROPOSED — awaiting greenlight.** livetemplate flattens `{{template}}` calls at parse time with
+  no cycle guard, so a self-referential template stack-overflows during `Parse`; a recursive file
+  tree drops to a standalone `html/template` injected as opaque `template.HTML` (prereview
+  `internal/review/filetree.go`, noting *"the same native-`<details>` approach tinkerdown uses"*),
+  which removes the whole subtree from reactive diffing. The one Tier C item with a genuine
+  capability gap and ≥2 hand-rolled consumers → **full design written**:
+  [`docs/proposals/recursive-templates-proposal.md`](../proposals/recursive-templates-proposal.md).
+  Recommended approach: route recursive invocations through the runtime nested-`TreeNode` path
+  `{{range}}` already uses (bounded by data depth, not parse-time expansion). Needs maintainer
+  greenlight before implementation.
 - **C9. Static-asset passthrough alongside the `/` LiveHandler.** ✅ **RESOLVED (docs, no new
   API).** The original pitch was a framework static-passthrough wrapper. On audit the common
   case — assets under a **known prefix** — is already handled by plain `net/http`:

--- a/docs/design/boilerplate-reduction.md
+++ b/docs/design/boilerplate-reduction.md
@@ -352,7 +352,7 @@ example would return to its documented ~10 lines; checklistkit's 5 builders coll
   → **Resolution: document the view-helper pattern (guide + example), keep a regression anchor.
   No core API change.**
 - **C8. Recursive `{{template}}` support (cross-app: prereview + tinkerdown).** 📝 **DESIGN
-  PROPOSED — awaiting greenlight.** livetemplate flattens `{{template}}` calls at parse time with
+  APPROVED (2026-07-15) — Phase 1 next.** livetemplate flattens `{{template}}` calls at parse time with
   no cycle guard, so a self-referential template stack-overflows during `Parse`; a recursive file
   tree drops to a standalone `html/template` injected as opaque `template.HTML` (prereview
   `internal/review/filetree.go`, noting *"the same native-`<details>` approach tinkerdown uses"*),
@@ -360,8 +360,10 @@ example would return to its documented ~10 lines; checklistkit's 5 builders coll
   capability gap and ≥2 hand-rolled consumers → **full design written**:
   [`docs/proposals/recursive-templates-proposal.md`](../proposals/recursive-templates-proposal.md).
   Recommended approach: route recursive invocations through the runtime nested-`TreeNode` path
-  `{{range}}` already uses (bounded by data depth, not parse-time expansion). Needs maintainer
-  greenlight before implementation.
+  `{{range}}` already uses (bounded by data depth, not parse-time expansion). Approach A
+  (selective), a max-depth guard erroring uniformly, and content-hash `data-key` fallback are all
+  decided (see the proposal's § Decisions); Phase 1 (crash → `ParseError`) is independently
+  shippable and up next.
 - **C9. Static-asset passthrough alongside the `/` LiveHandler.** ✅ **RESOLVED (docs, no new
   API).** The original pitch was a framework static-passthrough wrapper. On audit the common
   case — assets under a **known prefix** — is already handled by plain `net/http`:
@@ -414,8 +416,9 @@ real, used capability.
    cheap removal, **C7** a documented view-helper pattern with a regression anchor, **C1** a
    lifecycle callout, **C9** a static-assets composition note, **C6** a session-durability
    boundary note; **C2** and **C3** needed nothing (mechanism/idiom already documented); **C5**
-   is an `lvt`-repo follow-up. **C8** (recursive `{{template}}`) is the one remaining item with
-   a genuine cross-app capability gap — reserved for its own full treatment.
+   is an `lvt`-repo follow-up. **C8** (recursive `{{template}}`) is the one item with a genuine
+   cross-app capability gap — got its own full design, now **approved** with Phase 1 ready to
+   implement.
 
 ## Shipped with this document (core `livetemplate` repo)
 

--- a/docs/design/boilerplate-reduction.md
+++ b/docs/design/boilerplate-reduction.md
@@ -351,13 +351,15 @@ example would return to its documented ~10 lines; checklistkit's 5 builders coll
   `{{.lvt.AriaInvalid "field"}}` is exactly this pattern (`.lvt` is a struct value in the map).
   → **Resolution: document the view-helper pattern (guide + example), keep a regression anchor.
   No core API change.**
-- **C8. Recursive `{{template}}` support (cross-app: prereview + tinkerdown).** 📝 **DESIGN
-  APPROVED (2026-07-15) — Phase 1 next.** livetemplate flattens `{{template}}` calls at parse time with
-  no cycle guard, so a self-referential template stack-overflows during `Parse`; a recursive file
-  tree drops to a standalone `html/template` injected as opaque `template.HTML` (prereview
-  `internal/review/filetree.go`, noting *"the same native-`<details>` approach tinkerdown uses"*),
-  which removes the whole subtree from reactive diffing. The one Tier C item with a genuine
-  capability gap and ≥2 hand-rolled consumers → **full design written**:
+- **C8. Recursive `{{template}}` support (direct consumer: prereview; latent: tinkerdown).**
+  📝 **DESIGN APPROVED (2026-07-15) — Phase 1 next.** livetemplate flattens `{{template}}` calls at
+  parse time with no cycle guard, so a self-referential template stack-overflows during `Parse`; a
+  recursive file tree drops to a standalone `html/template` injected as opaque `template.HTML`
+  (prereview `internal/review/filetree.go`), which removes the whole subtree from reactive diffing.
+  tinkerdown corroborates the recursive-tree UI pattern (recursive-Go `writeNavNode` →
+  native-`<details>`) but serves static HTML, so it's a latent case, not a second bug victim. The
+  one Tier C item with a genuine capability gap and a documented direct consumer → **full design
+  written**:
   [`docs/proposals/recursive-templates-proposal.md`](../proposals/recursive-templates-proposal.md).
   Recommended approach: route recursive invocations through the runtime nested-`TreeNode` path
   `{{range}}` already uses (bounded by data depth, not parse-time expansion). Approach A

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -137,7 +137,9 @@ are routing recursion through the path that works, not inventing a new one.
   recursive invocations (see "Selective" below).
 - **Con:** the deepest change — parse must detect recursion and emit a runtime boundary; the
   framework must retain named templates as pre-built sub-trees and instantiate them per
-  invocation; needs an eval-time depth/cycle guard for pathological data.
+  invocation; needs an eval-time depth guard for pathological *data* (a self-referential
+  `.Children` pointer cycle, distinct from a merely-deep-but-finite tree — see Phase 4 for how
+  max-depth covers both shapes).
 
 ### Approach C — A sanctioned opaque-HTML subtree primitive (lighter fallback)
 
@@ -327,9 +329,16 @@ Three categories, each a hard gate — no phase merges with a category left as "
 - [ ] **Phase 4 — Eval-time depth guard.** Confirm the existing per-instance
       `GetStructureFingerprint()` lazy cache already covers deep trees (no new per-name cache — see
       §5); add a max-depth option with a clear error, applying the same on initial render *and* live
-      update (Open question 2). **Unit:** deep tree stays O(nodes); a leaf⇄directory branch flip
-      re-sends statics correctly; cyclic data errors cleanly on both render and update paths. **E2E:**
-      a data-driven cycle surfaces the max-depth error in the browser without wedging the session.
+      update (Open question 2). **Invariant that makes max-depth sufficient:** depth is incremented
+      **before** the guard check on every recursion level, so a Go-value **pointer cycle** in
+      `.Children` (a self-referential node — a shorter loop than max-depth) is still caught: each
+      traversal step advances depth and eventually trips the ceiling rather than infinite-looping.
+      This is the deliberate tradeoff behind choosing max-depth over a pointer-visited set (Decision
+      2): simpler, at the cost of erroring on a legitimately-deep-but-finite tree too — hence
+      configurable. **Unit:** deep tree stays O(nodes); a leaf⇄directory branch flip re-sends statics
+      correctly; a **self-referential-pointer `.Children`** errors at max-depth (not a hang); cyclic
+      data errors cleanly on both render and update paths. **E2E:** a data-driven cycle surfaces the
+      max-depth error in the browser without wedging the session.
 - [ ] **Phase 5 — Minimal-update proof + benchmarks + docs.** **Unit + Bench:** assert a deep
       single-node change emits one `["u", key, …]` and not a full re-send (the payoff);
       `BenchmarkRecursiveUpdate` + the wire-size assertion land here with the opaque-`template.HTML`
@@ -384,7 +393,8 @@ Three categories, each a hard gate — no phase merges with a category left as "
 ## Decisions
 
 The three headline questions this proposal solicited are **decided** (maintainer sign-off,
-2026-07-15):
+2026-07-15). *(Items keep their original open-question numbers; decided ones are pulled up here,
+so the numbering below is 1/2/4 and § Remaining design notes keeps 3/5/6.)*
 
 1. ✅ **Selective, not uniform.** Convert *only* recursive invocations to runtime boundaries; keep
    flattening non-recursive ones. Uniform runtime invocation is conceptually cleaner but a much

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -1,8 +1,9 @@
 # Recursive `{{template}}` Support
 
-**Status:** Proposed
+**Status:** Approved (2026-07-15) — the three headline decisions are settled (see § Decisions);
+Phase 1 (crash → `ParseError` guard) is ready to implement.
 **Tracking:** Tier C item C8 of the boilerplate-reduction pass (issue #483)
-**Audience:** livetemplate maintainers — a design to review before any implementation.
+**Audience:** livetemplate maintainers — the approved design of record for implementation.
 
 ## TL;DR
 
@@ -309,23 +310,29 @@ position-distinct nested nodes so this per-position logic engages — see Open q
 - **Performance:** deep trees render O(nodes); positionally-cached statics keep the wire cost
   near dynamics-only after first render — strictly better than today's full-string re-send.
 
-## Open questions
+## Decisions
 
-1. **Selective vs. uniform.** Recommended: convert *only* recursive invocations to runtime
-   boundaries (keep flattening non-recursive ones). Uniform runtime invocation is conceptually
-   cleaner but a much larger blast radius and a perf regression for the common flat case. Confirm
-   selective.
-2. **Depth guard: max-depth vs. pointer-visited.** Recommended max-depth (simpler, clearer error).
-   Default value + option name to settle. Also settle **what exceeding max-depth does on a live
-   update** (not just initial render): error the whole render, or degrade gracefully (truncate the
-   subtree and flag)? Recommend erroring uniformly so behavior doesn't diverge between render and
-   update — but confirm, since a runaway update shouldn't necessarily blank a working page.
+The three headline questions this proposal solicited are **decided** (maintainer sign-off,
+2026-07-15):
+
+1. ✅ **Selective, not uniform.** Convert *only* recursive invocations to runtime boundaries; keep
+   flattening non-recursive ones. Uniform runtime invocation is conceptually cleaner but a much
+   larger blast radius and a perf regression for the common flat case — not worth it.
+2. ✅ **Max-depth guard, erroring uniformly.** Use a configurable **max-depth** (simpler and a
+   clearer error than a pointer-visited set), enforced identically on initial render **and** live
+   update — exceeding it errors the render rather than degrading/truncating, so behavior doesn't
+   diverge between the two paths. (Default value + option name to settle during Phase 4; a
+   partial-render fallback can be revisited later if the hard-error UX proves too blunt.)
+4. ✅ **`data-key` falls back like `{{range}}`.** Do *not* require an explicit `data-key` inside a
+   runtime-invoked template; fall back to content-hash keys exactly as `{{range}}` does today.
+   Document that an explicit `data-key` is strongly preferred for large or reorderable trees.
+
+## Remaining design notes
+
+These are implementation invariants / scope boundaries, not open decisions:
+
 3. **Mutual recursion / indirect cycles** (`a`→`b`→`a`). The design handles it (the cycle set can
-   contain multiple names), but confirm test coverage expectations.
-4. **`data-key` requirement.** Targeted updates need stable node identity. Should the framework
-   *require* a `data-key` inside a runtime-invoked template (error if absent), or fall back to
-   content-hash keys as `{{range}}` does today? Recommend: fall back like range, document that
-   explicit `data-key` is strongly preferred for large trees.
+   contain multiple names); confirm test coverage during Phase 1/3.
 5. **Depth-change ⇒ position-distinct nested nodes.** The "no client changes" result (§6) rests on
    the eval producing genuinely position-distinct nested nodes at each recursion level, so the
    existing per-position `ClientNeedsStatics(nil, new)` fires for a *newly-materialized* level and

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -264,8 +264,8 @@ position-distinct nested nodes so this per-position logic engages — see Open q
       *between-render depth change* (grow and shrink) asserting a newly-materialized level receives
       its statics and a removed one is dropped — the Open-question-5 invariant.
 - [ ] **Phase 4 — Fingerprint reuse + eval-time depth guard.** Per-name fingerprint caching;
-      max-depth option with a clear error. Tests: deep tree stays O(nodes); cyclic data errors
-      cleanly.
+      max-depth option with a clear error, applying the same on initial render *and* live update
+      (Open question 2). Tests: deep tree stays O(nodes); cyclic data errors cleanly on both paths.
 - [ ] **Phase 5 — Minimal-update proof + docs.** Assert a deep single-node change emits one
       `["u", key, …]` and not a full re-send (the payoff). Update `template-support-matrix.md` and
       `current-limitations.md`; add a recipe. **Companion:** migrate prereview's `filetree.go`
@@ -294,7 +294,10 @@ position-distinct nested nodes so this per-position logic engages — see Open q
    cleaner but a much larger blast radius and a perf regression for the common flat case. Confirm
    selective.
 2. **Depth guard: max-depth vs. pointer-visited.** Recommended max-depth (simpler, clearer error).
-   Default value + option name to settle.
+   Default value + option name to settle. Also settle **what exceeding max-depth does on a live
+   update** (not just initial render): error the whole render, or degrade gracefully (truncate the
+   subtree and flag)? Recommend erroring uniformly so behavior doesn't diverge between render and
+   update — but confirm, since a runaway update shouldn't necessarily blank a working page.
 3. **Mutual recursion / indirect cycles** (`a`→`b`→`a`). The design handles it (the cycle set can
    contain multiple names), but confirm test coverage expectations.
 4. **`data-key` requirement.** Targeted updates need stable node identity. Should the framework
@@ -308,5 +311,5 @@ position-distinct nested nodes so this per-position logic engages — see Open q
    assumes it and Phase 3's depth-1..N parity tests must exercise depth *growth and shrink between
    renders*, not just static depths. Confirm the eval reuses the range item-instantiation path,
    which already assigns position-distinct child nodes.
-5. **Dynamic invocation** (`{{template (printf …) .}}`) remains a documented fallback
+6. **Dynamic invocation** (`{{template (printf …) .}}`) remains a documented fallback
    (`current-limitations.md:15,19`); recursion support does not change that — out of scope.

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -9,11 +9,16 @@ Phase 1 (crash → `ParseError` guard) is ready to implement.
 
 **Problem.** livetemplate inlines every `{{template "name" .}}` invocation into one flat
 template at parse time. A self-referential template (a folder tree, a nav tree, a threaded
-comment list) expands forever and **stack-overflows during `Parse`**. Two independent apps
-(prereview, tinkerdown) work around it by rendering the recursive part with standalone
-`html/template` and injecting the result as opaque `template.HTML` — which **removes the whole
-subtree from livetemplate's reactive diffing**: the entire tree is re-rendered and re-sent on
-every keystroke, defeating the framework's core value.
+comment list) expands forever and **stack-overflows during `Parse`**. **prereview** hits this
+directly: it wants a reactive folder tree, cannot use a recursive livetemplate template, and
+works around it by rendering the tree with standalone `html/template` and injecting the result as
+opaque `template.HTML` — which **removes the whole subtree from livetemplate's reactive diffing**:
+the entire tree is re-rendered and re-sent on every keystroke, defeating the framework's core
+value. **tinkerdown** corroborates that recursive tree UI is a recurring need — its sidebar nav is
+built by a recursive Go function emitting the same native-`<details>` markup — though its pages are
+currently served as static HTML (not livetemplate-reactive), so it is a latent case, not a second
+victim of the flatten bug. The core justification rests on the objective crash + prereview's
+documented reactive-diffing loss, not on consumer count.
 
 **Solution (recommended).** Stop inlining *recursive* invocations. Detect a self-referential
 invocation graph at parse time (the guard that's missing today), and evaluate those invocations
@@ -62,8 +67,8 @@ the crash into a clear `ParseError`, independent of whether the rest of the desi
 
 ### The real cost: opaque HTML defeats reactive diffing
 
-Both apps that need recursion escape-hatch identically. prereview
-(`internal/review/filetree.go`) is the clearest:
+The one app that hits this inside a livetemplate reactive tree, prereview
+(`internal/review/filetree.go`), shows the cost sharply:
 
 ```go
 // fileBrowserTmpl is a standalone html/template (NOT processed by livetemplate)
@@ -87,17 +92,27 @@ That is the boilerplate C8 removes: a hand-maintained standalone template, a zer
 large, frequently-touched structure (a repo's whole file tree) where incremental updates matter
 most.
 
-### Evidence (≥2 independent consumers)
+### Evidence
 
-- **prereview** — `internal/review/filetree.go` + `filetree.tmpl` (`treeNode` recurses on
-  `.Children`; native `<details>`; injected as `template.HTML`).
-- **tinkerdown** — nested nav built recursively (`internal/site/manager.go:115`,
-  `buildNavPageNode` recurses into children), rendered via the same native-`<details>` opaque-HTML
-  approach prereview's comment cross-references.
+- **prereview (the direct consumer)** — `internal/review/filetree.go` + `filetree.tmpl`
+  (`treeNode` recurses on `.Children`; native `<details>`; `data-key` on every node; injected as
+  `template.HTML`). It runs inside a livetemplate reactive tree, so the opaque slot is a real,
+  measured loss of incremental diffing. The `filetree.go` comment states the cause verbatim
+  ("livetemplate flattens `{{template}}` calls at parse time, which overflows on recursion").
+- **tinkerdown (corroborating pattern, not a bug victim)** — the sidebar nav is rendered by a
+  recursive **Go** function (`writeNavNode`, `internal/server/server.go:3660`, recursing over
+  `node.Children` and emitting the same native-`<details>` markup); the tree it walks is built by
+  `buildNavPageNode` (`internal/site/manager.go:121`). But tinkerdown serves pages as **static
+  HTML** (`servePage`: *"For now, just serve the static HTML"*) — the nav is never a livetemplate
+  reactive tree, and stdlib `html/template` would handle its recursion fine — so tinkerdown did
+  **not** hit the flatten bug. It confirms recursive-tree UI is a recurring need and that
+  native-`<details>` is the idiom, and it would become a real consumer *if* it made the nav
+  reactive — a latent case, kept separate from the direct evidence per this project's
+  "don't bundle unverified downstream-impact claims" discipline.
 
-This is the one Tier C item with two independent hand-rolled consumers *and* a genuine capability
-gap (not a discoverability or docs gap) — which is why it earns a real implementation rather than
-a doc note.
+This is the one Tier C item with a documented direct consumer (prereview) *and* a genuine
+capability gap (not a discoverability or docs gap) — the objective parse-time crash plus
+prereview's reactive-diffing loss are what earn it a real implementation rather than a doc note.
 
 ---
 
@@ -175,8 +190,9 @@ When evaluation reaches a runtime invocation boundary:
 1. Resolve the invoked name against the registry (step 2).
 2. Evaluate that sub-tree against the invocation's **pipe value** as the new dot. `$` naturally
    rebinds to that dot per invocation — matching Go's rule that a template calling itself drops
-   the caller's `$` (prereview relies on this: it resolves per-node display state at build time so
-   the recursive body never needs the root `$`).
+   the caller's `$`. This is a non-issue for prereview: its recursive `treeNode` body never
+   references root `$` (its only `$` — `{{$.FileFilter}}` — is in the non-recursive `fileBrowser`
+   wrapper), so the rebind doesn't change its behavior.
 3. Emit the result as a **nested `TreeNode`** under the current node (the same slot a nested tree
    already occupies).
 
@@ -266,33 +282,83 @@ position-distinct nested nodes so this per-position logic engages — see Open q
 
 ## Implementation phases
 
-> Outline for review — not yet a commitment. Each phase is one focused change with its own tests.
+> Outline for review — not yet a commitment. Each phase is one focused change. **Every phase must
+> ship its own tests across the three categories below; a phase is not done until its slice of the
+> test matrix is green.**
+
+### Test strategy (applies to every phase)
+
+Three categories, each a hard gate — no phase merges with a category left as "later":
+
+- **Correctness unit tests** (`internal/…`, in-repo): parse/build/eval invariants against
+  in-memory fixtures and `fstest`. Every phase adds the unit tests for the behavior it introduces.
+- **E2E integration tests** (chromedp, black-box in the `lvt` repo's `e2e/livetemplate_core_test.go`
+  suite per CLAUDE.md): a real browser drives a recursive-tree page; the harness captures **browser
+  console logs, server stderr, WebSocket frames, and rendered HTML** so a failure is diagnosable.
+  Asserts the payoff end-to-end — a deep single-node change delivers one `["u", key, …]` frame, not
+  a full re-send — and that expand/collapse/reorder at depth behave.
+- **Performance benchmarks** (`go test -bench`, checked in): `BenchmarkRecursiveRender` (first
+  render, O(nodes)) and `BenchmarkRecursiveUpdate` (one deep node changes) at depths/breadths
+  {10, 100, 1000 nodes}, plus a wire-size assertion (updated-bytes ≪ full-render bytes). Guards the
+  central claim that recursion is O(nodes) render + near-dynamics-only wire, and catches regressions
+  vs. today's opaque full-string re-send as a baseline row.
+
+### Core library
 
 - [ ] **Phase 1 — Defensive cycle guard (independently shippable).** Add visited-set/depth
       detection to `walkAndFlatten` so a self-referential template returns a clear
       `ParseError` ("recursive template requires runtime invocation; see …") instead of
       stack-overflowing. Ships value on its own (crash → diagnosable error) and lays the parse-time
-      detection Phase 2 builds on. Tests: direct + indirect cycle → error, not panic.
+      detection Phase 2 builds on. **Unit:** direct + indirect (`a`→`b`→`a`) cycle → error not
+      panic; a fuzz seed of self-referential sources. **E2E:** n/a (parse-time). **Bench:** n/a.
 - [ ] **Phase 2 — Retain runtime-invoked templates as sub-trees.** Build + register the named
-      body as a reusable sub-tree for templates flagged recursive in Phase 1. No rendering yet;
-      unit-test the registry + sub-tree build.
+      body as a reusable sub-tree for templates flagged recursive in Phase 1. No rendering yet.
+      **Unit:** registry membership + sub-tree build for direct and mutual recursion; non-recursive
+      `{{template}}` still flattens byte-for-byte (golden parity). **Bench:** compile-time cost of
+      registration is negligible vs. flatten.
 - [ ] **Phase 3 — Runtime invocation → nested `TreeNode`.** Wire eval to instantiate the sub-tree
-      per invocation against the pipe dot and splice the nested tree. Tests: a recursive fixture's
+      per invocation against the pipe dot and splice the nested tree. **Unit:** a recursive fixture's
       rendered **HTML content** matches the equivalent stdlib `html/template` output at depths 1..N
       (content parity — the *wire format* deliberately differs: nested `TreeNode` vs. inlined
-      string), plus a
-      *between-render depth change* (grow and shrink) asserting a newly-materialized level receives
-      its statics and a removed one is dropped — the Open-question-5 invariant.
+      string); a *between-render depth change* (grow and shrink) asserting a newly-materialized level
+      receives its statics and a removed one is dropped (Open-question-5 invariant). **E2E:** a
+      chromedp recursive-tree page renders correctly at depth and survives expand/collapse. **Bench:**
+      `BenchmarkRecursiveRender` lands here.
 - [ ] **Phase 4 — Eval-time depth guard.** Confirm the existing per-instance
       `GetStructureFingerprint()` lazy cache already covers deep trees (no new per-name cache — see
       §5); add a max-depth option with a clear error, applying the same on initial render *and* live
-      update (Open question 2). Tests: deep tree stays O(nodes); a leaf⇄directory branch flip
-      re-sends statics correctly; cyclic data errors cleanly on both paths.
-- [ ] **Phase 5 — Minimal-update proof + docs.** Assert a deep single-node change emits one
-      `["u", key, …]` and not a full re-send (the payoff). Update `template-support-matrix.md` and
-      `current-limitations.md`; add a recipe. **Companion:** migrate prereview's `filetree.go`
-      off the standalone-template escape hatch onto a native recursive `{{template}}` (proves the
-      boilerplate is actually removed; lands per the lockstep convention once a release ships).
+      update (Open question 2). **Unit:** deep tree stays O(nodes); a leaf⇄directory branch flip
+      re-sends statics correctly; cyclic data errors cleanly on both render and update paths. **E2E:**
+      a data-driven cycle surfaces the max-depth error in the browser without wedging the session.
+- [ ] **Phase 5 — Minimal-update proof + benchmarks + docs.** **Unit + Bench:** assert a deep
+      single-node change emits one `["u", key, …]` and not a full re-send (the payoff);
+      `BenchmarkRecursiveUpdate` + the wire-size assertion land here with the opaque-`template.HTML`
+      approach as the baseline row. **E2E:** the full black-box gate (console + server + WS + HTML
+      capture) proving the incremental-update path end-to-end. **Docs:** correct the
+      `template-support-matrix.md` "Circular template references" row (failure mode), update
+      `current-limitations.md`, add a recipe.
+
+### Companion migrations (dependent repos — land per the lockstep convention once a release ships)
+
+- [ ] **Phase 6 — prereview: remove the escape hatch (true workaround removal).** Replace
+      `FileBrowserHTML`/`fileBrowserTmpl` (`internal/review/filetree.go`) with a native recursive
+      `{{template "treeNode"}}` inside the reactive `prereview.tmpl`, deleting the standalone
+      `html/template` and the zero-arg `template.HTML` method. **Acceptance:** the file tree now
+      receives incremental `["u", key, …]` updates (verify via WS-frame capture in prereview's e2e
+      harness that selecting a deep file no longer re-sends the whole tree); existing prereview e2e
+      stays green; a benchmark/measurement of update bytes before/after documents the win.
+- [ ] **Phase 7 — tinkerdown: make the sidebar nav reactive (latent case → real consumer).**
+      Migrate `writeNavNode` (recursive-Go `<details>` string building, `internal/server/server.go`)
+      to a native recursive livetemplate `{{template}}`. **Note the honest scope:** tinkerdown
+      currently serves pages as static HTML (`servePage`'s *"Add WebSocket support for interactivity"*
+      TODO), so this phase also entails routing the nav through a livetemplate reactive tree — a
+      larger change than prereview's, and optional to the core feature. It earns its place by
+      proving recursion on a *second, independently-authored* app and retiring the hand-rolled
+      recursive-Go renderer. **Acceptance:** nav renders identically to the `writeNavNode` output
+      (visual-regression screenshot parity), and a nav change (e.g. active-page move) produces a
+      targeted update; tinkerdown e2e green. If reactive nav proves out of scope for tinkerdown's
+      roadmap, this phase degrades to "tinkerdown *could* adopt it" and is dropped without blocking
+      C8 — the core feature stands on Phase 6.
 
 ---
 
@@ -303,6 +369,11 @@ position-distinct nested nodes so this per-position logic engages — see Open q
   → nested `TreeNode`), an eval-time depth guard. `internal/build/fingerprint.go` is **reused
   as-is** — the existing per-instance lazy cache already covers deep recursion (§5); no per-name
   cache is added. `internal/diff` and the **client are unchanged** (reuses nested-tree wire format).
+  Tests span the core repo (unit + benchmarks), the `lvt` repo (chromedp e2e per CLAUDE.md), and —
+  for the companion migrations — the **prereview** and **tinkerdown** repos (Phases 6–7).
+- **Cross-repo work:** prereview (Phase 6, escape-hatch removal — a genuine simplification) and
+  tinkerdown (Phase 7, nav→reactive — a larger, optional migration). Both land per the lockstep
+  convention *after* a livetemplate release ships the feature; neither blocks the core phases.
 - **Backward compatibility:** high. The selective split means non-recursive composition keeps the
   existing flatten path byte-for-byte; only cyclic invocation graphs take the new path.
 - **Biggest risk:** the eval-time sub-tree instantiation is new plumbing. Mitigated by leaning on

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -1,0 +1,312 @@
+# Recursive `{{template}}` Support
+
+**Status:** Proposed
+**Tracking:** Tier C item C8 of the boilerplate-reduction pass (issue #483)
+**Audience:** livetemplate maintainers — a design to review before any implementation.
+
+## TL;DR
+
+**Problem.** livetemplate inlines every `{{template "name" .}}` invocation into one flat
+template at parse time. A self-referential template (a folder tree, a nav tree, a threaded
+comment list) expands forever and **stack-overflows during `Parse`**. Two independent apps
+(prereview, tinkerdown) work around it by rendering the recursive part with standalone
+`html/template` and injecting the result as opaque `template.HTML` — which **removes the whole
+subtree from livetemplate's reactive diffing**: the entire tree is re-rendered and re-sent on
+every keystroke, defeating the framework's core value.
+
+**Solution (recommended).** Stop inlining *recursive* invocations. Detect a self-referential
+invocation graph at parse time (the guard that's missing today), and evaluate those invocations
+at **runtime as a nested `TreeNode`** — the same mechanism `{{range}}` already uses. Recursion
+then terminates on the **data** (a finite tree of nodes), not on parse-time text expansion, and
+each level is a first-class diffable subtree. Non-recursive invocations keep flattening
+unchanged (zero regression risk to existing composition).
+
+**Non-goal.** This is not "arbitrary Go template recursion at any cost." It's "let a template
+call itself over a finite data structure and still get minimal updates."
+
+---
+
+## The Problem
+
+### What breaks today
+
+`{{template "name" pipe}}` is never a runtime construct. At parse time
+(`template.go:1195-1207`, `parseInternal`), `parse.FlattenTemplate` (`internal/parse/flatten.go`)
+**textually inlines** each invocation's body into the caller and replaces the template source
+with the flattened string. The `TemplateInvokeConstruct` named in CLAUDE.md is conceptual — it
+exists in no Go source; the real work is stdlib `*parse.TemplateNode` handling in
+`walkAndFlatten` (`flatten.go:286-325`).
+
+That routine looks the invoked template up by name (`flatten.go:288`) and **re-enters its body**
+(`flatten.go:315/322`) with **no visited-set, no depth counter, and no cycle check**. So:
+
+```
+{{define "treeNode"}}
+  <li>{{.Name}}<ul>{{range .Children}}{{template "treeNode" .}}{{end}}</ul></li>
+{{end}}
+```
+
+makes `walkAndFlatten` re-enter `treeNode`'s body endlessly, writing an infinitely long template
+string → **stack overflow at `Parse`**, before any `TreeNode`, evaluation, or fingerprint stage
+is reached. (The tree walker `walker.go:42-47` even returns a `ParseError` "template invocation
+found — should be flattened" if an invocation ever survives to tree-build time, confirming
+invocations are *only* ever inlined, never evaluated.)
+
+There is **no explicit "recursion unsupported" marker** in the docs; the support matrix
+(`template-support-matrix.md:174-179`) simply says composition is "automatically flattened,"
+which silently assumes a finite, acyclic invocation graph.
+
+### The real cost: opaque HTML defeats reactive diffing
+
+Both apps that need recursion escape-hatch identically. prereview
+(`internal/review/filetree.go`) is the clearest:
+
+```go
+// fileBrowserTmpl is a standalone html/template (NOT processed by livetemplate)
+// … because the folder tree is self-recursive ({{template "treeNode"}} calls
+// itself) and livetemplate flattens {{template}} calls at parse time, which
+// overflows on recursion. … the rendered markup is injected back into
+// prereview.tmpl as template.HTML — the same native-<details> approach
+// tinkerdown uses for its nested nav.
+func (s PrereviewState) FileBrowserHTML() template.HTML { … }
+```
+
+The template `emits {{.FileBrowserHTML}}` — a single dynamic slot holding the **entire** rendered
+tree as one HTML string. To livetemplate that slot is one opaque value: when *any* node changes
+(a file gets selected, a comment count ticks), the whole subtree string differs, so the whole
+subtree is re-serialized and re-sent. The recursive part gets **none** of livetemplate's minimal
+`["u", key, …]` updates — even though prereview already annotates every node with `data-key`,
+precisely so it *could* be diffed if the framework rendered it.
+
+That is the boilerplate C8 removes: a hand-maintained standalone template, a zero-arg
+`template.HTML` state method, and the silent loss of incremental updates for exactly the kind of
+large, frequently-touched structure (a repo's whole file tree) where incremental updates matter
+most.
+
+### Evidence (≥2 independent consumers)
+
+- **prereview** — `internal/review/filetree.go` + `filetree.tmpl` (`treeNode` recurses on
+  `.Children`; native `<details>`; injected as `template.HTML`).
+- **tinkerdown** — nested nav built recursively (`internal/site/manager.go:115`,
+  `buildNavPageNode` recurses into children), rendered via the same native-`<details>` opaque-HTML
+  approach prereview's comment cross-references.
+
+This is the one Tier C item with two independent hand-rolled consumers *and* a genuine capability
+gap (not a discoverability or docs gap) — which is why it earns a real implementation rather than
+a doc note.
+
+---
+
+## Approaches considered
+
+### Approach A — Runtime invocation as a nested `TreeNode` (recommended)
+
+Treat a recursive `{{template "name" .}}` as a **node boundary** instead of inlined text. At
+render time, the framework looks up the named template, evaluates its pre-built sub-tree against
+the invocation's dot, and splices the result in as a **nested `TreeNode`** (a child subtree with
+its own statics, dynamics, and fingerprint). Recursion bottoms out when the data does — a finite
+tree of nodes yields a finite tree of `TreeNode`s.
+
+This is deliberately the **same shape `{{range}}` already produces**: a range renders its item
+template once per item as a nested tree; a recursive template renders its named body once per
+node as a nested tree. The build/diff/wire machinery for nested trees already exists and is
+exercised — see `tree_test.go` nested cases and the range operations (`["u"/"i"/"r"/"o"]`). We
+are routing recursion through the path that works, not inventing a new one.
+
+- **Pro:** restores full reactive diffing for recursive structures (the whole point). Reuses the
+  nested-tree wire format — no new client-side ops. Backward compatible if applied *only* to
+  recursive invocations (see "Selective" below).
+- **Con:** the deepest change — parse must detect recursion and emit a runtime boundary; the
+  framework must retain named templates as pre-built sub-trees and instantiate them per
+  invocation; needs an eval-time depth/cycle guard for pathological data.
+
+### Approach C — A sanctioned opaque-HTML subtree primitive (lighter fallback)
+
+Bless the escape hatch: a first-class helper (e.g. `livetemplate.RawSubtree(html)` or a
+documented `template.HTML` convention) that the framework treats as a diff-opaque leaf, with
+framework-managed re-render. This is essentially what the apps do today, made official.
+
+- **Pro:** small, low-risk; removes the "is this safe?" ambiguity around injecting `template.HTML`.
+- **Con:** does **not** restore incremental updates — the subtree still re-sends wholesale on any
+  change. It sanctions the boilerplate rather than removing its cost. Worth shipping only if A is
+  deemed too large for now; A supersedes it.
+
+### Approach B — Depth-bounded inlining (rejected)
+
+Add a visited-set / max-depth guard to `walkAndFlatten` so recursion fails gracefully instead of
+overflowing. This prevents the crash but **cannot render data-driven depth** — the depth is
+unknown at parse time, so bounded inlining can only ever produce a fixed number of levels. It
+turns a crash into a wrong render. Rejected as a solution (though the *guard itself* is worth
+adding defensively — see Phase 1).
+
+---
+
+## Design (Approach A)
+
+### 1. Parse: detect recursion, split the invocation graph
+
+Add the missing cycle detection to flattening (`internal/parse/flatten.go`). While walking the
+invocation graph, track an in-progress set of template names. Two outcomes:
+
+- **Acyclic invocation** (today's case): inline as now. **Zero behavior change** — all existing
+  composition tests pass untouched.
+- **Cyclic invocation** (a name reachable from itself): do **not** inline. Mark every template on
+  the cycle as *runtime-invoked* and emit a **runtime invocation boundary** in the built tree at
+  each `{{template "name" .}}` site on the cycle, instead of splicing the body.
+
+This selective split is the key to low risk: non-recursive composition — the overwhelming common
+case — is completely unaffected. Only self-referential templates take the new path.
+
+### 2. Retain named templates as pre-built sub-trees
+
+Today flattening discards the separate `{{define}}`s (it inlines them). For runtime invocation,
+the framework must **keep** each runtime-invoked template's parsed body and build it into a
+reusable sub-tree "template" (mirroring how a `{{range}}` item body is compiled once and
+instantiated per item). Store these in a name→subtree registry on the compiled `Template`.
+
+### 3. Evaluate: instantiate the sub-tree per invocation → nested `TreeNode`
+
+When evaluation reaches a runtime invocation boundary:
+
+1. Resolve the invoked name against the registry (step 2).
+2. Evaluate that sub-tree against the invocation's **pipe value** as the new dot. `$` naturally
+   rebinds to that dot per invocation — matching Go's rule that a template calling itself drops
+   the caller's `$` (prereview relies on this: it resolves per-node display state at build time so
+   the recursive body never needs the root `$`).
+3. Emit the result as a **nested `TreeNode`** under the current node (the same slot a nested tree
+   already occupies).
+
+Recursion terminates because step 2's dot advances down the finite data tree (`.Children` empties
+out at the leaves).
+
+### 4. Eval-time depth/cycle guard (safety)
+
+Runtime recursion is bounded by data, so a **cyclic data structure** (a node whose `.Children`
+transitively contains an ancestor) would loop forever at eval. Add a guard: either a
+configurable **max-depth** (clear error on exceed) or a pointer-visited set mirroring the
+fingerprint code's existing `visitPath` pattern (`fingerprint.go:46,57-64`). Max-depth is simpler
+and gives a comprehensible error; recommend a generous default (e.g. 128) overridable via option.
+
+### 5. Fingerprint: reuse per template, don't re-hash per level
+
+A recursive structure repeats the *same* statics at every level, so the invoked template's static
+fingerprint is **identical** at every node. Fingerprint the runtime-invoked sub-tree **once** (by
+template name) and reuse it, rather than re-hashing O(depth) times. The existing cycle guard in
+`fingerprint.go` already makes a cyclic `TreeNode` graph well-defined; this optimization keeps
+deep *acyclic* trees O(nodes) with a tiny constant.
+
+This is a **server-side** hashing optimization only — the client never sees fingerprints
+(§6). Its user-visible payoff is statics *suppression*: at **stable depth**, the per-position
+`ClientNeedsStatics` finds an unchanged node and sends dynamics-only. This is not free at
+*changing* depth: a newly-appeared level is position-new, so its statics are (correctly) sent
+once. The self-similarity is a hashing win, not a wire-cost guarantee across depth changes.
+
+### 6. Wire format & diffing — no new client ops
+
+Each level serializes as a nested tree: statics sent on first render, dynamics-only on update.
+Because every node carries a stable identity (prereview already emits `data-key`), a change deep
+in the tree produces a targeted `["u", key, changes]` update — not a full re-send. **No new wire
+operations and no client changes** — verified, not assumed, against the client source:
+
+- **The client has no fingerprint concept at all.** Fingerprints are server-only: the server uses
+  them to *decide whether to send statics* (`ClientNeedsStatics`), and the wire never carries them
+  (`grep fingerprint` over `github.com/livetemplate/client` returns zero hits, as of client
+  v0.16.5). So there is no fingerprint-keyed client cache that identical-per-level structure could
+  collide in — the concern that self-similar levels confuse the client does not arise.
+- **The client caches statics *positionally* and merges depth-agnostically.** `TreeRenderer`
+  (`client/state/tree-renderer.ts`) stores statics inline at each tree path in `treeState`, and
+  `deepMergeTreeNodes` recurses on object nesting keyed by a path string with **no depth cap**.
+  Unbounded data-driven recursion is structurally identical to arbitrarily-deep nested ranges,
+  which the client already applies — so no client change is needed to *apply* the updates.
+
+The one design obligation this puts on the **server** eval (not the client): when recursion depth
+*changes* between renders (a node gains or loses children), each newly-materialized level is a
+tree position that had no prior node, so the existing per-position `ClientNeedsStatics(nil, new)`
+must fire and emit that level's statics. The recursive eval must therefore produce genuinely
+position-distinct nested nodes so this per-position logic engages — see Open question 5.
+
+### Worked example
+
+```
+{{define "treeNode"}}
+  <li data-key="{{.Path}}">
+    <span>{{.Name}}</span>
+    {{if .IsDir}}<ul>{{range .Children}}{{template "treeNode" .}}{{end}}</ul>{{end}}
+  </li>
+{{end}}
+```
+
+- Parse detects `treeNode` → `treeNode` (via the `range`'s invocation) is a cycle → `treeNode`
+  becomes runtime-invoked.
+- First render: full nested `TreeNode` tree; `treeNode`'s statics transmitted once per level the
+  data materializes, then cached client-side positionally and merged dynamics-only thereafter.
+- User selects a file 4 levels deep: only that node's dynamic (its `data-key` row) diffs → a
+  single `["u", "<path>", {…}]` reaches the client. Today: the entire `{{.FileBrowserHTML}}`
+  string re-sends.
+
+---
+
+## Implementation phases
+
+> Outline for review — not yet a commitment. Each phase is one focused change with its own tests.
+
+- [ ] **Phase 1 — Defensive cycle guard (independently shippable).** Add visited-set/depth
+      detection to `walkAndFlatten` so a self-referential template returns a clear
+      `ParseError` ("recursive template requires runtime invocation; see …") instead of
+      stack-overflowing. Ships value on its own (crash → diagnosable error) and lays the parse-time
+      detection Phase 2 builds on. Tests: direct + indirect cycle → error, not panic.
+- [ ] **Phase 2 — Retain runtime-invoked templates as sub-trees.** Build + register the named
+      body as a reusable sub-tree for templates flagged recursive in Phase 1. No rendering yet;
+      unit-test the registry + sub-tree build.
+- [ ] **Phase 3 — Runtime invocation → nested `TreeNode`.** Wire eval to instantiate the sub-tree
+      per invocation against the pipe dot and splice the nested tree. Tests: a recursive fixture
+      renders identically to the equivalent stdlib `html/template` output at depths 1..N, plus a
+      *between-render depth change* (grow and shrink) asserting a newly-materialized level receives
+      its statics and a removed one is dropped — the Open-question-5 invariant.
+- [ ] **Phase 4 — Fingerprint reuse + eval-time depth guard.** Per-name fingerprint caching;
+      max-depth option with a clear error. Tests: deep tree stays O(nodes); cyclic data errors
+      cleanly.
+- [ ] **Phase 5 — Minimal-update proof + docs.** Assert a deep single-node change emits one
+      `["u", key, …]` and not a full re-send (the payoff). Update `template-support-matrix.md` and
+      `current-limitations.md`; add a recipe. **Companion:** migrate prereview's `filetree.go`
+      off the standalone-template escape hatch onto a native recursive `{{template}}` (proves the
+      boilerplate is actually removed; lands per the lockstep convention once a release ships).
+
+---
+
+## Scope & risk
+
+- **Surfaces touched:** `internal/parse/` (cycle detection, runtime-boundary emission),
+  a name→subtree registry on the compiled `Template`, `internal/build`/eval (instantiate sub-tree
+  → nested `TreeNode`), `internal/build/fingerprint.go` (per-name reuse), an eval-time depth
+  guard. `internal/diff` and the **client are unchanged** (reuses nested-tree wire format).
+- **Backward compatibility:** high. The selective split means non-recursive composition keeps the
+  existing flatten path byte-for-byte; only cyclic invocation graphs take the new path.
+- **Biggest risk:** the eval-time sub-tree instantiation is new plumbing. Mitigated by leaning on
+  the range item-template model, which already does structurally the same thing.
+- **Performance:** deep trees render O(nodes); positionally-cached statics keep the wire cost
+  near dynamics-only after first render — strictly better than today's full-string re-send.
+
+## Open questions
+
+1. **Selective vs. uniform.** Recommended: convert *only* recursive invocations to runtime
+   boundaries (keep flattening non-recursive ones). Uniform runtime invocation is conceptually
+   cleaner but a much larger blast radius and a perf regression for the common flat case. Confirm
+   selective.
+2. **Depth guard: max-depth vs. pointer-visited.** Recommended max-depth (simpler, clearer error).
+   Default value + option name to settle.
+3. **Mutual recursion / indirect cycles** (`a`→`b`→`a`). The design handles it (the cycle set can
+   contain multiple names), but confirm test coverage expectations.
+4. **`data-key` requirement.** Targeted updates need stable node identity. Should the framework
+   *require* a `data-key` inside a runtime-invoked template (error if absent), or fall back to
+   content-hash keys as `{{range}}` does today? Recommend: fall back like range, document that
+   explicit `data-key` is strongly preferred for large trees.
+5. **Depth-change ⇒ position-distinct nested nodes.** The "no client changes" result (§6) rests on
+   the eval producing genuinely position-distinct nested nodes at each recursion level, so the
+   existing per-position `ClientNeedsStatics(nil, new)` fires for a *newly-materialized* level and
+   emits its statics. This is a Phase 3 correctness invariant, not a client concern — the design
+   assumes it and Phase 3's depth-1..N parity tests must exercise depth *growth and shrink between
+   renders*, not just static depths. Confirm the eval reuses the range item-instantiation path,
+   which already assigns position-distinct child nodes.
+5. **Dynamic invocation** (`{{template (printf …) .}}`) remains a documented fallback
+   (`current-limitations.md:15,19`); recursion support does not change that — out of scope.

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -52,9 +52,12 @@ is reached. (The tree walker `walker.go:42-47` even returns a `ParseError` "temp
 found — should be flattened" if an invocation ever survives to tree-build time, confirming
 invocations are *only* ever inlined, never evaluated.)
 
-There is **no explicit "recursion unsupported" marker** in the docs; the support matrix
-(`template-support-matrix.md:174-179`) simply says composition is "automatically flattened,"
-which silently assumes a finite, acyclic invocation graph.
+The support matrix *does* flag this — `template-support-matrix.md` has a "Circular template
+references | ❌ | Not supported, would cause infinite loop" row — but it **mischaracterizes the
+failure mode**: it isn't a runtime infinite loop, it's a **stack overflow during `Parse`** (the
+recursive `walkAndFlatten` above), before any tree or render. And there is **no implementation
+guard** — the crash is unbounded on template source. Phase 1 both corrects that doc row and turns
+the crash into a clear `ParseError`, independent of whether the rest of the design lands.
 
 ### The real cost: opaque HTML defeats reactive diffing
 
@@ -273,8 +276,10 @@ position-distinct nested nodes so this per-position logic engages — see Open q
       body as a reusable sub-tree for templates flagged recursive in Phase 1. No rendering yet;
       unit-test the registry + sub-tree build.
 - [ ] **Phase 3 — Runtime invocation → nested `TreeNode`.** Wire eval to instantiate the sub-tree
-      per invocation against the pipe dot and splice the nested tree. Tests: a recursive fixture
-      renders identically to the equivalent stdlib `html/template` output at depths 1..N, plus a
+      per invocation against the pipe dot and splice the nested tree. Tests: a recursive fixture's
+      rendered **HTML content** matches the equivalent stdlib `html/template` output at depths 1..N
+      (content parity — the *wire format* deliberately differs: nested `TreeNode` vs. inlined
+      string), plus a
       *between-render depth change* (grow and shrink) asserting a newly-materialized level receives
       its statics and a removed one is dropped — the Open-question-5 invariant.
 - [ ] **Phase 4 — Eval-time depth guard.** Confirm the existing per-instance

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -187,19 +187,33 @@ configurable **max-depth** (clear error on exceed) or a pointer-visited set mirr
 fingerprint code's existing `visitPath` pattern (`fingerprint.go:46,57-64`). Max-depth is simpler
 and gives a comprehensible error; recommend a generous default (e.g. 128) overridable via option.
 
-### 5. Fingerprint: reuse per template, don't re-hash per level
+### 5. Fingerprint: lean on the existing per-instance cache — do **not** cache per template name
 
-A recursive structure repeats the *same* statics at every level, so the invoked template's static
-fingerprint is **identical** at every node. Fingerprint the runtime-invoked sub-tree **once** (by
-template name) and reuse it, rather than re-hashing O(depth) times. The existing cycle guard in
-`fingerprint.go` already makes a cyclic `TreeNode` graph well-defined; this optimization keeps
-deep *acyclic* trees O(nodes) with a tiny constant.
+**Naive intuition (wrong):** "a recursive structure repeats the same statics at every level, so
+fingerprint the invoked template once by name and reuse it." This is unsafe, and the worked
+example below is exactly the counter-case: `{{if .IsDir}}<ul>…</ul>{{end}}` means a **leaf** node
+(`IsDir=false`) and a **directory** node (`IsDir=true`) take different conditional branches and so
+build **structurally different** trees — different structure fingerprints. A per-name cache would
+conflate them. Most real recursive templates have a leaf/branch conditional, so this is the common
+case, not an edge case.
 
-This is a **server-side** hashing optimization only — the client never sees fingerprints
-(§6). Its user-visible payoff is statics *suppression*: at **stable depth**, the per-position
-`ClientNeedsStatics` finds an unchanged node and sends dynamics-only. This is not free at
-*changing* depth: a newly-appeared level is position-new, so its statics are (correctly) sent
-once. The self-similarity is a hashing win, not a wire-cost guarantee across depth changes.
+**Correct approach — reuse existing machinery, add nothing.** The structure fingerprint is
+**content-independent**: two nodes with the same structure hash to the same value regardless of
+their dynamic content (per `CalculateStructureFingerprint`). A recursive template therefore emits
+a **small, bounded set of distinct branch-shapes** (here: leaf-shape and dir-shape), not one shape
+and not O(depth) shapes — and all nodes of a given shape already share a fingerprint *value* by
+equality, with no per-name cache. Recomputation is already avoided by the **existing per-instance
+lazy cache** `TreeNode.GetStructureFingerprint()` (`internal/build/types.go`): each node computes
+its fingerprint once on first access. So the design needs **no new fingerprint caching at all** —
+it must only *not* introduce a per-name cache that would collapse distinct branch-shapes. The
+existing `fingerprint.go` cycle guard (`visitPath`) keeps a cyclic `TreeNode` graph well-defined.
+
+The user-visible payoff is statics *suppression*, and it composes with the per-shape fingerprints:
+at **stable depth**, the per-position `ClientNeedsStatics` compares a node's fingerprint to its
+prior render's and sends dynamics-only when the shape is unchanged. A node that *flips branch*
+(a leaf becoming a directory) changes shape → its statics are correctly re-sent. A
+newly-materialized level at *growing* depth is position-new → its statics are (correctly) sent
+once. Suppression is per-node-per-shape, not a blanket "identical across all levels" guarantee.
 
 ### 6. Wire format & diffing — no new client ops
 
@@ -211,8 +225,8 @@ operations and no client changes** — verified, not assumed, against the client
 - **The client has no fingerprint concept at all.** Fingerprints are server-only: the server uses
   them to *decide whether to send statics* (`ClientNeedsStatics`), and the wire never carries them
   (`grep fingerprint` over `github.com/livetemplate/client` returns zero hits, as of client
-  v0.16.5). So there is no fingerprint-keyed client cache that identical-per-level structure could
-  collide in — the concern that self-similar levels confuse the client does not arise.
+  v0.16.5). So there is no fingerprint-keyed client cache that repeated per-level structure could
+  collide in — the concern that recurring levels confuse the client does not arise.
 - **The client caches statics *positionally* and merges depth-agnostically.** `TreeRenderer`
   (`client/state/tree-renderer.ts`) stores statics inline at each tree path in `treeState`, and
   `deepMergeTreeNodes` recurses on object nesting keyed by a path string with **no depth cap**.
@@ -263,9 +277,11 @@ position-distinct nested nodes so this per-position logic engages — see Open q
       renders identically to the equivalent stdlib `html/template` output at depths 1..N, plus a
       *between-render depth change* (grow and shrink) asserting a newly-materialized level receives
       its statics and a removed one is dropped — the Open-question-5 invariant.
-- [ ] **Phase 4 — Fingerprint reuse + eval-time depth guard.** Per-name fingerprint caching;
-      max-depth option with a clear error, applying the same on initial render *and* live update
-      (Open question 2). Tests: deep tree stays O(nodes); cyclic data errors cleanly on both paths.
+- [ ] **Phase 4 — Eval-time depth guard.** Confirm the existing per-instance
+      `GetStructureFingerprint()` lazy cache already covers deep trees (no new per-name cache — see
+      §5); add a max-depth option with a clear error, applying the same on initial render *and* live
+      update (Open question 2). Tests: deep tree stays O(nodes); a leaf⇄directory branch flip
+      re-sends statics correctly; cyclic data errors cleanly on both paths.
 - [ ] **Phase 5 — Minimal-update proof + docs.** Assert a deep single-node change emits one
       `["u", key, …]` and not a full re-send (the payoff). Update `template-support-matrix.md` and
       `current-limitations.md`; add a recipe. **Companion:** migrate prereview's `filetree.go`
@@ -278,8 +294,9 @@ position-distinct nested nodes so this per-position logic engages — see Open q
 
 - **Surfaces touched:** `internal/parse/` (cycle detection, runtime-boundary emission),
   a name→subtree registry on the compiled `Template`, `internal/build`/eval (instantiate sub-tree
-  → nested `TreeNode`), `internal/build/fingerprint.go` (per-name reuse), an eval-time depth
-  guard. `internal/diff` and the **client are unchanged** (reuses nested-tree wire format).
+  → nested `TreeNode`), an eval-time depth guard. `internal/build/fingerprint.go` is **reused
+  as-is** — the existing per-instance lazy cache already covers deep recursion (§5); no per-name
+  cache is added. `internal/diff` and the **client are unchanged** (reuses nested-tree wire format).
 - **Backward compatibility:** high. The selective split means non-recursive composition keeps the
   existing flatten path byte-for-byte; only cyclic invocation graphs take the new path.
 - **Biggest risk:** the eval-time sub-tree instantiation is new plumbing. Mitigated by leaning on


### PR DESCRIPTION
## Tier C · C8 — recursive `{{template}}` support (design proposal)

Part of the boilerplate-reduction sweep (issue **#483**, now closed — C8 was the one item with a genuine capability gap and was spun out into its own design, tracked here).

**Status: approved design of record.** The maintainer signed off on the three headline decisions in-session (2026-07-15) — this PR records the approved design; it does not itself request a decision. **No implementation lands in this PR** (docs-only); Phase 1 is ready to implement next.

### The gap
livetemplate flattens `{{template "name" .}}` textually at parse time (`internal/parse/flatten.go`, `walkAndFlatten`) with no cycle/depth guard, so a self-referential template **stack-overflows at `Parse`**. prereview hits this directly: it wants a reactive folder tree, can't use a recursive livetemplate template, and drops the tree to a standalone `html/template` injected as opaque `template.HTML` — losing incremental diffing. (tinkerdown corroborates the recursive-tree-UI *pattern* but serves static HTML, so it's a latent case, not a second bug victim — see the proposal's Evidence section.)

### The proposal
`docs/proposals/recursive-templates-proposal.md`. Approved approach: **selectively** route *recursive* invocations through runtime invocation → nested `TreeNode` (keeping non-recursive `{{template}}` flattening byte-for-byte unchanged), reusing the existing `{{range}}` nested-tree machinery — no new wire ops.

The "no new client changes" claim is **verified against `github.com/livetemplate/client` v0.16.5** (the client has no fingerprint concept; `deepMergeTreeNodes` caches statics positionally and recurses depth-agnostically). All prereview/tinkerdown citations were **verified against the actual repos** on this machine.

### Decisions recorded (maintainer sign-off, 2026-07-15)
1. **Selective**, not uniform runtime invocation (minimal blast radius).
2. **Max-depth guard, erroring uniformly** on initial render and live update (over a pointer-visited set; depth increments before the check so data pointer-cycles are still bounded).
3. **`data-key` falls back to content-hash** like `{{range}}` (explicit key preferred for large trees).

The proposal's § Decisions covers these (items 1/2/4, keeping their original open-question numbers); § Remaining design notes keeps items 3/5/6 (implementation invariants / scope boundaries, not open decisions).

### Scope
- Proposal doc + `docs/design/boilerplate-reduction.md` C8 entry → 📝 DESIGN APPROVED.
- 7 phased implementation sketch, each with a hard test gate (correctness unit + chromedp e2e with console/server/WS/HTML capture + `go test -bench` benchmarks). Phases 6–7 are companion migrations (prereview escape-hatch removal; tinkerdown nav→reactive, honestly scoped as larger/optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
