### PR TITLE
feat(parse): render recursive {{template}} at runtime (Tier C · C8 Phases 2-5)

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -31,6 +31,23 @@ jobs:
         repository: livetemplate/lvt
         path: lvt
 
+    # Mirror of the "Use matching docs branch" step below: a core change that
+    # alters the wire format also changes lvt's exact-format golden files, which
+    # can only be regenerated on a matching lvt branch (lvt's own CI runs against
+    # the published core). If a lvt branch of the same name exists, use it.
+    - name: Use matching LVT branch if available
+      working-directory: lvt
+      env:
+        LVT_REF: ${{ github.head_ref || github.ref_name }}
+      run: |
+        if git ls-remote --exit-code --heads origin "$LVT_REF" >/dev/null 2>&1; then
+          echo "Using livetemplate/lvt branch: $LVT_REF"
+          git fetch origin "$LVT_REF" --depth=1
+          git checkout FETCH_HEAD
+        else
+          echo "No matching livetemplate/lvt branch for $LVT_REF; using default branch"
+        fi
+
     - name: Checkout client library
       uses: actions/checkout@v4
       with:

--- a/config.go
+++ b/config.go
@@ -38,6 +38,14 @@ type EnvConfig struct {
 	// Environment: LVT_DEV_MODE (true/false, 1/0)
 	DevMode bool
 
+	// MaxTemplateDepth caps how deep recursive {{template}} invocations may nest
+	// while building the reactive tree. It stops unbounded recursion (e.g.
+	// self-referential data) from overflowing the stack, surfacing a clear error
+	// instead. Zero uses the built-in default (128); set a higher value only if
+	// your data is legitimately deeper.
+	// Environment: LVT_MAX_TEMPLATE_DEPTH (positive integer)
+	MaxTemplateDepth int
+
 	// WebSocketDisabled disables WebSocket connections (HTTP-only mode).
 	// Environment: LVT_WEBSOCKET_DISABLED (true/false, 1/0)
 	WebSocketDisabled bool
@@ -163,6 +171,15 @@ func LoadEnvConfig() (*EnvConfig, error) {
 		config.DevMode = b
 	}
 
+	// Load MaxTemplateDepth
+	if val := os.Getenv("LVT_MAX_TEMPLATE_DEPTH"); val != "" {
+		n, err := strconv.Atoi(val)
+		if err != nil || n <= 0 {
+			return nil, fmt.Errorf("invalid LVT_MAX_TEMPLATE_DEPTH %q: must be a positive integer", val)
+		}
+		config.MaxTemplateDepth = n
+	}
+
 	// Load WebSocketDisabled
 	if val := os.Getenv("LVT_WEBSOCKET_DISABLED"); val != "" {
 		b, err := parseBool(val)
@@ -284,6 +301,10 @@ func (c *EnvConfig) ToOptions() []Option {
 
 	if c.DevMode {
 		opts = append(opts, WithDevMode(true))
+	}
+
+	if c.MaxTemplateDepth > 0 {
+		opts = append(opts, WithMaxTemplateDepth(c.MaxTemplateDepth))
 	}
 
 	if c.WebSocketDisabled {

--- a/docs/design/boilerplate-reduction.md
+++ b/docs/design/boilerplate-reduction.md
@@ -352,7 +352,7 @@ example would return to its documented ~10 lines; checklistkit's 5 builders coll
   → **Resolution: document the view-helper pattern (guide + example), keep a regression anchor.
   No core API change.**
 - **C8. Recursive `{{template}}` support (direct consumer: prereview; latent: tinkerdown).**
-  📝 **DESIGN APPROVED (2026-07-15) — Phase 1 next.** livetemplate flattens `{{template}}` calls at
+  🔨 **DESIGN APPROVED (2026-07-15); Phase 1 SHIPPED (2026-07-16).** livetemplate flattens `{{template}}` calls at
   parse time with no cycle guard, so a self-referential template stack-overflows during `Parse`; a
   recursive file tree drops to a standalone `html/template` injected as opaque `template.HTML`
   (prereview `internal/review/filetree.go`), which removes the whole subtree from reactive diffing.
@@ -364,8 +364,10 @@ example would return to its documented ~10 lines; checklistkit's 5 builders coll
   Recommended approach: route recursive invocations through the runtime nested-`TreeNode` path
   `{{range}}` already uses (bounded by data depth, not parse-time expansion). Approach A
   (selective), a max-depth guard erroring uniformly, and content-hash `data-key` fallback are all
-  decided (see the proposal's § Decisions); Phase 1 (crash → `ParseError`) is independently
-  shippable and up next.
+  decided (see the proposal's § Decisions). **Phase 1 (crash → `ParseError`)** landed: an
+  active-path cycle guard in `internal/parse/flatten.go` rejects self-referential templates at
+  parse time with a `ParseError` naming the cycle, instead of stack-overflowing; the support matrix
+  row is corrected. Phases 2–5 (runtime nested-`TreeNode` invocation) remain.
 - **C9. Static-asset passthrough alongside the `/` LiveHandler.** ✅ **RESOLVED (docs, no new
   API).** The original pitch was a framework static-passthrough wrapper. On audit the common
   case — assets under a **known prefix** — is already handled by plain `net/http`:

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -244,9 +244,23 @@ once. Suppression is per-node-per-shape, not a blanket "identical across all lev
 ### 6. Wire format & diffing — no new client ops
 
 Each level serializes as a nested tree: statics sent on first render, dynamics-only on update.
-Because every node carries a stable identity (prereview already emits `data-key`), a change deep
-in the tree produces a targeted `["u", key, changes]` update — not a full re-send. **No new wire
-operations and no client changes** — verified, not assumed, against the client source:
+Direct-child list edits (add / insert / reorder / remove) produce granular range ops
+(`["a"]`/`["i"]`/`["o"]`/`["r"]`) carrying only the changed items — **no new wire operations and no
+client changes** — verified, not assumed, against the client source below.
+
+> **Keying caveat (implemented behavior, corrected from the original claim).** Each `{{range}}`
+> item is a `{{template}}` invocation, so its top-level tree is the invocation wrapper (empty
+> statics). `buildRangeTreeWithStatics` looks for an explicit `data-key` in those top-level statics
+> and, not finding it (the wrapper hides the item's real `<li data-key>`), falls back to a **deep
+> content hash** over the item's dynamics. Identity is still exact — the `data-key` value is one of
+> the hashed dynamics, so distinct items get distinct keys. But because the hash is *deep* (a
+> directory item's dynamics include its whole nested subtree), editing a node **deep** in the tree
+> changes every ancestor's key, so the enclosing branch is re-sent whole (its unaffected siblings
+> are not). A per-leaf `["u", key, {…}]` for deep edits requires honoring the explicit `data-key`
+> *through* the invocation wrapper; a first attempt (unwrapping the item) regressed the deep-edit
+> case to a full range re-send, so it is deferred to a focused follow-up. Renders are always
+> correct; this is update *size*, not correctness. Pinned by
+> `TestRecursiveTemplate_DescendantBranchRebuild`.
 
 - **The client has no fingerprint concept at all.** Fingerprints are server-only: the server uses
   them to *decide whether to send statics* (`ClientNeedsStatics`), and the wire never carries them
@@ -286,9 +300,12 @@ position-distinct nested nodes so this per-position logic engages. **Verified** 
   becomes runtime-invoked.
 - First render: full nested `TreeNode` tree; `treeNode`'s statics transmitted once per level the
   data materializes, then cached client-side positionally and merged dynamics-only thereafter.
-- User selects a file 4 levels deep: only that node's dynamic (its `data-key` row) diffs → a
-  single `["u", "<path>", {…}]` reaches the client. Today: the entire `{{.FileBrowserHTML}}`
-  string re-sends.
+- User renames a file 4 levels deep: the change reaches the client, and the diff is scoped to the
+  branch that contains the edit — its sibling branches are **not** re-sent. (Per the keying caveat
+  above, today the enclosing branch is re-sent whole rather than a single per-leaf
+  `["u", "<path>", {…}]`; scoping the deep edit down to the leaf is a tracked follow-up.) Even so,
+  this is dramatically smaller than the status quo, where the entire `{{.FileBrowserHTML}}` string
+  re-sends on any change anywhere.
 
 ---
 
@@ -347,15 +364,19 @@ Three categories, each a hard gate — no phase merges with a category left as "
       3×; the backstop fires on an empty recursive set.
 - [x] **Phase 3 — Runtime invocation → nested `TreeNode`. DONE.** `evaluator` gained a
       `templates map[string]*parse.Tree`; `walkAST`'s `TemplateNode` case now calls `invokeTemplate`
-      (`internal/parse/invoke.go`), which evaluates the pipe to the invocation dot, **rebinds dot**
-      (Go resets `.`/`$` on a template call — a nil `varCtx` + `data = pipe value` gives the clean
-      fresh scope; `walkList` lazily re-inits vars if the body declares any), re-walks the registered
-      body, and wraps the result via `createConditionalWrapper` (one nested dynamic slot, mirroring
-      `{{if}}`). **Unit (`recursive_template_test.go` / `recursive_template_diff_test.go`):** nested
-      file-tree, single-level base case, and **mutual** recursion render to exact HTML; a minimal
-      update on add-child emits a single granular range op (`["a", …]`) — key extraction descends
-      through the invocation wrapper — carrying only the new node; a between-render **depth-grows**
-      change resends the new level's statics; `Execute` (initial HTTP HTML) renders recursion natively.
+      (`internal/parse/invoke.go`), which **rebinds dot** to match Go exactly: `{{template "x" pipe}}`
+      binds dot to the pipe value (evaluated against the caller's dot), while a no-argument
+      `{{template "x"}}` binds dot to **nil** (not the caller's dot) — a nil `varCtx` gives the clean
+      fresh scope, and `walkList` lazily re-inits vars if the body declares any. It re-walks the
+      registered body and wraps the result via `createConditionalWrapper` (one nested dynamic slot,
+      mirroring `{{if}}`). **Unit (`recursive_template_test.go` / `recursive_template_diff_test.go`):**
+      nested file-tree, single-level base case, and **mutual** recursion render to exact HTML;
+      direct-child edits emit granular range ops (`["a"]` append, `["i", after-id]` mid-list insert
+      anchored on the preceding sibling's key, `["o"]` reorder, `["r"]` remove) carrying only the
+      changed item — proving keying descends through the invocation wrapper; a between-render
+      **depth-grows** change resends the new level's statics; a **deep**-descendant edit re-sends the
+      enclosing branch whole (`_DescendantBranchRebuild`, per the §6 keying caveat) while leaving
+      sibling branches untouched; `Execute` (initial HTTP HTML) renders recursion natively.
       **E2E/Bench:** deferred to Phase 5.
 - [x] **Phase 4 — Eval-time depth guard + option. DONE.** `build.Context` gained
       `InvocationDepth`/`MaxInvocationDepth`; `invokeTemplate` increments a per-invocation `*ctx` copy
@@ -370,12 +391,21 @@ Three categories, each a hard gate — no phase merges with a category left as "
       guard on infinite data; no-crash on the full path; `WithMaxTemplateDepth(3)` rejects a deep tree
       on update that the default renders.
 - [ ] **Phase 5 — Benchmarks + browser e2e + docs (remaining).** The minimal-update **proof** landed
-      in Phase 3 (`TestRecursiveTemplate_MinimalUpdate_AddChild`/`_DepthGrows`). Still to do:
-      `BenchmarkRecursiveRender`/`BenchmarkRecursiveUpdate` with the opaque-`template.HTML` baseline
-      row; the full chromedp black-box gate (console + server + WS + HTML capture); flip the
-      `template-support-matrix.md` "Recursive / circular template references" row from ❌ to ✅, update
+      in Phase 3 (`_MinimalUpdate_AddChild`/`_InsertMiddle`/`_Reorder`/`_Remove`/`_DepthGrows`,
+      `_DescendantBranchRebuild`), plus the depth-guard first-render leg (`_FirstRenderOverLimit`).
+      Still to do: `BenchmarkRecursiveRender`/`BenchmarkRecursiveUpdate` with the opaque-`template.HTML`
+      baseline row; the full chromedp black-box gate (console + server + WS + HTML capture, in the lvt
+      repo against the local build); flip the `template-support-matrix.md` "Recursive / circular
+      template references" row from ❌ to ✅ **with the keying footnote** (deep edits re-render the
+      enclosing branch; explicit `data-key` not yet honored through the invocation wrapper), update
       `current-limitations.md`, add a recipe. **Splittable into a fast-follow PR** so the functional
       change reviews on its own.
+- [ ] **Follow-up — honor explicit `data-key` through the invocation wrapper.** So a deep-descendant
+      edit scopes down to a single per-leaf `["u", key, {…}]` instead of re-sending the enclosing
+      branch. The naive unwrap (exposing the item's `<li>` as its top-level tree) regressed the
+      deep-edit case to a full range re-send via an un-diagnosed diff-engine path — so this needs a
+      diagnosed diff-engine fix, tracked as its own issue. Not a C8 blocker (renders are correct;
+      this is update size).
 
 ### Companion migrations (dependent repos — land per the lockstep convention once a release ships)
 
@@ -441,7 +471,12 @@ so the numbering below is 1/2/4 and § Remaining design notes keeps 3/5/6.)*
    for alpha; revisit if the divergence proves confusing.
 4. ✅ **`data-key` falls back like `{{range}}`.** Do *not* require an explicit `data-key` inside a
    runtime-invoked template; fall back to content-hash keys exactly as `{{range}}` does today.
-   Document that an explicit `data-key` is strongly preferred for large or reorderable trees.
+   **Implemented reality (see §6 keying caveat):** a recursive range item is a `{{template}}`
+   invocation whose wrapper hides its `<li data-key>`, so keying *always* uses the content hash today
+   — the explicit `data-key` is not yet honored through the wrapper. Identity is still exact (the
+   `data-key` value is a hashed dynamic), and direct-child add/insert/reorder/remove stay granular;
+   the only cost is that a *deep* edit re-sends the enclosing branch. Making an explicit `data-key`
+   actually take effect (and scope deep edits to the leaf) is the tracked follow-up.
 
 ## Remaining design notes
 

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -28,7 +28,16 @@ each level is a first-class diffable subtree. Non-recursive invocations keep fla
 unchanged (zero regression risk to existing composition).
 
 **Non-goal.** This is not "arbitrary Go template recursion at any cost." It's "let a template
-call itself over a finite data structure and still get minimal updates."
+call itself over a finite data structure and stay inside the reactive tree."
+
+**What ships now vs. later (measured, not assumed).** What lands with C8: recursive templates
+*render* correctly and *update reactively* in place (DOM/focus/scroll preserved) — the capability
+prereview and tinkerdown lack today. What does **not** yet land: genuinely *minimal* per-edit
+payloads. Recursive range items are keyed by a deep content hash, so a deep edit re-sends its whole
+enclosing top-level branch; for a deep, narrow tree that is ~the size of re-sending the entire
+opaque string it replaces (benchmarked: ~24 KB vs ~23.5 KB, at ~25× the CPU). Scoping deep edits to
+a single leaf `["u", key, {…}]` needs the data-key-through-the-wrapper follow-up (§ Remaining design
+notes). So C8 is shipped for the *capability*, with update-size optimization tracked separately.
 
 ---
 
@@ -303,9 +312,17 @@ position-distinct nested nodes so this per-position logic engages. **Verified** 
 - User renames a file 4 levels deep: the change reaches the client, and the diff is scoped to the
   branch that contains the edit — its sibling branches are **not** re-sent. (Per the keying caveat
   above, today the enclosing branch is re-sent whole rather than a single per-leaf
-  `["u", "<path>", {…}]`; scoping the deep edit down to the leaf is a tracked follow-up.) Even so,
-  this is dramatically smaller than the status quo, where the entire `{{.FileBrowserHTML}}` string
-  re-sends on any change anywhere.
+  `["u", "<path>", {…}]`; scoping the deep edit down to the leaf is a tracked follow-up.)
+  **How much this beats the status quo depends on the tree's shape, and the honest answer is "less
+  than you'd hope for deep, narrow trees."** The enclosing branch is `1/branch` of the tree, so a
+  wide tree (many top-level entries) re-sends a small slice, but a deep, narrow one re-sends a large
+  fraction. Measured (`recursive_template_bench_test.go`, depth-5 branch-3): a deep-leaf edit's
+  update is **~24 KB vs ~23.5 KB** for re-sending the entire opaque `{{.FileBrowserHTML}}` string —
+  essentially equal in bytes, and ~25× the CPU to compute. So the unconditional win here is **not**
+  payload size; it is (a) rendering correctly at all (the status quo overflows the flattener) and
+  (b) applying the change as an in-place tree update that preserves DOM/focus/scroll state, where the
+  opaque string can only replace `innerHTML` wholesale. The payload-size win arrives with the
+  data-key-through-the-wrapper follow-up.
 
 ---
 
@@ -390,16 +407,32 @@ Three categories, each a hard gate — no phase merges with a category left as "
       HTML-structure fallback while the **update** path propagates the guard error. **Unit:** tree-path
       guard on infinite data; no-crash on the full path; `WithMaxTemplateDepth(3)` rejects a deep tree
       on update that the default renders.
-- [ ] **Phase 5 — Benchmarks + browser e2e + docs (remaining).** The minimal-update **proof** landed
+- [~] **Phase 5 — Benchmarks + browser e2e + docs (partly done).** The minimal-update **proof** landed
       in Phase 3 (`_MinimalUpdate_AddChild`/`_InsertMiddle`/`_Reorder`/`_Remove`/`_DepthGrows`,
       `_DescendantBranchRebuild`), plus the depth-guard first-render leg (`_FirstRenderOverLimit`).
-      Still to do: `BenchmarkRecursiveRender`/`BenchmarkRecursiveUpdate` with the opaque-`template.HTML`
-      baseline row; the full chromedp black-box gate (console + server + WS + HTML capture, in the lvt
-      repo against the local build); flip the `template-support-matrix.md` "Recursive / circular
-      template references" row from ❌ to ✅ **with the keying footnote** (deep edits re-render the
-      enclosing branch; explicit `data-key` not yet honored through the invocation wrapper), update
-      `current-limitations.md`, add a recipe. **Splittable into a fast-follow PR** so the functional
-      change reviews on its own.
+      - [x] **Browser e2e written + validated.** `lvt/e2e/recursive_tree_e2e_test.go`
+        (`TestRecursiveTemplate_E2E`, `//go:build browser`): a full-HTML recursive file tree renders
+        its complete nested structure on first load AND reactively applies a deep-branch insert through
+        the **published** client — no reload, no console errors — capturing all four sources (console +
+        server logs + WS frames + HTML). **PASS (1.96s)** against the C8 branch via a temporary go.work
+        repoint to the worktree. This gate caught a real bug the fragment-only unit tests missed: the
+        e2e first failed with a `walkAndFlatten` **stack overflow** because it was silently building
+        against the *published* (pre-C8) livetemplate — proving the run genuinely exercises the
+        recursion path. **Release-gated:** committed on branch `lvt/tierc-c8-recursive-e2e` (not `main`
+        — lvt CI builds against published livetemplate, which overflows until C8 releases); open the PR
+        in lockstep once a livetemplate release ships C8.
+      - [x] `BenchmarkRecursiveRender`/`BenchmarkRecursiveUpdate` with the opaque-`template.HTML`
+        baseline row (`recursive_template_bench_test.go`). **Finding (corrects the "minimal updates"
+        premise):** a deep-leaf edit's update (~24 KB, the enclosing top-level branch) is
+        ~equal in bytes to re-sending the whole opaque string (~23.5 KB) and ~25× the CPU — so the
+        payload win is not delivered for deep, narrow trees pre-follow-up. Render is ~20-30× an opaque
+        Execute. The benchmark comments and TL;DR/§6 now state this honestly; the win C8 ships is
+        capability + reactive DOM-state preservation, not payload size.
+      - [ ] **Release-gated docs:** flip the `template-support-matrix.md` "Recursive / circular template
+        references" row from ❌ to ✅ **with the keying footnote** (deep edits re-render the enclosing
+        branch; explicit `data-key` not yet honored through the invocation wrapper), update
+        `current-limitations.md`, add a recipe. Matrix reflects *released* behavior, so this lands with
+        the release, not before.
 - [ ] **Follow-up — honor explicit `data-key` through the invocation wrapper.** So a deep-descendant
       edit scopes down to a single per-leaf `["u", key, {…}]` instead of re-sending the enclosing
       branch. The naive unwrap (exposing the item's `<li>` as its top-level tree) regressed the

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -307,12 +307,21 @@ Three categories, each a hard gate — no phase merges with a category left as "
 
 ### Core library
 
-- [ ] **Phase 1 — Defensive cycle guard (independently shippable).** Add visited-set/depth
-      detection to `walkAndFlatten` so a self-referential template returns a clear
-      `ParseError` ("recursive template requires runtime invocation; see …") instead of
-      stack-overflowing. Ships value on its own (crash → diagnosable error) and lays the parse-time
-      detection Phase 2 builds on. **Unit:** direct + indirect (`a`→`b`→`a`) cycle → error not
-      panic; a fuzz seed of self-referential sources. **E2E:** n/a (parse-time). **Bench:** n/a.
+- [x] **Phase 1 — Defensive cycle guard (independently shippable). DONE.** Added an active-path
+      cycle check (`checkFlattenCycle`) to `walkAndFlatten` (`internal/parse/flatten.go`): a
+      `{{template}}` whose name is already being inlined on the current path returns a
+      `ParseError` naming the cycle (`treeNode -> treeNode`, `a -> b -> a`) instead of
+      stack-overflowing during `Parse`. The stack is seeded with the entry point's name so a
+      self-referential entry point is caught too. Preserves the cycle-name info Phase 2 needs to
+      flag runtime-invoked templates. Also corrected the `template-support-matrix.md`
+      "Recursive / circular template references" row (failure mode: parse-time `ParseError`, not a
+      runtime infinite loop). **Unit (`internal/parse/flatten_cycle_test.go`):** the discriminating
+      *diamond* test (same template invoked on non-nested paths still flattens — proves active-path,
+      not global-visited), direct + mutual (`a`→`b`→`a`) + self-referential-entry cycles → `*ParseError`
+      not panic, non-recursive composition unaffected. **Black-box (`recursive_template_test.go`):**
+      the real `New(...).Parse(...)` path returns an error, not a crash. **Fuzz
+      (`FuzzFlattenTemplate`):** seeded with self-referential sources; 370K execs, no overflow.
+      **E2E:** n/a (parse-time). **Bench:** n/a.
 - [ ] **Phase 2 — Retain runtime-invoked templates as sub-trees.** Build + register the named
       body as a reusable sub-tree for templates flagged recursive in Phase 1. No rendering yet.
       **Unit:** registry membership + sub-tree build for direct and mutual recursion; non-recursive
@@ -343,9 +352,10 @@ Three categories, each a hard gate — no phase merges with a category left as "
       single-node change emits one `["u", key, …]` and not a full re-send (the payoff);
       `BenchmarkRecursiveUpdate` + the wire-size assertion land here with the opaque-`template.HTML`
       approach as the baseline row. **E2E:** the full black-box gate (console + server + WS + HTML
-      capture) proving the incremental-update path end-to-end. **Docs:** correct the
-      `template-support-matrix.md` "Circular template references" row (failure mode), update
-      `current-limitations.md`, add a recipe.
+      capture) proving the incremental-update path end-to-end. **Docs:** flip the
+      `template-support-matrix.md` "Recursive / circular template references" row from ❌ to ✅
+      (Phase 1 already corrected its *failure-mode* wording), update `current-limitations.md`, add a
+      recipe.
 
 ### Companion migrations (dependent repos — land per the lockstep convention once a release ships)
 

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -178,12 +178,16 @@ invocation graph, track an in-progress set of template names. Two outcomes:
 This selective split is the key to low risk: non-recursive composition — the overwhelming common
 case — is completely unaffected. Only self-referential templates take the new path.
 
-### 2. Retain named templates as pre-built sub-trees
+### 2. Retain named templates as re-walkable ASTs (name→AST registry)
 
-Today flattening discards the separate `{{define}}`s (it inlines them). For runtime invocation,
-the framework must **keep** each runtime-invoked template's parsed body and build it into a
-reusable sub-tree "template" (mirroring how a `{{range}}` item body is compiled once and
-instantiated per item). Store these in a name→subtree registry on the compiled `Template`.
+Today flattening inlines the separate `{{define}}`s and discards them. For runtime invocation,
+the framework must **keep** each runtime-invoked template's parsed body — as its **AST, re-walked
+per invocation**, not a compiled/cached sub-tree. (There is no "compile-once" model to mirror:
+`{{range}}`, `{{if}}`, and `{{with}}` all re-walk their raw `*parse.ListNode` on every evaluation;
+the registry is the same idea keyed by name.) As implemented, `FlattenTemplate` leaves recursive
+calls verbatim and appends each flattened body as a `{{define}}` block, so the un-wrapped flattened
+string carries them; `parse.Parse` then collects the associated templates into a
+`registry map[string]*parse.Tree` on the compiled `Template` — no separate threading needed.
 
 ### 3. Evaluate: instantiate the sub-tree per invocation → nested `TreeNode`
 
@@ -257,9 +261,15 @@ operations and no client changes** — verified, not assumed, against the client
 
 The one design obligation this puts on the **server** eval (not the client): when recursion depth
 *changes* between renders (a node gains or loses children), each newly-materialized level is a
-tree position that had no prior node, so the existing per-position `ClientNeedsStatics(nil, new)`
-must fire and emit that level's statics. The recursive eval must therefore produce genuinely
-position-distinct nested nodes so this per-position logic engages — see Open question 5.
+tree position that had no prior node, so that level's statics must be (re)sent. The mechanism is
+**not** a literal `ClientNeedsStatics(nil, new)` call at that position — it is the ordinary
+fingerprint-based per-position resend: the node whose structure changed (e.g. the `{{if .IsDir}}`
+slot going from empty to a nested `<ul>`+range) gets a different `GetStructureFingerprint()`, so
+`ClientNeedsStatics` returns true for it and `PrepareTreeForClient` keeps its statics; the new
+range items carry their own statics on insert. The recursive eval must therefore produce genuinely
+position-distinct nested nodes so this per-position logic engages. **Verified** by
+`TestRecursiveTemplate_MinimalUpdate_DepthGrows` (a leaf→directory flip resends the new level's
+`"s"`) — see Open question 5.
 
 ### Worked example
 
@@ -322,40 +332,50 @@ Three categories, each a hard gate — no phase merges with a category left as "
       the real `New(...).Parse(...)` path returns an error, not a crash. **Fuzz
       (`FuzzFlattenTemplate`):** seeded with self-referential sources; 370K execs, no overflow.
       **E2E:** n/a (parse-time). **Bench:** n/a.
-- [ ] **Phase 2 — Retain runtime-invoked templates as sub-trees.** Build + register the named
-      body as a reusable sub-tree for templates flagged recursive in Phase 1. No rendering yet.
-      **Unit:** registry membership + sub-tree build for direct and mutual recursion; non-recursive
-      `{{template}}` still flattens byte-for-byte (golden parity). **Bench:** compile-time cost of
-      registration is negligible vs. flatten.
-- [ ] **Phase 3 — Runtime invocation → nested `TreeNode`.** Wire eval to instantiate the sub-tree
-      per invocation against the pipe dot and splice the nested tree. **Unit:** a recursive fixture's
-      rendered **HTML content** matches the equivalent stdlib `html/template` output at depths 1..N
-      (content parity — the *wire format* deliberately differs: nested `TreeNode` vs. inlined
-      string); a *between-render depth change* (grow and shrink) asserting a newly-materialized level
-      receives its statics and a removed one is dropped (Open-question-5 invariant). **E2E:** a
-      chromedp recursive-tree page renders correctly at depth and survives expand/collapse. **Bench:**
-      `BenchmarkRecursiveRender` lands here.
-- [ ] **Phase 4 — Eval-time depth guard.** Confirm the existing per-instance
-      `GetStructureFingerprint()` lazy cache already covers deep trees (no new per-name cache — see
-      §5); add a max-depth option with a clear error, applying the same on initial render *and* live
-      update (Open question 2). **Invariant that makes max-depth sufficient:** depth is incremented
-      **before** the guard check on every recursion level, so a Go-value **pointer cycle** in
-      `.Children` (a self-referential node — a shorter loop than max-depth) is still caught: each
-      traversal step advances depth and eventually trips the ceiling rather than infinite-looping.
-      This is the deliberate tradeoff behind choosing max-depth over a pointer-visited set (Decision
-      2): simpler, at the cost of erroring on a legitimately-deep-but-finite tree too — hence
-      configurable. **Unit:** deep tree stays O(nodes); a leaf⇄directory branch flip re-sends statics
-      correctly; a **self-referential-pointer `.Children`** errors at max-depth (not a hang); cyclic
-      data errors cleanly on both render and update paths. **E2E:** a data-driven cycle surfaces the
-      max-depth error in the browser without wedging the session.
-- [ ] **Phase 5 — Minimal-update proof + benchmarks + docs.** **Unit + Bench:** assert a deep
-      single-node change emits one `["u", key, …]` and not a full re-send (the payoff);
-      `BenchmarkRecursiveUpdate` + the wire-size assertion land here with the opaque-`template.HTML`
-      approach as the baseline row. **E2E:** the full black-box gate (console + server + WS + HTML
-      capture) proving the incremental-update path end-to-end. **Docs:** flip the
-      `template-support-matrix.md` "Recursive / circular template references" row from ❌ to ✅
-      (Phase 1 already corrected its *failure-mode* wording), update `current-limitations.md`, add a
-      recipe.
+- [x] **Phase 2 — Detection + registry (via appended `{{define}}` blocks). DONE.** Corrected the
+      original "retain a reusable/compile-once sub-tree" framing: there is **no compiled sub-tree** —
+      the registry holds each recursive body's **AST, re-walked per invocation** (exactly as `{{range}}`
+      re-walks its item body per item; see §5). `detectRecursiveTemplates` (a DFS reachable-from-self
+      pre-pass in `internal/parse/flatten.go`) flags the cycle members; `walkAndFlatten` emits their
+      `{{template}}` calls **verbatim** (un-inlined) instead of recursing, and `FlattenTemplate` appends
+      each flattened body as a `{{define "name"}}…{{end}}` block. On re-parse those become associated
+      templates that `parse.Parse` collects into a `registry map[string]*parse.Tree` on `parse.Template`
+      — **no cross-package threading**; the flattened string carries everything. `checkFlattenCycle`
+      stays as a backstop: if detection ever under-identifies a cycle, the un-emitted call re-enters
+      and errors cleanly instead of overflowing. **Unit (`flatten_cycle_test.go`):** recursion emitted
+      verbatim + as a define (direct, mutual, self-entry), re-parses cleanly; the diamond still inlines
+      3×; the backstop fires on an empty recursive set.
+- [x] **Phase 3 — Runtime invocation → nested `TreeNode`. DONE.** `evaluator` gained a
+      `templates map[string]*parse.Tree`; `walkAST`'s `TemplateNode` case now calls `invokeTemplate`
+      (`internal/parse/invoke.go`), which evaluates the pipe to the invocation dot, **rebinds dot**
+      (Go resets `.`/`$` on a template call — a nil `varCtx` + `data = pipe value` gives the clean
+      fresh scope; `walkList` lazily re-inits vars if the body declares any), re-walks the registered
+      body, and wraps the result via `createConditionalWrapper` (one nested dynamic slot, mirroring
+      `{{if}}`). **Unit (`recursive_template_test.go` / `recursive_template_diff_test.go`):** nested
+      file-tree, single-level base case, and **mutual** recursion render to exact HTML; a minimal
+      update on add-child emits a single granular range op (`["a", …]`) — key extraction descends
+      through the invocation wrapper — carrying only the new node; a between-render **depth-grows**
+      change resends the new level's statics; `Execute` (initial HTTP HTML) renders recursion natively.
+      **E2E/Bench:** deferred to Phase 5.
+- [x] **Phase 4 — Eval-time depth guard + option. DONE.** `build.Context` gained
+      `InvocationDepth`/`MaxInvocationDepth`; `invokeTemplate` increments a per-invocation `*ctx` copy
+      **before** the guard check, so a Go-value **pointer cycle** in `.Children` (a short loop) still
+      trips the ceiling rather than infinite-looping — the deliberate max-depth-over-visited-set
+      tradeoff (Decision 2), hence configurable via `WithMaxTemplateDepth(n)` /
+      `LVT_MAX_TEMPLATE_DEPTH` (default 128). Note the guard's reach differs by path: the tree-only
+      path (`compat.ParseTemplateToTree`) has no other protection and our guard is sole (proven on
+      infinite data); the full `buildTree` path calls html/template `Execute` first, whose own depth
+      limit trips first on infinite data, and on first render an over-limit finite tree degrades to the
+      HTML-structure fallback while the **update** path propagates the guard error. **Unit:** tree-path
+      guard on infinite data; no-crash on the full path; `WithMaxTemplateDepth(3)` rejects a deep tree
+      on update that the default renders.
+- [ ] **Phase 5 — Benchmarks + browser e2e + docs (remaining).** The minimal-update **proof** landed
+      in Phase 3 (`TestRecursiveTemplate_MinimalUpdate_AddChild`/`_DepthGrows`). Still to do:
+      `BenchmarkRecursiveRender`/`BenchmarkRecursiveUpdate` with the opaque-`template.HTML` baseline
+      row; the full chromedp black-box gate (console + server + WS + HTML capture); flip the
+      `template-support-matrix.md` "Recursive / circular template references" row from ❌ to ✅, update
+      `current-limitations.md`, add a recipe. **Splittable into a fast-follow PR** so the functional
+      change reviews on its own.
 
 ### Companion migrations (dependent repos — land per the lockstep convention once a release ships)
 
@@ -409,11 +429,16 @@ so the numbering below is 1/2/4 and § Remaining design notes keeps 3/5/6.)*
 1. ✅ **Selective, not uniform.** Convert *only* recursive invocations to runtime boundaries; keep
    flattening non-recursive ones. Uniform runtime invocation is conceptually cleaner but a much
    larger blast radius and a perf regression for the common flat case — not worth it.
-2. ✅ **Max-depth guard, erroring uniformly.** Use a configurable **max-depth** (simpler and a
-   clearer error than a pointer-visited set), enforced identically on initial render **and** live
-   update — exceeding it errors the render rather than degrading/truncating, so behavior doesn't
-   diverge between the two paths. (Default value + option name to settle during Phase 4; a
-   partial-render fallback can be revisited later if the hard-error UX proves too blunt.)
+2. ✅ **Max-depth guard (`WithMaxTemplateDepth`, default 128).** A configurable **max-depth**
+   (simpler and a clearer error than a pointer-visited set), incremented before the check so a
+   short pointer cycle still trips it. **Resolved with a known path divergence** (see Phase 4): the
+   guard fires in `walkAST`, but exceeding it on the **update** path propagates a clean depth error,
+   while on **first render** it degrades to the HTML-structure fallback (the framework's general
+   AST-build-failure behavior) rather than erroring. Infinite data on the full `buildTree` path
+   trips html/template `Execute`'s own depth limit first; the tree-only path
+   (`compat.ParseTemplateToTree`) relies solely on this guard. The uniform-hard-error goal was
+   dropped as it would require special-casing depth errors out of the shared fallback — acceptable
+   for alpha; revisit if the divergence proves confusing.
 4. ✅ **`data-key` falls back like `{{range}}`.** Do *not* require an explicit `data-key` inside a
    runtime-invoked template; fall back to content-hash keys exactly as `{{range}}` does today.
    Document that an explicit `data-key` is strongly preferred for large or reorderable trees.

--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -30,14 +30,19 @@ unchanged (zero regression risk to existing composition).
 **Non-goal.** This is not "arbitrary Go template recursion at any cost." It's "let a template
 call itself over a finite data structure and stay inside the reactive tree."
 
-**What ships now vs. later (measured, not assumed).** What lands with C8: recursive templates
-*render* correctly and *update reactively* in place (DOM/focus/scroll preserved) — the capability
-prereview and tinkerdown lack today. What does **not** yet land: genuinely *minimal* per-edit
-payloads. Recursive range items are keyed by a deep content hash, so a deep edit re-sends its whole
-enclosing top-level branch; for a deep, narrow tree that is ~the size of re-sending the entire
-opaque string it replaces (benchmarked: ~24 KB vs ~23.5 KB, at ~25× the CPU). Scoping deep edits to
-a single leaf `["u", key, {…}]` needs the data-key-through-the-wrapper follow-up (§ Remaining design
-notes). So C8 is shipped for the *capability*, with update-size optimization tracked separately.
+**What ships with C8 (measured, e2e-verified).** Recursive templates *render* correctly (the flatten
+path overflows), *update reactively* in place (DOM/focus/scroll preserved via morphdom), AND scope a
+deep edit to a **minimal per-leaf payload**: recursive range items are keyed by their real data-key
+(read through the invocation wrapper), so a deep edit leaves every ancestor's key stable and the
+differential range diff emits a nested `["u", key, …]` chain down to the single changed node —
+statics-free, no unaffected sibling. Benchmarked at depth-5 branch-3: a deep-leaf update is **~200 B
+vs ~23.5 KB** for re-sending the opaque `{{.FileBrowserHTML}}` string (~100× smaller), at ~20× the
+CPU to compute the diff. Delivering this required two diff-engine changes beyond keying — teaching
+the differential range path to emit per-item `["u"]` for kept-changed items (framework-wide: it
+benefits every nested data-keyed range, not just recursion) and re-attaching the flatten-appended
+`{{define}}` blocks in body extraction so full HTML documents take the reactive path instead of
+silently degrading to HTML-string diffing. Verified end-to-end by a chromedp browser test (deep
+rename morphs the node in place, the unaffected sibling's DOM survives, the WS frame is scoped).
 
 ---
 
@@ -254,22 +259,30 @@ once. Suppression is per-node-per-shape, not a blanket "identical across all lev
 
 Each level serializes as a nested tree: statics sent on first render, dynamics-only on update.
 Direct-child list edits (add / insert / reorder / remove) produce granular range ops
-(`["a"]`/`["i"]`/`["o"]`/`["r"]`) carrying only the changed items — **no new wire operations and no
-client changes** — verified, not assumed, against the client source below.
+(`["a"]`/`["i"]`/`["o"]`/`["r"]`); a deep content edit produces a nested `["u", key, …]` chain —
+**no new wire operations and no client changes** — verified, not assumed, against the client source
+below and by browser e2e.
 
-> **Keying caveat (implemented behavior, corrected from the original claim).** Each `{{range}}`
-> item is a `{{template}}` invocation, so its top-level tree is the invocation wrapper (empty
-> statics). `buildRangeTreeWithStatics` looks for an explicit `data-key` in those top-level statics
-> and, not finding it (the wrapper hides the item's real `<li data-key>`), falls back to a **deep
-> content hash** over the item's dynamics. Identity is still exact — the `data-key` value is one of
-> the hashed dynamics, so distinct items get distinct keys. But because the hash is *deep* (a
-> directory item's dynamics include its whole nested subtree), editing a node **deep** in the tree
-> changes every ancestor's key, so the enclosing branch is re-sent whole (its unaffected siblings
-> are not). A per-leaf `["u", key, {…}]` for deep edits requires honoring the explicit `data-key`
-> *through* the invocation wrapper; a first attempt (unwrapping the item) regressed the deep-edit
-> case to a full range re-send, so it is deferred to a focused follow-up. Renders are always
-> correct; this is update *size*, not correctness. Pinned by
-> `TestRecursiveTemplate_DescendantBranchRebuild`.
+> **Keying + deep-update design (implemented).** Each `{{range}}` item is a `{{template}}`
+> invocation, so its top-level tree is the invocation wrapper (empty statics) that hides the item's
+> real `<li data-key>` one level down. `buildRangeTreeWithStatics` reads that `data-key` value
+> **through** the wrapper (`allWrappedItemKeys`) and uses it as the item's stable key — not a content
+> hash of the subtree. Because the key is stable, a deep-descendant edit leaves every ancestor's key
+> unchanged, so the item is *kept-but-changed* rather than remove+insert. Two diff-engine changes
+> then make deep edits **per-leaf** minimal:
+> 1. **Nested-range-containing ranges stay off the stream-mode transition** (`transition.go`), which
+>    keeps the old item trees on the differential path (stream mode discards them).
+> 2. **The differential range diff emits `["u", key, <recursive diff>]` for kept-changed items**
+>    (`generateKeptItemUpdateOps`) instead of bailing to a full-tree replace — reusing the same
+>    tree-compare that produced the range's ops, so the recursion composes down to the changed leaf.
+>    An item whose *statics* changed (a conditional branch flipped) would need statics a `["u"]`
+>    payload cannot carry, so those fall back to a full-range replace (guarded by `mapContainsStatics`).
+>
+> This is framework-wide: every nested data-keyed range gets per-item `["u"]`, not just recursion.
+> The client already applies nested-ops-in-payload (`deepMergeTreeNodes`), so it is server-only.
+> Pinned by `TestRecursiveTemplate_DescendantScopesToLeaf` and the nested-range fuzz + TS-oracle
+> suites; verified end-to-end by the lvt browser e2e (deep rename morphs in place, sibling DOM
+> survives, WS frame scoped).
 
 - **The client has no fingerprint concept at all.** Fingerprints are server-only: the server uses
   them to *decide whether to send statics* (`ClientNeedsStatics`), and the wire never carries them
@@ -309,20 +322,15 @@ position-distinct nested nodes so this per-position logic engages. **Verified** 
   becomes runtime-invoked.
 - First render: full nested `TreeNode` tree; `treeNode`'s statics transmitted once per level the
   data materializes, then cached client-side positionally and merged dynamics-only thereafter.
-- User renames a file 4 levels deep: the change reaches the client, and the diff is scoped to the
-  branch that contains the edit — its sibling branches are **not** re-sent. (Per the keying caveat
-  above, today the enclosing branch is re-sent whole rather than a single per-leaf
-  `["u", "<path>", {…}]`; scoping the deep edit down to the leaf is a tracked follow-up.)
-  **How much this beats the status quo depends on the tree's shape, and the honest answer is "less
-  than you'd hope for deep, narrow trees."** The enclosing branch is `1/branch` of the tree, so a
-  wide tree (many top-level entries) re-sends a small slice, but a deep, narrow one re-sends a large
-  fraction. Measured (`recursive_template_bench_test.go`, depth-5 branch-3): a deep-leaf edit's
-  update is **~24 KB vs ~23.5 KB** for re-sending the entire opaque `{{.FileBrowserHTML}}` string —
-  essentially equal in bytes, and ~25× the CPU to compute. So the unconditional win here is **not**
-  payload size; it is (a) rendering correctly at all (the status quo overflows the flattener) and
-  (b) applying the change as an in-place tree update that preserves DOM/focus/scroll state, where the
-  opaque string can only replace `innerHTML` wholesale. The payload-size win arrives with the
-  data-key-through-the-wrapper follow-up.
+- User renames a file 4 levels deep: because items are keyed by their stable `data-key` (read
+  through the invocation wrapper), every ancestor's key is unchanged, so the diff emits a nested
+  `["u", "<path>", {…}]` chain down to the single renamed node — statics-free, and carrying no
+  unaffected sibling (neither a top-level branch nor an in-branch sibling). Measured
+  (`recursive_template_bench_test.go`, depth-5 branch-3, ~364 nodes): a deep-leaf edit's update is
+  **~200 B vs ~23.5 KB** for re-sending the entire opaque `{{.FileBrowserHTML}}` string — a ~100×
+  wire-size reduction, at ~20× the CPU to compute the diff. The client applies it by merging the
+  nested ops into the item and morphing the existing `<li>` in place (DOM/focus/scroll preserved),
+  where the opaque string can only replace `innerHTML` wholesale.
 
 ---
 
@@ -391,10 +399,9 @@ Three categories, each a hard gate — no phase merges with a category left as "
       direct-child edits emit granular range ops (`["a"]` append, `["i", after-id]` mid-list insert
       anchored on the preceding sibling's key, `["o"]` reorder, `["r"]` remove) carrying only the
       changed item — proving keying descends through the invocation wrapper; a between-render
-      **depth-grows** change resends the new level's statics; a **deep**-descendant edit re-sends the
-      enclosing branch whole (`_DescendantBranchRebuild`, per the §6 keying caveat) while leaving
-      sibling branches untouched; `Execute` (initial HTTP HTML) renders recursion natively.
-      **E2E/Bench:** deferred to Phase 5.
+      **depth-grows** change resends the new level's statics; a **deep**-descendant edit scopes to a
+      nested per-leaf `["u", key, …]` chain (`_DescendantScopesToLeaf`, per §6) leaving every sibling
+      untouched; `Execute` (initial HTTP HTML) renders recursion natively. **E2E/Bench:** in Phase 5.
 - [x] **Phase 4 — Eval-time depth guard + option. DONE.** `build.Context` gained
       `InvocationDepth`/`MaxInvocationDepth`; `invokeTemplate` increments a per-invocation `*ctx` copy
       **before** the guard check, so a Go-value **pointer cycle** in `.Children` (a short loop) still
@@ -407,38 +414,32 @@ Three categories, each a hard gate — no phase merges with a category left as "
       HTML-structure fallback while the **update** path propagates the guard error. **Unit:** tree-path
       guard on infinite data; no-crash on the full path; `WithMaxTemplateDepth(3)` rejects a deep tree
       on update that the default renders.
-- [~] **Phase 5 — Benchmarks + browser e2e + docs (partly done).** The minimal-update **proof** landed
-      in Phase 3 (`_MinimalUpdate_AddChild`/`_InsertMiddle`/`_Reorder`/`_Remove`/`_DepthGrows`,
-      `_DescendantBranchRebuild`), plus the depth-guard first-render leg (`_FirstRenderOverLimit`).
+- [x] **Phase 5 — Benchmarks + browser e2e + docs. DONE (minus release-gated docs).** Diff proofs in
+      Phase 3 (`_MinimalUpdate_*`, `_DescendantScopesToLeaf`, `_FullDocument_Reactive`) + depth-guard
+      first-render leg (`_FirstRenderOverLimit`).
       - [x] **Browser e2e written + validated.** `lvt/e2e/recursive_tree_e2e_test.go`
         (`TestRecursiveTemplate_E2E`, `//go:build browser`): a full-HTML recursive file tree renders
-        its complete nested structure on first load AND reactively applies a deep-branch insert through
-        the **published** client — no reload, no console errors — capturing all four sources (console +
-        server logs + WS frames + HTML). **PASS (1.96s)** against the C8 branch via a temporary go.work
-        repoint to the worktree. This gate caught a real bug the fragment-only unit tests missed: the
-        e2e first failed with a `walkAndFlatten` **stack overflow** because it was silently building
-        against the *published* (pre-C8) livetemplate — proving the run genuinely exercises the
-        recursion path. **Release-gated:** committed on branch `lvt/tierc-c8-recursive-e2e` (not `main`
-        — lvt CI builds against published livetemplate, which overflows until C8 releases); open the PR
-        in lockstep once a livetemplate release ships C8.
-      - [x] `BenchmarkRecursiveRender`/`BenchmarkRecursiveUpdate` with the opaque-`template.HTML`
-        baseline row (`recursive_template_bench_test.go`). **Finding (corrects the "minimal updates"
-        premise):** a deep-leaf edit's update (~24 KB, the enclosing top-level branch) is
-        ~equal in bytes to re-sending the whole opaque string (~23.5 KB) and ~25× the CPU — so the
-        payload win is not delivered for deep, narrow trees pre-follow-up. Render is ~20-30× an opaque
-        Execute. The benchmark comments and TL;DR/§6 now state this honestly; the win C8 ships is
-        capability + reactive DOM-state preservation, not payload size.
+        its complete nested structure, reactively applies a deep-branch **insert**, AND a deep
+        **rename** — the rename morphs the existing `<li>` in place (a JS marker on it survives), the
+        unaffected sibling's DOM node survives (its marker survives too), and the WS frame is **scoped**
+        to the changed leaf (carries `hash-RENAMED.go`, not README/main/new-1). Captures all four
+        sources (console + server logs + WS frames + HTML). **PASS** against the worktree via a
+        temporary go.work repoint. This gate caught the full-document registry-drop bug the
+        fragment-only unit tests missed (see below). **Release-gated:** on branch
+        `lvt/tierc-c8-recursive-e2e`; open the PR in lockstep once a livetemplate release ships C8.
+      - [x] `BenchmarkRecursiveRender`/`BenchmarkRecursiveUpdate` + opaque-`template.HTML` baseline
+        (`recursive_template_bench_test.go`). Deep-leaf update **~200 B vs ~23.5 KB** opaque re-send
+        (~100× smaller, statics-free per-leaf `["u"]` chain), at ~20× the CPU. TL;DR/§6/benchmark
+        comments updated to the delivered numbers.
+      - [x] **Full-document registry-drop fix** (surfaced by the e2e): `FlattenTemplate` appends the
+        recursion cycle members as `{{define}}` blocks after `</html>`, and body extraction dropped
+        them for full HTML documents — leaving the recursion registry empty at serve time, so the whole
+        template silently degraded to HTML-string diffing (none of the reactive tree / per-leaf path
+        ran). `ExtractTemplateBodyContent` now re-attaches trailing `{{define}}` blocks; pinned by
+        `TestRecursiveTemplate_FullDocument_Reactive`.
       - [ ] **Release-gated docs:** flip the `template-support-matrix.md` "Recursive / circular template
-        references" row from ❌ to ✅ **with the keying footnote** (deep edits re-render the enclosing
-        branch; explicit `data-key` not yet honored through the invocation wrapper), update
-        `current-limitations.md`, add a recipe. Matrix reflects *released* behavior, so this lands with
-        the release, not before.
-- [ ] **Follow-up — honor explicit `data-key` through the invocation wrapper.** So a deep-descendant
-      edit scopes down to a single per-leaf `["u", key, {…}]` instead of re-sending the enclosing
-      branch. The naive unwrap (exposing the item's `<li>` as its top-level tree) regressed the
-      deep-edit case to a full range re-send via an un-diagnosed diff-engine path — so this needs a
-      diagnosed diff-engine fix, tracked as its own issue. Not a C8 blocker (renders are correct;
-      this is update size).
+        references" row from ❌ to ✅, update `current-limitations.md`, add a recipe. Matrix reflects
+        *released* behavior, so this lands with the release, not before.
 
 ### Companion migrations (dependent repos — land per the lockstep convention once a release ships)
 
@@ -502,14 +503,12 @@ so the numbering below is 1/2/4 and § Remaining design notes keeps 3/5/6.)*
    (`compat.ParseTemplateToTree`) relies solely on this guard. The uniform-hard-error goal was
    dropped as it would require special-casing depth errors out of the shared fallback — acceptable
    for alpha; revisit if the divergence proves confusing.
-4. ✅ **`data-key` falls back like `{{range}}`.** Do *not* require an explicit `data-key` inside a
-   runtime-invoked template; fall back to content-hash keys exactly as `{{range}}` does today.
-   **Implemented reality (see §6 keying caveat):** a recursive range item is a `{{template}}`
-   invocation whose wrapper hides its `<li data-key>`, so keying *always* uses the content hash today
-   — the explicit `data-key` is not yet honored through the wrapper. Identity is still exact (the
-   `data-key` value is a hashed dynamic), and direct-child add/insert/reorder/remove stay granular;
-   the only cost is that a *deep* edit re-sends the enclosing branch. Making an explicit `data-key`
-   actually take effect (and scope deep edits to the leaf) is the tracked follow-up.
+4. ✅ **`data-key` honored through the wrapper.** A recursive range item is a `{{template}}`
+   invocation whose wrapper hides its `<li data-key>`; `buildRangeTreeWithStatics` reads that
+   `data-key` value **through** the wrapper (`allWrappedItemKeys`) and keys by it, falling back to a
+   content hash only when an item exposes none. Stable keys are what let a deep edit scope to a
+   per-leaf `["u", key, …]` chain (via the differential per-item diff, §6) instead of re-sending the
+   enclosing branch. Direct-child add/insert/reorder/remove stay granular.
 
 ## Remaining design notes
 

--- a/docs/references/template-support-matrix.md
+++ b/docs/references/template-support-matrix.md
@@ -173,7 +173,7 @@ Stripping uses the HTML tokenizer (not a regex), so it is context-aware:
 |---------|--------|-------|
 | `{{define}}` / `{{template}}` | ✅ | Automatically flattened via `FlattenTemplate()` in `internal/parse/flatten.go` |
 | `{{block}}` | ✅ | Resolved during flattening; equivalent to `{{define}}` + `{{template}}` |
-| Circular template references | ❌ | Not supported, would cause infinite loop |
+| Recursive / circular template references | ❌ | Rejected at parse time with a clear `ParseError` naming the cycle (e.g. `treeNode -> treeNode`). Because `{{template}}` calls are inlined during flattening, a self-referential template cannot be inlined; runtime invocation of recursive templates is a planned feature (see `docs/proposals/recursive-templates-proposal.md`). |
 | Undefined template invocation | ❌ | Returns error from Go template engine |
 
 Template composition is fully supported through automatic AST flattening. `FlattenTemplate()` walks the parsed template tree, identifies the entry point, and inlines all `{{template}}` invocations into a single flat template before tree generation.

--- a/fuzz_ts_oracle_test.go
+++ b/fuzz_ts_oracle_test.go
@@ -254,6 +254,202 @@ func runModalFuzzSessionWithTSOracle(t *testing.T, rng *rand.Rand, seed int64, n
 	}
 }
 
+// runNestedRangeFuzzSessionWithTSOracle drives the nested-range template (a range
+// whose items each contain nested ranges + conditionals) through the real
+// TypeScript client, comparing the client-applied HTML to the expected render on
+// every cycle. This is the client-application coverage the Go-invariant
+// runNestedRangeFuzzSession lacks — it exercises the per-item ["u", key, <nested
+// ops>] chains the differential range diff now produces for kept-changed
+// nested-range items (previously a full-tree fallback), verifying the client
+// applies them (deepMergeTreeNodes → applyDifferentialOpsToRange) without diverging.
+func runNestedRangeFuzzSessionWithTSOracle(t *testing.T, rng *rand.Rand, seed int64, numMutations int, weights mutations.MutationWeights) {
+	t.Helper()
+	runNestedRangeOracleTemplate(t, rng, seed, numMutations, app.NestedRangeTemplate, weights, true)
+}
+
+// nestedRangeContentHashTemplate mirrors app.NestedRangeTemplate but keys items by
+// data-item (an attribute the diff engine does NOT recognize), so both nesting
+// levels fall to CONTENT-HASH keying instead of stable data-keys. That routes a
+// content edit through remove+insert (a changed item's hash key is new, so it is
+// not "kept") rather than the per-item ["u"] path — the path apps like checklistkit
+// (data-item), devbox-dash (data-issue) and prereview's bank (data-ref) actually
+// take. Suppressing the stream-mode transition for these nested-range-containing
+// ranges (this change) moves them onto the differential path, so exercise it.
+const nestedRangeContentHashTemplate = `<div class="tree-view">
+{{range .Categories}}
+    <div data-item="cat-{{.ID}}" class="category">
+        <h3>{{.Name}}</h3>
+        {{if .IsOpen}}
+        <ul class="items">
+        {{range .Items}}
+            <li data-item="{{.ID}}" class="{{if .Complete}}done{{end}} priority-{{.Priority}}">
+                <span class="title">{{.Title}}</span>
+                {{if .Body}}<p class="body">{{.Body}}</p>{{end}}
+            </li>
+        {{else}}
+            <li class="empty">No items in category</li>
+        {{end}}
+        </ul>
+        {{end}}
+    </div>
+{{else}}
+    <p class="empty">No categories</p>
+{{end}}
+</div>`
+
+// stableKeys=false suppresses the KeyStability invariant, which is inherently
+// incompatible with content-hash keys (a content edit changes the item's hash key
+// by design). The oracle HTML comparison and update-minimality checks still run —
+// those are the correctness signals for a content-hash range.
+func runNestedRangeOracleTemplate(t *testing.T, rng *rand.Rand, seed int64, numMutations int, templateStr string, weights mutations.MutationWeights, stableKeys bool) {
+	t.Helper()
+
+	oracle := getTSOracle(t)
+
+	tmpl := &Template{templateStr: templateStr}
+	if _, err := tmpl.Parse(templateStr); err != nil {
+		t.Skipf("Template parse error: %v", err)
+	}
+
+	state := app.GenNestedRangeState(rng)
+	verifier := invariants.NewVerifier(seed)
+
+	initialTree, err := compat.ParseTemplateToTree("test", templateStr, state.ToMap())
+	if err != nil {
+		t.Fatalf("Initial render failed: %v", err)
+	}
+	tmpl.lastTree = initialTree
+	initialBuildTree := convertToBuildTree(initialTree)
+	prevBuildTree := initialBuildTree
+	oracleTreeMap := invariants.TreeToMap(initialBuildTree)
+
+	if err := verifier.VerifyAll(nil, state.ToMap(), nil, initialBuildTree, initialBuildTree, true); err != nil {
+		t.Fatalf("First render invariant violation: %v", err)
+	}
+
+	for cycle := 0; cycle < numMutations; cycle++ {
+		oldStateMap := state.ToMap()
+
+		mutation := app.GenNestedRangeMutation(rng, state, weights)
+		verifier.RecordMutation(mutation)
+		if err := app.ApplyNestedRangeMutation(state, mutation); err != nil {
+			continue
+		}
+
+		newTree, err := compat.ParseTemplateToTree("test", templateStr, state.ToMap())
+		if err != nil {
+			t.Fatalf("Render failed at cycle %d: %v", cycle, err)
+		}
+
+		diffTree := tmpl.compareTreesAndGetChanges(tmpl.lastTree, newTree)
+		newBuildTree := convertToBuildTree(newTree)
+		diffBuildTree := convertToBuildTree(diffTree)
+
+		diffMap := invariants.TreeToMap(diffBuildTree)
+		response, err := oracle.ApplyDiffRaw(oracleTreeMap, diffMap)
+		if err != nil {
+			t.Errorf("TypeScript oracle error at cycle %d (seed=%d, mutation=%s): %v", cycle, seed, mutation.String(), err)
+			return
+		}
+		if response.Tree != nil {
+			if newOracleMap, ok := response.Tree.(map[string]any); ok {
+				oracleTreeMap = newOracleMap
+			}
+		}
+
+		expectedMap := invariants.TreeToMap(newBuildTree)
+		expectedHTML, err := render.TreeToHTML(expectedMap)
+		if err != nil {
+			t.Errorf("Failed to render expected tree at cycle %d: %v", cycle, err)
+			return
+		}
+
+		if !htmlEquivalent(response.HTML, expectedHTML) {
+			diffJSON, _ := json.MarshalIndent(diffMap, "  ", "  ")
+			t.Errorf("TypeScript oracle HTML diverged at cycle %d (seed=%d, mutation=%s)\n"+
+				"  Oracle HTML:   %s\n"+
+				"  Expected HTML: %s\n"+
+				"  Diff sent:\n%s",
+				cycle, seed, mutation.String(),
+				normalizeHTMLForTest(response.HTML), normalizeHTMLForTest(expectedHTML), string(diffJSON))
+			return
+		}
+
+		if stableKeys {
+			if err := verifier.VerifyAll(oldStateMap, state.ToMap(), prevBuildTree, newBuildTree, diffBuildTree, false); err != nil {
+				t.Errorf("Invariant violation at cycle %d (seed=%d): %v", cycle, seed, err)
+				return
+			}
+		} else if err := verifier.VerifyUpdateMinimality(diffBuildTree, false); err != nil {
+			// Content-hash keys are legitimately unstable, so skip KeyStability; the
+			// minimality invariant and the oracle HTML check above still apply.
+			t.Errorf("Minimality violation at cycle %d (seed=%d): %v", cycle, seed, err)
+			return
+		}
+
+		tmpl.lastTree = newTree
+		prevBuildTree = newBuildTree
+	}
+}
+
+// TestFuzzNestedRanges_TSOracle validates that the real TypeScript client correctly
+// applies the diffs produced for nested data-keyed ranges — the per-item ["u"]
+// chains the framework now emits for kept-changed nested-range items. The
+// Go-invariant TestFuzzNestedRanges_* checks the diff is minimal/valid; this checks
+// the client APPLIES it without HTML divergence.
+func TestFuzzNestedRanges_TSOracle(t *testing.T) {
+	weights := mutations.NestedRangeWeights
+
+	rapid.Check(t, func(rt *rapid.T) {
+		seed := rapid.Int64().Draw(rt, "seed")
+		numMutations := rapid.IntRange(20, 60).Draw(rt, "numMutations")
+
+		rng := rand.New(rand.NewSource(seed))
+		runNestedRangeFuzzSessionWithTSOracle(t, rng, seed, numMutations, weights)
+	})
+}
+
+// TestFuzzNestedRanges_UpdateHeavy_TSOracle biases toward content edits on kept
+// items — the mutation shape that most exercises the new per-item ["u"] path
+// (rather than structural add/remove/reorder) — validated through the client.
+func TestFuzzNestedRanges_UpdateHeavy_TSOracle(t *testing.T) {
+	weights := mutations.MutationWeights{
+		UpdateItem:         0.40, // heavy content edits (kept-item ["u"] path)
+		UpdateCategory:     0.20,
+		ToggleExpand:       0.15,
+		AddToCategory:      0.10,
+		RemoveFromCategory: 0.10,
+		ReorderWithin:      0.05,
+	}
+
+	rapid.Check(t, func(rt *rapid.T) {
+		seed := rapid.Int64().Draw(rt, "seed")
+		numMutations := rapid.IntRange(20, 60).Draw(rt, "numMutations")
+
+		rng := rand.New(rand.NewSource(seed))
+		runNestedRangeFuzzSessionWithTSOracle(t, rng, seed, numMutations, weights)
+	})
+}
+
+// TestFuzzNestedRangesContentHash_TSOracle validates the content-hash-keyed nested
+// range (data-item, unrecognized by the diff engine → content-hash keys). This
+// change suppresses the stream-mode transition for nested-range-containing ranges,
+// moving these onto the differential path where a content edit becomes
+// remove+insert (the item's hash key is new). Confirms the client applies that
+// correctly — the shape real apps (checklistkit/devbox/prereview) use, which the
+// id=-keyed nested fuzz above does not cover.
+func TestFuzzNestedRangesContentHash_TSOracle(t *testing.T) {
+	weights := mutations.NestedRangeWeights
+
+	rapid.Check(t, func(rt *rapid.T) {
+		seed := rapid.Int64().Draw(rt, "seed")
+		numMutations := rapid.IntRange(20, 60).Draw(rt, "numMutations")
+
+		rng := rand.New(rand.NewSource(seed))
+		runNestedRangeOracleTemplate(t, rng, seed, numMutations, nestedRangeContentHashTemplate, weights, false)
+	})
+}
+
 // htmlEquivalent compares two HTML strings for semantic equivalence.
 // It normalizes whitespace and handles minor formatting differences.
 func htmlEquivalent(a, b string) bool {

--- a/internal/build/types.go
+++ b/internal/build/types.go
@@ -172,6 +172,17 @@ type Context struct {
 	// TemplateName is the name of the template being built.
 	// Used for expression caching to avoid redundant template executions.
 	TemplateName string
+
+	// InvocationDepth counts how many recursive {{template}} invocations are
+	// currently nested on the build path. Incremented in a per-invocation copy
+	// of the Context (see invokeTemplate), so sibling branches count
+	// independently. Guards against runaway recursion — self-referential data
+	// or a pathologically deep tree — overflowing the Go stack during the walk.
+	InvocationDepth int
+
+	// MaxInvocationDepth caps InvocationDepth. Zero means "use the built-in
+	// default"; a positive value (set via WithMaxTemplateDepth) overrides it.
+	MaxInvocationDepth int
 }
 
 // NewContext creates a context for first render (includes all statics).

--- a/internal/build/wrapper.go
+++ b/internal/build/wrapper.go
@@ -192,6 +192,13 @@ func injectWrapperDivStringBased(htmlDoc string, wrapperID string, loadingDisabl
 // template. Handles body tags with or without attributes (e.g., <body>,
 // <body class="dark">). Uses html.Tokenizer (see locateBodyAndFirstScript)
 // to avoid being fooled by '<body' substrings in head content.
+//
+// It also re-attaches any trailing {{define}} blocks that FlattenTemplate appends
+// AFTER the document (past </body></html>) for recursive {{template}} support: the
+// body's {{template}} calls reference those defines, and the extracted content is
+// parsed on its own for reactive tree generation, so dropping them would leave the
+// recursion registry empty and silently degrade recursive templates to HTML-string
+// diffing.
 func ExtractTemplateBodyContent(templateStr string) string {
 	bodyOpenStart, bodyOpenEnd, bodyCloseStart, _ := locateBodyAndFirstScript(templateStr)
 	if bodyOpenStart < 0 {
@@ -205,7 +212,21 @@ func ExtractTemplateBodyContent(templateStr string) string {
 	if bodyCloseStart < 0 || bodyOpenEnd > bodyCloseStart {
 		return strings.TrimSpace(templateStr[bodyOpenEnd:])
 	}
-	return strings.TrimSpace(templateStr[bodyOpenEnd:bodyCloseStart])
+	body := strings.TrimSpace(templateStr[bodyOpenEnd:bodyCloseStart])
+	return body + trailingDefineBlocks(templateStr[bodyCloseStart:])
+}
+
+// trailingDefineBlocks returns the {{define}} blocks (from the first {{define
+// onward) found in the content after the body close, or "" if there are none.
+// FlattenTemplate appends recursion cycle members there; Go templates collect
+// {{define}} regardless of position, so appending them to the body content keeps
+// the extracted template self-contained.
+func trailingDefineBlocks(afterBody string) string {
+	idx := strings.Index(afterBody, "{{define")
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimRight(afterBody[idx:], " \t\r\n")
 }
 
 // ExtractTemplateContent extracts template content using wrapper ID with proper HTML parsing.

--- a/internal/build/wrapper_test.go
+++ b/internal/build/wrapper_test.go
@@ -362,6 +362,52 @@ func TestNormalizeTemplateSpacing(t *testing.T) {
 }
 
 // TestExtractTemplateBodyContent_WithAttributes tests body tags with attributes.
+// TestExtractTemplateBodyContent_TrailingDefines pins the recursion-registry
+// re-attachment: FlattenTemplate appends the recursive {{define}} cycle members
+// AFTER </body></html>, and body extraction must carry them along or a full-doc
+// recursive template silently degrades to HTML-structure diffing.
+func TestExtractTemplateBodyContent_TrailingDefines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			"full doc, no trailing define",
+			`<html><body><ul><li>x</li></ul></body></html>`,
+			`<ul><li>x</li></ul>`,
+		},
+		{
+			"full doc, one trailing define re-attached",
+			`<html><body><ul>{{template "n" .}}</ul></body></html>{{define "n"}}<li>{{.}}</li>{{end}}`,
+			`<ul>{{template "n" .}}</ul>{{define "n"}}<li>{{.}}</li>{{end}}`,
+		},
+		{
+			"full doc, multiple trailing defines re-attached",
+			`<html><body><ul>{{template "a" .}}</ul></body></html>{{define "a"}}A{{end}}{{define "b"}}B{{end}}`,
+			`<ul>{{template "a" .}}</ul>{{define "a"}}A{{end}}{{define "b"}}B{{end}}`,
+		},
+		{
+			"trailing whitespace before/after the define is trimmed to the block",
+			"<html><body>X</body></html>\n{{define \"a\"}}A{{end}}\n",
+			`X{{define "a"}}A{{end}}`,
+		},
+		{
+			"fragment (no body) returned as-is, defines and all",
+			`{{define "n"}}<li>{{.}}</li>{{end}}<ul>{{template "n" .}}</ul>`,
+			`{{define "n"}}<li>{{.}}</li>{{end}}<ul>{{template "n" .}}</ul>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if result := ExtractTemplateBodyContent(tt.input); result != tt.expected {
+				t.Errorf("Expected %q, got: %q", tt.expected, result)
+			}
+		})
+	}
+}
+
 func TestExtractTemplateBodyContent_WithAttributes(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/diff/helpers_range.go
+++ b/internal/diff/helpers_range.go
@@ -13,6 +13,26 @@ const (
 	maxInsertionPoints = 3
 )
 
+// nodeContainsNestedRange reports whether any TreeNode reachable through node's
+// dynamics is a range construct. A range whose items contain nested ranges is
+// kept off the stream-mode transition and diffed item-by-item, so a deep edit
+// scopes to a nested ["u", key, …] instead of re-sending the branch.
+func nodeContainsNestedRange(node *TreeNode) bool {
+	if node == nil {
+		return false
+	}
+	for _, d := range node.Dynamics {
+		child, ok := d.(*TreeNode)
+		if !ok {
+			continue
+		}
+		if child.HasRange() || nodeContainsNestedRange(child) {
+			return true
+		}
+	}
+	return false
+}
+
 // HasReordering returns true if the order of keys differs between old and new.
 // Returns false if lengths differ (which indicates insertions/removals).
 func HasReordering(oldKeys, newKeys []string) bool {

--- a/internal/diff/range_ops.go
+++ b/internal/diff/range_ops.go
@@ -121,12 +121,15 @@ func GenerateRangeDifferentialOperations(oldValue, newValue interface{}, stripSt
 		return nil
 	}
 
-	// Kept-item changes can't be encoded as differential ops; full-tree fallback (spec §5c/§5d).
-	if hasKeptItemChanged(ctx) {
-		return nil
-	}
+	// A kept-but-changed item is encoded as a per-item ["u", key, <recursive diff>]
+	// (generateKeptItemUpdateOps); if any can't be expressed that way, keptOK is
+	// false and we fall back to a full-tree replace (spec §5c/§5d).
+	keptChanged := hasKeptItemChanged(ctx)
 
-	if isPureReorderingCtx(ctx) {
+	// A content change is not a pure reorder; only take the reorder shortcut when
+	// nothing changed in place (a trailing ["o"] is still appended below when the
+	// key order changed alongside content).
+	if !keptChanged && isPureReorderingCtx(ctx) {
 		return []interface{}{[]interface{}{"o", ctx.newKeys}}
 	}
 
@@ -138,6 +141,13 @@ func GenerateRangeDifferentialOperations(oldValue, newValue interface{}, stripSt
 
 	operations := make([]interface{}, 0, 4)
 	operations = generateRemovalOps(ctx, operations)
+	if keptChanged {
+		updated, keptOK := generateKeptItemUpdateOps(ctx, operations)
+		if !keptOK {
+			return nil
+		}
+		operations = updated
+	}
 	operations = generateInsertionOps(ctx, operations)
 
 	if sameKeySet(ctx.oldKeys, ctx.newKeys) && HasReordering(ctx.oldKeys, ctx.newKeys) {
@@ -241,6 +251,98 @@ func GenerateRangeStreamOperations(
 	}
 
 	return operations
+}
+
+// generateKeptItemUpdateOps emits ["u", key, <recursive item diff>] for each item
+// present in both renders whose content changed, reusing the same tree-compare
+// that produced this range's ops so a deep edit scopes to the changed leaf rather
+// than re-sending the whole item. It returns ok=false when a changed item cannot
+// be expressed as a per-item update (a non-*TreeNode item, or a change the
+// recursive diff produced no payload for) — the caller then falls back to a
+// full-tree replace, preserving the pre-existing safe behavior.
+func generateKeptItemUpdateOps(ctx *rangeContext, operations []interface{}) ([]interface{}, bool) {
+	for _, key := range ctx.newKeys {
+		oldItem, exists := ctx.oldByKey[key]
+		if !exists {
+			continue
+		}
+		oldNode, ok1 := oldItem.(*TreeNode)
+		newNode, ok2 := ctx.newByKey[key].(*TreeNode)
+		if !ok1 || !ok2 {
+			return nil, false
+		}
+		structureChanged, contentChanged := itemChange(oldNode, newNode)
+		// A changed statics fingerprint means the item's own structure changed (a
+		// conditional branch flipped in/out); it needs statics a dynamics-only ["u"]
+		// cannot carry, so fall back to a full-range replace. Decided from the
+		// fingerprint up front, before spending a recursive diff on it.
+		if structureChanged {
+			return nil, false
+		}
+		if !contentChanged {
+			continue
+		}
+		rangeMatches := FindRangeConstructMatches(oldNode, newNode)
+		itemChanges := CompareTreesAndGetChangesWithPath(oldNode, newNode, false, "", rangeMatches)
+		payload := itemUpdatePayload(itemChanges, ctx.keyPos)
+		// The item's own structure is unchanged, but a NESTED range may have inserted
+		// a sub-item whose statics ride in the payload — still not a valid
+		// dynamics-only update, so fall back to a full-range replace.
+		if len(payload) == 0 || containsStatics(payload) {
+			return nil, false
+		}
+		operations = append(operations, []interface{}{"u", key, payload})
+	}
+	return operations, true
+}
+
+// itemChange reports how a kept item changed between renders: structureChanged
+// when its statics fingerprint differs (a conditional branch flipped — needs
+// statics a ["u"] cannot carry), contentChanged when its dynamics differ within
+// the same structure. Both signals gate the kept-item path (hasKeptItemChanged
+// uses their OR; generateKeptItemUpdateOps needs them apart).
+func itemChange(oldNode, newNode *TreeNode) (structureChanged, contentChanged bool) {
+	structureChanged = build.CalculateStaticsFingerprint(oldNode) != build.CalculateStaticsFingerprint(newNode)
+	contentChanged = keys.ItemHashUint64(oldNode.Dynamics) != keys.ItemHashUint64(newNode.Dynamics)
+	return
+}
+
+// containsStatics reports whether a ["u"] payload carries statics anywhere (an "s"
+// key at any depth, including inside nested range-op arrays like
+// {"2": [["u", k, {"s": …}]]}). Such a payload is not a valid dynamics-only update
+// — the range must fall back to a full replace.
+func containsStatics(v interface{}) bool {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		if _, ok := val["s"]; ok {
+			return true
+		}
+		for _, e := range val {
+			if containsStatics(e) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, e := range val {
+			if containsStatics(e) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// itemUpdatePayload converts an item's recursive-diff changes tree into the wire
+// payload map the client deep-merges into the retained item (nested range diffs
+// ride along as {"d": [...]} fields). The key position is dropped: the client
+// already indexes by key, so re-sending it is redundant (matches
+// dynamicsToUpdatePayload).
+func itemUpdatePayload(changes *TreeNode, keyPos int) map[string]interface{} {
+	m := changes.ToMap()
+	if keyPos >= 0 {
+		delete(m, build.PositionKey(keyPos))
+	}
+	return m
 }
 
 // generateStreamRemovalOps: sorted for determinism (mirrors generateRemovalOps).
@@ -471,10 +573,7 @@ func hasKeptItemChanged(ctx *rangeContext) bool {
 		if !oldOk || !newOk {
 			return true
 		}
-		if build.CalculateStaticsFingerprint(oldNode) != build.CalculateStaticsFingerprint(newNode) {
-			return true
-		}
-		if keys.ItemHashUint64(oldNode.Dynamics) != keys.ItemHashUint64(newNode.Dynamics) {
+		if structureChanged, contentChanged := itemChange(oldNode, newNode); structureChanged || contentChanged {
 			return true
 		}
 	}

--- a/internal/diff/range_ops_test.go
+++ b/internal/diff/range_ops_test.go
@@ -1,8 +1,10 @@
 package diff
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/livetemplate/livetemplate/internal/build"
@@ -187,9 +189,10 @@ func TestGenerateRangeDifferentialOperations_Insertion(t *testing.T) {
 
 // TestGenerateRangeDifferentialOperations_Mixed verifies that a render combining
 // structural changes (id1/id3 removed, id4 added) with a kept-item content change
-// (id2: "Old Name" → "New Name") signals nil-return so the caller emits a full-tree
-// replacement. Kept-item content changes cannot be encoded as differential ops
-// (spec §5d).
+// (id2: "Old Name" → "New Name") is encoded as differential ops: removes for the
+// dropped items, a per-item ["u"] for the kept-but-changed one, and an append for
+// the new one. Kept-item content changes are diffed in place (they no longer force
+// a full-tree fallback).
 func TestGenerateRangeDifferentialOperations_Mixed(t *testing.T) {
 	item1 := &TreeNode{Dynamics: []interface{}{"id1", "Name 1"}}
 	item2Old := &TreeNode{Dynamics: []interface{}{"id2", "Old Name"}}
@@ -209,9 +212,48 @@ func TestGenerateRangeDifferentialOperations_Mixed(t *testing.T) {
 	}
 
 	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
-	if ops != nil {
-		t.Errorf("Expected nil-return (full-tree fallback signal), got ops: %v", ops)
+	if ops == nil {
+		t.Fatal("Expected differential ops, got nil-return")
 	}
+	got := opTypeCounts(ops)
+	if got["r"] != 2 {
+		t.Errorf("Expected 2 remove ops (id1, id3), got %d: %v", got["r"], ops)
+	}
+	if got["a"] != 1 {
+		t.Errorf("Expected 1 append op (id4), got %d: %v", got["a"], ops)
+	}
+	if !hasUpdateOp(ops, "id2", "New Name") {
+		t.Errorf("Expected ['u','id2',{'1':'New Name'}], got: %v", ops)
+	}
+}
+
+// opTypeCounts tallies operations by their op-type string ("r","u","a","i","o","p").
+func opTypeCounts(ops []interface{}) map[string]int {
+	counts := map[string]int{}
+	for _, op := range ops {
+		if arr, ok := op.([]interface{}); ok && len(arr) >= 1 {
+			if t, ok := arr[0].(string); ok {
+				counts[t]++
+			}
+		}
+	}
+	return counts
+}
+
+// hasUpdateOp reports whether ops contains ["u", key, {"1": value}] — position 1
+// is the name/title dynamic in every test item ([id, name]).
+func hasUpdateOp(ops []interface{}, key, value string) bool {
+	for _, op := range ops {
+		arr, ok := op.([]interface{})
+		if !ok || len(arr) < 3 || arr[0] != "u" || arr[1] != key {
+			continue
+		}
+		payload, ok := arr[2].(map[string]interface{})
+		if ok && payload["1"] == value {
+			return true
+		}
+	}
+	return false
 }
 
 // TestGenerateRangeDifferentialOperations_EmptyToItems tests transition from empty to items.
@@ -642,10 +684,11 @@ func TestHasKeptItemChanged_NonTreeNodeReturnsTrue(t *testing.T) {
 	}
 }
 
-// TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack
-// covers a single item present on both renders whose Dynamics changed. The
-// diff engine signals nil-return so the caller emits a full-tree replacement.
-func TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack(t *testing.T) {
+// TestGenerateRangeDifferentialOperations_KeptItemContentChange_EmitsUpdateOp
+// covers a single item present on both renders whose Dynamics changed. The diff
+// engine encodes it in place as ["u", key, {changed dynamics}] rather than
+// falling back to a full-tree replacement.
+func TestGenerateRangeDifferentialOperations_KeptItemContentChange_EmitsUpdateOp(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	oldValue := &TreeNode{
 		Statics: statics,
@@ -656,15 +699,17 @@ func TestGenerateRangeDifferentialOperations_KeptItemContentChange_FallsBack(t *
 		Range:   &RangeData{Items: []interface{}{&TreeNode{Dynamics: []interface{}{"id1", "New"}}}},
 	}
 
-	if ops := GenerateRangeDifferentialOperations(oldValue, newValue, false); ops != nil {
-		t.Errorf("Expected nil-return for kept-item content change, got: %v", ops)
+	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
+	if len(ops) != 1 || !hasUpdateOp(ops, "id1", "New") {
+		t.Errorf("Expected [['u','id1',{'1':'New'}]], got: %v", ops)
 	}
 }
 
-// TestGenerateRangeDifferentialOperations_StructuralAndContent_FallsBack covers
-// a render that adds an item AND mutates an existing item's content. The
-// content-change signal wins — full-tree replacement carries both correctly.
-func TestGenerateRangeDifferentialOperations_StructuralAndContent_FallsBack(t *testing.T) {
+// TestGenerateRangeDifferentialOperations_StructuralAndContent_EmitsOps covers a
+// render that adds an item AND mutates an existing item's content: both are
+// encoded differentially — a per-item ["u"] for the kept item plus an append for
+// the new one.
+func TestGenerateRangeDifferentialOperations_StructuralAndContent_EmitsOps(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 	oldValue := &TreeNode{
 		Statics: statics,
@@ -678,8 +723,84 @@ func TestGenerateRangeDifferentialOperations_StructuralAndContent_FallsBack(t *t
 		}},
 	}
 
+	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
+	if !hasUpdateOp(ops, "id1", "New") {
+		t.Errorf("Expected a ['u','id1',{'1':'New'}] op, got: %v", ops)
+	}
+	if opTypeCounts(ops)["a"] != 1 {
+		t.Errorf("Expected 1 append op (id2), got: %v", ops)
+	}
+}
+
+// TestGenerateRangeDifferentialOperations_NestedRangeKeptItem_EmitsNestedUpdate is
+// the headline nested case (the flat-scalar tests above don't exercise it): an
+// outer range item that itself contains a nested range, where one nested leaf's
+// content changes. The outer range must emit a single ["u", outerKey, payload]
+// whose payload carries a nested ["u", innerKey, …] scoped to the changed leaf —
+// not re-send the whole outer item or its unchanged nested sibling.
+func TestGenerateRangeDifferentialOperations_NestedRangeKeptItem_EmitsNestedUpdate(t *testing.T) {
+	inner := []string{`<li data-key="`, `">`, `</li>`}
+	outer := []string{`<div data-key="`, `">`, `</div>`}
+	mkItem := func(innerTitle string) *TreeNode {
+		return &TreeNode{
+			Statics: outer,
+			Dynamics: []interface{}{"cat1", &TreeNode{
+				Statics: inner,
+				Range: &RangeData{
+					Statics: inner,
+					Items: []interface{}{
+						&TreeNode{Statics: inner, Dynamics: []interface{}{"i1", "A"}},
+						&TreeNode{Statics: inner, Dynamics: []interface{}{"i2", innerTitle}},
+					},
+				},
+			}},
+		}
+	}
+	oldValue := &TreeNode{Statics: outer, Range: &RangeData{Statics: outer, Items: []interface{}{mkItem("B")}}}
+	newValue := &TreeNode{Statics: outer, Range: &RangeData{Statics: outer, Items: []interface{}{mkItem("RENAMED")}}}
+
+	ops := GenerateRangeDifferentialOperations(oldValue, newValue, true)
+	if len(ops) != 1 {
+		t.Fatalf("expected a single outer ['u'] op, got: %v", ops)
+	}
+	op, _ := ops[0].([]interface{})
+	if len(op) < 3 || op[0] != "u" || op[1] != "cat1" {
+		t.Fatalf("expected ['u','cat1',payload], got: %v", ops[0])
+	}
+	js, _ := json.Marshal(op[2])
+	s := string(js)
+	if !strings.Contains(s, "RENAMED") {
+		t.Errorf("nested ['u'] payload must carry the changed leaf 'RENAMED', got: %s", s)
+	}
+	if strings.Contains(s, `"s":[`) {
+		t.Errorf("nested ['u'] payload must be statics-free (client has them cached), got: %s", s)
+	}
+	if !strings.Contains(s, `"u"`) || !strings.Contains(s, "i2") {
+		t.Errorf("outer payload must carry a nested ['u','i2',…] op, got: %s", s)
+	}
+}
+
+// TestGenerateRangeDifferentialOperations_ItemStructureChange_FallsBack covers a
+// kept item whose STATICS changed (a conditional branch flipped in/out) — the
+// per-item ["u"] payload would need statics the client lacks, which an update op
+// must not carry, so the range falls back to a full-tree replacement.
+func TestGenerateRangeDifferentialOperations_ItemStructureChange_FallsBack(t *testing.T) {
+	oldValue := &TreeNode{
+		Statics: []string{`<li data-key="`, `">`, `</li>`},
+		Range: &RangeData{Items: []interface{}{
+			&TreeNode{Statics: []string{`<li data-key="`, `">`, `</li>`}, Dynamics: []interface{}{"id1", "A"}},
+		}},
+	}
+	newValue := &TreeNode{
+		Statics: []string{`<li data-key="`, `">`, `</li>`},
+		Range: &RangeData{Items: []interface{}{
+			// Same key, but the item's statics changed (extra slot / different shape).
+			&TreeNode{Statics: []string{`<li data-key="`, `"><b>`, `</b></li>`}, Dynamics: []interface{}{"id1", "A"}},
+		}},
+	}
+
 	if ops := GenerateRangeDifferentialOperations(oldValue, newValue, false); ops != nil {
-		t.Errorf("Expected nil-return for combined structural+content change, got: %v", ops)
+		t.Errorf("Expected nil-return (full-tree fallback) for item structure change, got: %v", ops)
 	}
 }
 
@@ -1114,10 +1235,10 @@ func TestSameKeySet(t *testing.T) {
 // This was the core bug discovered during Phase 2 fuzz testing.
 // =============================================================================
 
-// TestGenerateRangeDifferentialOperations_UpdateAndReorder verifies content+reorder
-// renders take the full-tree fallback. Phase 4 removed the per-item ["u"] producer,
-// so the reorder cannot be emitted in isolation when kept items also changed content
-// — full-tree replacement carries both correctly.
+// TestGenerateRangeDifferentialOperations_UpdateAndReorder verifies that a
+// combined content change + reorder is encoded differentially: a per-item ["u"]
+// for the changed item plus a trailing ["o"] carrying the new key order. (Earlier
+// this took the full-tree fallback; the per-item ["u"] producer is back.)
 func TestGenerateRangeDifferentialOperations_UpdateAndReorder(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 
@@ -1138,14 +1259,43 @@ func TestGenerateRangeDifferentialOperations_UpdateAndReorder(t *testing.T) {
 		}},
 	}
 
-	if ops := GenerateRangeDifferentialOperations(oldValue, newValue, false); ops != nil {
-		t.Errorf("Expected nil-return for content+reorder change, got: %v", ops)
+	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
+	if !hasUpdateOp(ops, "id1", "Alpha Updated") {
+		t.Errorf("Expected a ['u','id1',{'1':'Alpha Updated'}] op, got: %v", ops)
+	}
+	if !hasReorderOp(ops, []string{"id2", "id1", "id3"}) {
+		t.Errorf("Expected a trailing ['o',['id2','id1','id3']] op, got: %v", ops)
 	}
 }
 
+// hasReorderOp reports whether ops contains ["o", wantKeys].
+func hasReorderOp(ops []interface{}, wantKeys []string) bool {
+	for _, op := range ops {
+		arr, ok := op.([]interface{})
+		if !ok || len(arr) < 2 || arr[0] != "o" {
+			continue
+		}
+		gotKeys, ok := arr[1].([]string)
+		if !ok || len(gotKeys) != len(wantKeys) {
+			continue
+		}
+		match := true
+		for i := range wantKeys {
+			if gotKeys[i] != wantKeys[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
 // TestGenerateRangeDifferentialOperations_MultipleUpdatesAndReorder same shape as
-// _UpdateAndReorder but with multiple kept-item content changes — also takes the
-// full-tree fallback per Phase 4.
+// _UpdateAndReorder but with multiple kept-item content changes — each emits its
+// own ["u"] alongside the trailing ["o"].
 func TestGenerateRangeDifferentialOperations_MultipleUpdatesAndReorder(t *testing.T) {
 	statics := []string{`<li data-key="`, `">`, `</li>`}
 
@@ -1166,8 +1316,12 @@ func TestGenerateRangeDifferentialOperations_MultipleUpdatesAndReorder(t *testin
 		}},
 	}
 
-	if ops := GenerateRangeDifferentialOperations(oldValue, newValue, false); ops != nil {
-		t.Errorf("Expected nil-return for multi-content+reorder change, got: %v", ops)
+	ops := GenerateRangeDifferentialOperations(oldValue, newValue, false)
+	if !hasUpdateOp(ops, "id1", "One Updated") || !hasUpdateOp(ops, "id2", "Two Updated") {
+		t.Errorf("Expected ['u'] ops for id1 and id2, got: %v", ops)
+	}
+	if !hasReorderOp(ops, []string{"id3", "id2", "id1"}) {
+		t.Errorf("Expected a trailing ['o',['id3','id2','id1']] op, got: %v", ops)
 	}
 }
 

--- a/internal/diff/transition.go
+++ b/internal/diff/transition.go
@@ -40,10 +40,19 @@ func transitionRangeIfHomogeneous(rd *build.RangeData) {
 	if !ok {
 		return
 	}
+	// Ranges whose items contain nested ranges stay on the differential path,
+	// which retains the old item trees stream mode discards. Only that path can
+	// recursively diff a kept-but-changed item into a nested ["u", key, …]
+	// (see GenerateRangeDifferentialOperations); transitioning to stream would
+	// force the whole enclosing branch to re-send on any deep edit. The check
+	// rides the homogeneity loop below, which already walks every item.
+	if nodeContainsNestedRange(firstItem) {
+		return
+	}
 	ref := build.CalculateStaticsFingerprint(firstItem)
 	for _, item := range rd.Items[1:] {
 		itemNode, ok := item.(*build.TreeNode)
-		if !ok || build.CalculateStaticsFingerprint(itemNode) != ref {
+		if !ok || build.CalculateStaticsFingerprint(itemNode) != ref || nodeContainsNestedRange(itemNode) {
 			return
 		}
 	}

--- a/internal/diff/transition_test.go
+++ b/internal/diff/transition_test.go
@@ -167,9 +167,16 @@ func TestTransitionToStreamMode_NestedRangesNotTransitioned(t *testing.T) {
 
 	TransitionToStreamMode(tree)
 
+	// A range whose items contain nested ranges must stay off the stream transition:
+	// stream mode discards the old item trees the recursive per-item diff needs, so
+	// keeping it on the differential path is what lets a deep edit scope to a nested
+	// ["u", key, …] instead of re-sending the whole enclosing branch.
 	outerRange := tree.Dynamics[0].(*build.TreeNode).Range
-	if outerRange.StreamState == nil {
-		t.Errorf("Outer top-level range should transition")
+	if outerRange.StreamState != nil {
+		t.Errorf("Outer range whose items contain nested ranges MUST NOT transition to stream")
+	}
+	if outerRange.Items == nil {
+		t.Errorf("Outer range Items must remain populated for the differential per-item diff")
 	}
 	if innerRangeNode.Range.StreamState != nil {
 		t.Errorf("Nested range MUST NOT transition (proposal §5a top-level only)")

--- a/internal/fuzz/invariants/verifier.go
+++ b/internal/fuzz/invariants/verifier.go
@@ -354,8 +354,23 @@ func hasStaticsInMap(m map[string]any) bool {
 		return true
 	}
 	for _, v := range m {
-		if nested, ok := v.(map[string]any); ok {
-			if hasStaticsInMap(nested) {
+		if staticsInValue(v) {
+			return true
+		}
+	}
+	return false
+}
+
+// staticsInValue recurses into nested maps AND slices — a ["u"] payload can carry
+// statics inside a nested range-op array (e.g. {"2": [["u", k, {"s": …}]]}), not
+// only inside nested maps, so the array case must be walked too.
+func staticsInValue(v any) bool {
+	switch val := v.(type) {
+	case map[string]any:
+		return hasStaticsInMap(val)
+	case []any:
+		for _, e := range val {
+			if staticsInValue(e) {
 				return true
 			}
 		}

--- a/internal/parse/api.go
+++ b/internal/parse/api.go
@@ -12,6 +12,13 @@ type Template struct {
 	name     string
 	ast      *parse.Tree
 	builtins map[string]reflect.Value
+
+	// registry holds the ASTs of recursively-invoked templates, keyed by name.
+	// FlattenTemplate leaves recursive {{template}} calls un-inlined and appends
+	// their (flattened) bodies as {{define}} blocks; those bodies re-parse here
+	// as associated templates, which Parse collects into this map. Empty when the
+	// template uses no recursion. Threaded to the evaluator by BuildTree.
+	registry map[string]*parse.Tree
 }
 
 // Parse parses a template string into an executable template structure.
@@ -27,10 +34,26 @@ func Parse(templateStr string, funcMap template.FuncMap) (*Template, error) {
 	if parsed.Tree == nil || parsed.Tree.Root == nil {
 		return nil, fmt.Errorf("template has no parse tree")
 	}
+
+	// Collect any associated {{define}} templates into the recursion registry.
+	// These are present only when FlattenTemplate detected recursion and emitted
+	// the cycle members as defines; a normal (fully-inlined) template has none.
+	var registry map[string]*parse.Tree
+	for _, assoc := range tmpl.Templates() {
+		if assoc.Name() == parsed.Name() || assoc.Tree == nil || assoc.Tree.Root == nil {
+			continue
+		}
+		if registry == nil {
+			registry = make(map[string]*parse.Tree)
+		}
+		registry[assoc.Name()] = assoc.Tree
+	}
+
 	return &Template{
 		name:     parsed.Name(),
 		ast:      parsed.Tree,
 		builtins: precomputeBuiltins(funcMap),
+		registry: registry,
 	}, nil
 }
 
@@ -40,6 +63,6 @@ func BuildTree(tmpl *Template, data interface{}, ctx *Context) (*TreeNode, error
 	if ctx == nil {
 		ctx = &Context{}
 	}
-	eval := &evaluator{builtins: tmpl.builtins}
+	eval := &evaluator{builtins: tmpl.builtins, templates: tmpl.registry}
 	return walkAST(tmpl.ast.Root, eval, data, nil, ctx)
 }

--- a/internal/parse/eval.go
+++ b/internal/parse/eval.go
@@ -17,6 +17,14 @@ var sentinel = &struct{}{}
 // replacing the old "serialize → re-parse → execute" pattern.
 type evaluator struct {
 	builtins map[string]reflect.Value
+
+	// templates holds the ASTs of recursively-invoked templates, keyed by name.
+	// Populated from a Template's registry (see Parse). A {{template "x" .}} node
+	// whose name is present here is evaluated at build time via invokeTemplate,
+	// producing a nested TreeNode. Non-recursive {{template}} calls never reach
+	// the evaluator — they are inlined during flattening — so this is empty for
+	// templates that don't use recursion.
+	templates map[string]*parse.Tree
 }
 
 // cachedBuiltins holds pre-reflected builtin functions, computed once.

--- a/internal/parse/flatten.go
+++ b/internal/parse/flatten.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"slices"
 	"strings"
 	"text/template/parse"
 )
@@ -61,9 +62,11 @@ func FlattenTemplate(tmpl *template.Template) (string, error) {
 		templates[t.Name()] = t
 	}
 
-	// Walk the tree and flatten
+	// Walk the tree and flatten. The active-path stack is seeded with the entry
+	// point's name so a self-referential entry point is caught on its first
+	// re-invocation and mutual-recursion errors print the cycle as authored.
 	var buf bytes.Buffer
-	if err := walkAndFlatten(mainTemplate.Tree.Root, templates, &buf); err != nil {
+	if err := walkAndFlatten(mainTemplate.Tree.Root, templates, &buf, []string{mainTemplate.Name()}); err != nil {
 		return "", err
 	}
 
@@ -202,7 +205,15 @@ func hasTemplateNode(node parse.Node) bool {
 }
 
 // walkAndFlatten recursively walks the AST and builds flattened template string.
-func walkAndFlatten(node parse.Node, templates map[string]*template.Template, buf *bytes.Buffer) error {
+//
+// stack holds the names of the templates whose bodies are currently being
+// inlined on the path from the entry point to this node (an active-path set,
+// not a global visited-set). A {{template "X"}} whose name is already on the
+// stack is a self-referential cycle: inlining it would expand forever and
+// stack-overflow at Parse, so it returns a ParseError instead. The same name
+// invoked twice on non-nested paths (a diamond) is not a cycle and still
+// inlines, because each invocation pops off the stack when its body returns.
+func walkAndFlatten(node parse.Node, templates map[string]*template.Template, buf *bytes.Buffer, stack []string) error {
 	if node == nil {
 		return nil
 	}
@@ -211,7 +222,7 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 	case *parse.ListNode:
 		// Process all child nodes
 		for _, child := range n.Nodes {
-			if err := walkAndFlatten(child, templates, buf); err != nil {
+			if err := walkAndFlatten(child, templates, buf, stack); err != nil {
 				return err
 			}
 		}
@@ -232,13 +243,13 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 		buf.WriteString(formatPipeForFlatten(n.Pipe))
 		buf.WriteString("}}")
 
-		if err := walkAndFlatten(n.List, templates, buf); err != nil {
+		if err := walkAndFlatten(n.List, templates, buf, stack); err != nil {
 			return err
 		}
 
 		if n.ElseList != nil {
 			buf.WriteString("{{else}}")
-			if err := walkAndFlatten(n.ElseList, templates, buf); err != nil {
+			if err := walkAndFlatten(n.ElseList, templates, buf, stack); err != nil {
 				return err
 			}
 		}
@@ -251,13 +262,13 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 		buf.WriteString(formatPipeForFlatten(n.Pipe))
 		buf.WriteString("}}")
 
-		if err := walkAndFlatten(n.List, templates, buf); err != nil {
+		if err := walkAndFlatten(n.List, templates, buf, stack); err != nil {
 			return err
 		}
 
 		if n.ElseList != nil {
 			buf.WriteString("{{else}}")
-			if err := walkAndFlatten(n.ElseList, templates, buf); err != nil {
+			if err := walkAndFlatten(n.ElseList, templates, buf, stack); err != nil {
 				return err
 			}
 		}
@@ -270,13 +281,13 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 		buf.WriteString(formatPipeForFlatten(n.Pipe))
 		buf.WriteString("}}")
 
-		if err := walkAndFlatten(n.List, templates, buf); err != nil {
+		if err := walkAndFlatten(n.List, templates, buf, stack); err != nil {
 			return err
 		}
 
 		if n.ElseList != nil {
 			buf.WriteString("{{else}}")
-			if err := walkAndFlatten(n.ElseList, templates, buf); err != nil {
+			if err := walkAndFlatten(n.ElseList, templates, buf, stack); err != nil {
 				return err
 			}
 		}
@@ -293,6 +304,16 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 		if refTemplate.Tree == nil || refTemplate.Tree.Root == nil {
 			return fmt.Errorf("template %q has no parse tree", n.Name)
 		}
+
+		// Cycle detection: if this template is already being inlined on the
+		// current path, inlining its body again would recurse forever and
+		// stack-overflow during Parse (livetemplate inlines {{template}} calls
+		// at parse time; it does not yet evaluate recursive invocations at
+		// runtime). Return a structured error naming the cycle instead.
+		if err := checkFlattenCycle(n, stack); err != nil {
+			return err
+		}
+		stack = append(stack, n.Name)
 
 		// Handle data context changes
 		// If template invocation passes a different context (e.g., {{template "name" .Field}}),
@@ -312,14 +333,14 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 			buf.WriteString(formatPipeForFlatten(n.Pipe))
 			buf.WriteString("}}")
 
-			if err := walkAndFlatten(refTemplate.Tree.Root, templates, buf); err != nil {
+			if err := walkAndFlatten(refTemplate.Tree.Root, templates, buf, stack); err != nil {
 				return err
 			}
 
 			buf.WriteString("{{end}}")
 		} else {
 			// No context change needed - inline as-is
-			if err := walkAndFlatten(refTemplate.Tree.Root, templates, buf); err != nil {
+			if err := walkAndFlatten(refTemplate.Tree.Root, templates, buf, stack); err != nil {
 				return err
 			}
 		}
@@ -331,6 +352,28 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 	}
 
 	return nil
+}
+
+// checkFlattenCycle reports a self-referential {{template}} invocation. If the
+// invoked name already appears on the active-path stack, inlining it again
+// would expand forever, so it returns a ParseError naming the cycle (the path
+// from the name's first appearance back to itself, e.g. "page -> row -> page").
+// Returns nil when the invocation is acyclic and safe to inline.
+func checkFlattenCycle(n *parse.TemplateNode, stack []string) error {
+	i := slices.Index(stack, n.Name)
+	if i < 0 {
+		return nil
+	}
+	cycle := strings.Join(stack[i:], " -> ") + " -> " + n.Name
+	return &ParseError{
+		Phase:    "parse",
+		NodeType: "template",
+		Expr:     n.Name,
+		Pos:      int(n.Position()),
+		Msg: fmt.Sprintf("recursive template invocation is not supported (cycle: %s); "+
+			"livetemplate inlines {{template}} calls at parse time, so a self-referential "+
+			"template would expand infinitely", cycle),
+	}
 }
 
 // formatPipe converts a pipe to its string representation.

--- a/internal/parse/flatten.go
+++ b/internal/parse/flatten.go
@@ -313,6 +313,11 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 		if err := checkFlattenCycle(n, stack); err != nil {
 			return err
 		}
+		// Push this name for the body recursion below. Reusing stack's backing
+		// array across sibling {{template}} invocations is safe only because the
+		// walk is strictly sequential (each child fully returns before the next
+		// starts) — a stale tail is never read concurrently. This invariant must
+		// hold if the walk is ever parallelized.
 		stack = append(stack, n.Name)
 
 		// Handle data context changes

--- a/internal/parse/flatten.go
+++ b/internal/parse/flatten.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"maps"
 	"slices"
+	"strconv"
 	"strings"
 	"text/template/parse"
 )
@@ -62,15 +64,97 @@ func FlattenTemplate(tmpl *template.Template) (string, error) {
 		templates[t.Name()] = t
 	}
 
+	// Identify templates that participate in a cycle. Their {{template}} calls are
+	// left un-inlined (emitted verbatim) and their bodies are re-emitted once as
+	// {{define}} blocks, so the recursion is resolved at build time rather than by
+	// infinite inlining. Non-recursive composition is unaffected — recursive is
+	// empty and every call inlines as before.
+	recursive := detectRecursiveTemplates(templates)
+
 	// Walk the tree and flatten. The active-path stack is seeded with the entry
 	// point's name so a self-referential entry point is caught on its first
 	// re-invocation and mutual-recursion errors print the cycle as authored.
+	// checkFlattenCycle stays as a backstop: if detection ever under-identifies a
+	// cycle, the un-emitted call re-enters here and is caught with a clean error
+	// instead of overflowing the stack.
 	var buf bytes.Buffer
-	if err := walkAndFlatten(mainTemplate.Tree.Root, templates, &buf, []string{mainTemplate.Name()}); err != nil {
+	if err := walkAndFlatten(mainTemplate.Tree.Root, templates, &buf, []string{mainTemplate.Name()}, recursive); err != nil {
 		return "", err
 	}
 
+	// Append each recursive template's flattened body as a {{define}} block. On
+	// re-parse these become associated templates that parse.Parse collects into
+	// the recursion registry; at build time invokeTemplate walks them per call.
+	// Bodies are flattened with the same recursive set, so their own recursive
+	// calls stay verbatim while any non-recursive {{template}} calls inline.
+	// Sorted for deterministic output (stable fingerprints and caching).
+	// detectRecursiveTemplates only records names whose templates have a non-nil
+	// Tree/Root, so templates[name] is safe to dereference here.
+	for _, name := range slices.Sorted(maps.Keys(recursive)) {
+		body := templates[name].Tree.Root
+		buf.WriteString("{{define ")
+		buf.WriteString(strconv.Quote(name))
+		buf.WriteString("}}")
+		if err := walkAndFlatten(body, templates, &buf, []string{name}, recursive); err != nil {
+			return "", err
+		}
+		buf.WriteString("{{end}}")
+	}
+
 	return buf.String(), nil
+}
+
+// detectRecursiveTemplates returns the set of template names that participate in
+// a cycle in the invocation graph — a name reachable from itself by following
+// {{template}} calls. Direct self-recursion, mutual recursion, and longer cycles
+// are all captured; a template merely on a path *into* a cycle is not.
+func detectRecursiveTemplates(templates map[string]*template.Template) map[string]bool {
+	graph := make(map[string][]string, len(templates))
+	for name, t := range templates {
+		if t.Tree == nil || t.Tree.Root == nil {
+			continue
+		}
+		graph[name] = collectInvokedTemplateNames(t.Tree.Root)
+	}
+
+	recursive := make(map[string]bool)
+	for name := range graph {
+		if reachableFromSelf(name, graph) {
+			recursive[name] = true
+		}
+	}
+	return recursive
+}
+
+// collectInvokedTemplateNames returns the names invoked by {{template}} nodes
+// anywhere within node's subtree (duplicates allowed; callers only test membership).
+func collectInvokedTemplateNames(node parse.Node) []string {
+	var names []string
+	forEachTemplateNode(node, func(tn *parse.TemplateNode) bool {
+		names = append(names, tn.Name)
+		return true
+	})
+	return names
+}
+
+// reachableFromSelf reports whether start can reach itself by following the
+// invocation graph — i.e. start lies on a cycle.
+func reachableFromSelf(start string, graph map[string][]string) bool {
+	visited := make(map[string]bool)
+	stack := append([]string(nil), graph[start]...)
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if n == start {
+			return true
+		}
+		if visited[n] {
+			continue
+		}
+		visited[n] = true
+		stack = append(stack, graph[n]...)
+	}
+	return false
 }
 
 // HasTemplateComposition checks if template uses {{define}}/{{template}}/{{block}}.
@@ -151,57 +235,42 @@ func findTopLevelTemplateInvocation(node *parse.ListNode) string {
 	return ""
 }
 
-// hasTemplateNode recursively checks for {{template}} or {{block}} nodes.
-func hasTemplateNode(node parse.Node) bool {
-	if node == nil {
-		return false
-	}
-
+// forEachTemplateNode walks node's subtree and calls fn for every {{template}}
+// (or {{block}}) invocation found, in source order. fn returns false to stop the
+// walk early; forEachTemplateNode returns false in that case, true if it ran to
+// completion. It descends List/If/Range/With bodies (both branches); a nil node
+// is a no-op, so callers need no nil guards.
+func forEachTemplateNode(node parse.Node, fn func(*parse.TemplateNode) bool) bool {
 	switch n := node.(type) {
 	case *parse.ListNode:
 		if n == nil {
-			return false
+			return true
 		}
 		for _, child := range n.Nodes {
-			if hasTemplateNode(child) {
-				return true
+			if !forEachTemplateNode(child, fn) {
+				return false
 			}
 		}
 	case *parse.IfNode:
-		if n == nil {
-			return false
-		}
-		if hasTemplateNode(n.List) {
-			return true
-		}
-		if n.ElseList != nil && hasTemplateNode(n.ElseList) {
-			return true
-		}
+		return forEachTemplateNode(n.List, fn) && forEachTemplateNode(n.ElseList, fn)
 	case *parse.RangeNode:
-		if n == nil {
-			return false
-		}
-		if hasTemplateNode(n.List) {
-			return true
-		}
-		if n.ElseList != nil && hasTemplateNode(n.ElseList) {
-			return true
-		}
+		return forEachTemplateNode(n.List, fn) && forEachTemplateNode(n.ElseList, fn)
 	case *parse.WithNode:
-		if n == nil {
-			return false
-		}
-		if hasTemplateNode(n.List) {
-			return true
-		}
-		if n.ElseList != nil && hasTemplateNode(n.ElseList) {
-			return true
-		}
+		return forEachTemplateNode(n.List, fn) && forEachTemplateNode(n.ElseList, fn)
 	case *parse.TemplateNode:
-		return true
+		return fn(n)
 	}
+	return true
+}
 
-	return false
+// hasTemplateNode recursively checks for {{template}} or {{block}} nodes.
+func hasTemplateNode(node parse.Node) bool {
+	found := false
+	forEachTemplateNode(node, func(*parse.TemplateNode) bool {
+		found = true
+		return false // stop at the first hit
+	})
+	return found
 }
 
 // walkAndFlatten recursively walks the AST and builds flattened template string.
@@ -213,7 +282,7 @@ func hasTemplateNode(node parse.Node) bool {
 // stack-overflow at Parse, so it returns a ParseError instead. The same name
 // invoked twice on non-nested paths (a diamond) is not a cycle and still
 // inlines, because each invocation pops off the stack when its body returns.
-func walkAndFlatten(node parse.Node, templates map[string]*template.Template, buf *bytes.Buffer, stack []string) error {
+func walkAndFlatten(node parse.Node, templates map[string]*template.Template, buf *bytes.Buffer, stack []string, recursive map[string]bool) error {
 	if node == nil {
 		return nil
 	}
@@ -222,7 +291,7 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 	case *parse.ListNode:
 		// Process all child nodes
 		for _, child := range n.Nodes {
-			if err := walkAndFlatten(child, templates, buf, stack); err != nil {
+			if err := walkAndFlatten(child, templates, buf, stack, recursive); err != nil {
 				return err
 			}
 		}
@@ -243,13 +312,13 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 		buf.WriteString(formatPipeForFlatten(n.Pipe))
 		buf.WriteString("}}")
 
-		if err := walkAndFlatten(n.List, templates, buf, stack); err != nil {
+		if err := walkAndFlatten(n.List, templates, buf, stack, recursive); err != nil {
 			return err
 		}
 
 		if n.ElseList != nil {
 			buf.WriteString("{{else}}")
-			if err := walkAndFlatten(n.ElseList, templates, buf, stack); err != nil {
+			if err := walkAndFlatten(n.ElseList, templates, buf, stack, recursive); err != nil {
 				return err
 			}
 		}
@@ -262,13 +331,13 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 		buf.WriteString(formatPipeForFlatten(n.Pipe))
 		buf.WriteString("}}")
 
-		if err := walkAndFlatten(n.List, templates, buf, stack); err != nil {
+		if err := walkAndFlatten(n.List, templates, buf, stack, recursive); err != nil {
 			return err
 		}
 
 		if n.ElseList != nil {
 			buf.WriteString("{{else}}")
-			if err := walkAndFlatten(n.ElseList, templates, buf, stack); err != nil {
+			if err := walkAndFlatten(n.ElseList, templates, buf, stack, recursive); err != nil {
 				return err
 			}
 		}
@@ -281,13 +350,13 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 		buf.WriteString(formatPipeForFlatten(n.Pipe))
 		buf.WriteString("}}")
 
-		if err := walkAndFlatten(n.List, templates, buf, stack); err != nil {
+		if err := walkAndFlatten(n.List, templates, buf, stack, recursive); err != nil {
 			return err
 		}
 
 		if n.ElseList != nil {
 			buf.WriteString("{{else}}")
-			if err := walkAndFlatten(n.ElseList, templates, buf, stack); err != nil {
+			if err := walkAndFlatten(n.ElseList, templates, buf, stack, recursive); err != nil {
 				return err
 			}
 		}
@@ -295,6 +364,22 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 		buf.WriteString("{{end}}")
 
 	case *parse.TemplateNode:
+		// A recursive template is left un-inlined: emit the invocation verbatim so
+		// it survives re-parse as a {{template}} node and is evaluated at build
+		// time (see invokeTemplate). Its body is emitted once as a {{define}} block
+		// by FlattenTemplate. This branch is what breaks the infinite inlining that
+		// checkFlattenCycle below can only detect after the fact.
+		if recursive[n.Name] {
+			buf.WriteString("{{template ")
+			buf.WriteString(strconv.Quote(n.Name))
+			if n.Pipe != nil {
+				buf.WriteByte(' ')
+				buf.WriteString(formatPipeForFlatten(n.Pipe))
+			}
+			buf.WriteString("}}")
+			return nil
+		}
+
 		// {{template "name" .}} - inline the template
 		refTemplate, exists := templates[n.Name]
 		if !exists {
@@ -338,14 +423,14 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 			buf.WriteString(formatPipeForFlatten(n.Pipe))
 			buf.WriteString("}}")
 
-			if err := walkAndFlatten(refTemplate.Tree.Root, templates, buf, stack); err != nil {
+			if err := walkAndFlatten(refTemplate.Tree.Root, templates, buf, stack, recursive); err != nil {
 				return err
 			}
 
 			buf.WriteString("{{end}}")
 		} else {
 			// No context change needed - inline as-is
-			if err := walkAndFlatten(refTemplate.Tree.Root, templates, buf, stack); err != nil {
+			if err := walkAndFlatten(refTemplate.Tree.Root, templates, buf, stack, recursive); err != nil {
 				return err
 			}
 		}

--- a/internal/parse/flatten_cycle_test.go
+++ b/internal/parse/flatten_cycle_test.go
@@ -1,0 +1,115 @@
+package parse
+
+import (
+	"errors"
+	"html/template"
+	"strings"
+	"testing"
+)
+
+// mustParse builds an associated template set from src. The root template is
+// named "main"; any {{define}} blocks in src become associated templates, the
+// same shape parseInternal produces before it calls FlattenTemplate.
+func mustParse(t *testing.T, src string) *template.Template {
+	t.Helper()
+	tmpl, err := template.New("main").Parse(src)
+	if err != nil {
+		t.Fatalf("stdlib Parse failed (fixture bug, not the code under test): %v", err)
+	}
+	return tmpl
+}
+
+// TestFlattenTemplate_Diamond is the discriminating test for the cycle guard:
+// the same template invoked more than once on non-nested paths is NOT a cycle
+// and must still flatten. "leaf" is invoked three times (twice as siblings in
+// "row", once directly in "page") with no invocation ever nested inside its own
+// body. A correct active-path guard pops each invocation on return, so this
+// flattens cleanly; a global visited-set would wrongly reject the second "leaf".
+func TestFlattenTemplate_Diamond(t *testing.T) {
+	src := `{{define "leaf"}}<span>{{.}}</span>{{end}}` +
+		`{{define "row"}}{{template "leaf" .A}}{{template "leaf" .B}}{{end}}` +
+		`{{define "page"}}{{template "row" .}}{{template "leaf" .C}}{{end}}` +
+		`{{template "page" .}}`
+
+	out, err := FlattenTemplate(mustParse(t, src))
+	if err != nil {
+		t.Fatalf("diamond composition must flatten without error, got: %v", err)
+	}
+	// leaf's statics appear once per invocation (3×): proves each was inlined.
+	if got := strings.Count(out, "<span>"); got != 3 {
+		t.Errorf("expected leaf inlined 3 times, got %d in:\n%s", got, out)
+	}
+}
+
+// TestFlattenTemplate_Cycles covers the self-referential invocation graphs that
+// stack-overflowed during Parse before this guard. Each must come back as a
+// *ParseError naming the cycle — never a panic and never a silent success.
+func TestFlattenTemplate_Cycles(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantCycle string // substring expected in the reported cycle
+	}{
+		{
+			name: "direct recursion",
+			src: `{{define "treeNode"}}<li>{{.Name}}<ul>` +
+				`{{range .Children}}{{template "treeNode" .}}{{end}}` +
+				`</ul></li>{{end}}` +
+				`{{template "treeNode" .}}`,
+			wantCycle: "treeNode -> treeNode",
+		},
+		{
+			name: "mutual recursion",
+			src: `{{define "a"}}<div>{{template "b" .}}</div>{{end}}` +
+				`{{define "b"}}<span>{{template "a" .}}</span>{{end}}` +
+				`{{template "a" .}}`,
+			wantCycle: "a -> b -> a",
+		},
+		{
+			name:      "self-referential entry point",
+			src:       `<div>{{template "main" .}}</div>`,
+			wantCycle: "main -> main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := FlattenTemplate(mustParse(t, tt.src))
+			if err == nil {
+				t.Fatal("expected a ParseError for recursive template, got nil")
+			}
+
+			var pe *ParseError
+			if !errors.As(err, &pe) {
+				t.Fatalf("expected *ParseError, got %T: %v", err, err)
+			}
+			if pe.Phase != "parse" {
+				t.Errorf("expected Phase %q, got %q", "parse", pe.Phase)
+			}
+			if !strings.Contains(err.Error(), tt.wantCycle) {
+				t.Errorf("error should report cycle %q, got: %v", tt.wantCycle, err)
+			}
+			if !strings.Contains(err.Error(), "recursive") {
+				t.Errorf("error should mention %q, got: %v", "recursive", err)
+			}
+		})
+	}
+}
+
+// TestFlattenTemplate_NonRecursiveUnaffected guards against the guard: ordinary
+// (acyclic) composition must keep flattening byte-for-byte as before.
+func TestFlattenTemplate_NonRecursiveUnaffected(t *testing.T) {
+	src := `{{define "header"}}<h1>{{.Title}}</h1>{{end}}` +
+		`{{define "footer"}}<footer>{{.Year}}</footer>{{end}}` +
+		`{{template "header" .}}<main>{{.Body}}</main>{{template "footer" .}}`
+
+	out, err := FlattenTemplate(mustParse(t, src))
+	if err != nil {
+		t.Fatalf("non-recursive composition must flatten cleanly, got: %v", err)
+	}
+	for _, want := range []string{"<h1>", "<main>", "<footer>"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("flattened output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/parse/flatten_cycle_test.go
+++ b/internal/parse/flatten_cycle_test.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"bytes"
 	"errors"
 	"html/template"
 	"strings"
@@ -41,14 +42,19 @@ func TestFlattenTemplate_Diamond(t *testing.T) {
 	}
 }
 
-// TestFlattenTemplate_Cycles covers the self-referential invocation graphs that
-// stack-overflowed during Parse before this guard. Each must come back as a
-// *ParseError naming the cycle — never a panic and never a silent success.
-func TestFlattenTemplate_Cycles(t *testing.T) {
+// TestFlattenTemplate_RecursionEmittedForRuntime covers the self-referential
+// invocation graphs that once stack-overflowed during Parse. They must now
+// flatten cleanly: each cycle member's {{template}} call is left verbatim (so it
+// survives re-parse and is evaluated at build time by invokeTemplate) and its
+// body is re-emitted once as a {{define}} block for the recursion registry.
+func TestFlattenTemplate_RecursionEmittedForRuntime(t *testing.T) {
 	tests := []struct {
-		name      string
-		src       string
-		wantCycle string // substring expected in the reported cycle
+		name string
+		src  string
+		// verbatim invocations that must remain un-inlined, and the {{define}}
+		// blocks that must be appended for the registry.
+		wantVerbatim []string
+		wantDefines  []string
 	}{
 		{
 			name: "direct recursion",
@@ -56,43 +62,77 @@ func TestFlattenTemplate_Cycles(t *testing.T) {
 				`{{range .Children}}{{template "treeNode" .}}{{end}}` +
 				`</ul></li>{{end}}` +
 				`{{template "treeNode" .}}`,
-			wantCycle: "treeNode -> treeNode",
+			wantVerbatim: []string{`{{template "treeNode"`},
+			wantDefines:  []string{`{{define "treeNode"}}`},
 		},
 		{
 			name: "mutual recursion",
 			src: `{{define "a"}}<div>{{template "b" .}}</div>{{end}}` +
 				`{{define "b"}}<span>{{template "a" .}}</span>{{end}}` +
 				`{{template "a" .}}`,
-			wantCycle: "a -> b -> a",
+			wantVerbatim: []string{`{{template "a"`, `{{template "b"`},
+			wantDefines:  []string{`{{define "a"}}`, `{{define "b"}}`},
 		},
 		{
-			name:      "self-referential entry point",
-			src:       `<div>{{template "main" .}}</div>`,
-			wantCycle: "main -> main",
+			name:         "self-referential entry point",
+			src:          `<div>{{template "main" .}}</div>`,
+			wantVerbatim: []string{`{{template "main"`},
+			wantDefines:  []string{`{{define "main"}}`},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := FlattenTemplate(mustParse(t, tt.src))
-			if err == nil {
-				t.Fatal("expected a ParseError for recursive template, got nil")
+			out, err := FlattenTemplate(mustParse(t, tt.src))
+			if err != nil {
+				t.Fatalf("recursive template must flatten for runtime invocation, got: %v", err)
 			}
-
-			var pe *ParseError
-			if !errors.As(err, &pe) {
-				t.Fatalf("expected *ParseError, got %T: %v", err, err)
+			for _, want := range tt.wantVerbatim {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected verbatim invocation %q (recursion left un-inlined) in:\n%s", want, out)
+				}
 			}
-			if pe.Phase != "parse" {
-				t.Errorf("expected Phase %q, got %q", "parse", pe.Phase)
+			for _, want := range tt.wantDefines {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected registry define %q appended in:\n%s", want, out)
+				}
 			}
-			if !strings.Contains(err.Error(), tt.wantCycle) {
-				t.Errorf("error should report cycle %q, got: %v", tt.wantCycle, err)
-			}
-			if !strings.Contains(err.Error(), "recursive") {
-				t.Errorf("error should mention %q, got: %v", "recursive", err)
+			// The flattened string must re-parse (it feeds parse.Parse), which
+			// also confirms the appended defines are well-formed.
+			if _, err := template.New("verify").Parse(out); err != nil {
+				t.Errorf("flattened output must re-parse, got: %v\n%s", err, out)
 			}
 		})
+	}
+}
+
+// TestFlattenTemplate_CycleBackstop proves the active-path guard (checkFlattenCycle)
+// still fires as a safety net: if detection ever under-identifies a cycle, the
+// un-emitted {{template}} call re-enters walkAndFlatten and must produce a clean
+// ParseError naming the cycle — never a stack overflow. Simulated by walking a
+// self-referential template with an empty recursive set (detection "missed" it).
+func TestFlattenTemplate_CycleBackstop(t *testing.T) {
+	src := `{{define "treeNode"}}<li>{{.Name}}` +
+		`{{range .Children}}{{template "treeNode" .}}{{end}}` +
+		`</li>{{end}}` +
+		`{{template "treeNode" .}}`
+	tmpl := mustParse(t, src)
+	templates := map[string]*template.Template{}
+	for _, tm := range tmpl.Templates() {
+		templates[tm.Name()] = tm
+	}
+
+	var buf bytes.Buffer
+	err := walkAndFlatten(tmpl.Tree.Root, templates, &buf, []string{tmpl.Name()}, map[string]bool{})
+	if err == nil {
+		t.Fatal("empty recursive set must fall through to the cycle backstop, got nil")
+	}
+	var pe *ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "treeNode -> treeNode") || !strings.Contains(err.Error(), "recursive") {
+		t.Errorf("backstop error should name the cycle, got: %v", err)
 	}
 }
 

--- a/internal/parse/flatten_fuzz_test.go
+++ b/internal/parse/flatten_fuzz_test.go
@@ -1,0 +1,45 @@
+package parse
+
+import (
+	"html/template"
+	"testing"
+)
+
+// FuzzFlattenTemplate guards the flatten path against inputs that make
+// walkAndFlatten recurse without bound. Before the cycle guard, a
+// self-referential {{template}} stack-overflowed here; the seed corpus pins
+// exactly those shapes. FlattenTemplate must always return (a flattened string
+// or a ParseError) and never panic — Go's fuzzer fails the run on any panic or
+// fatal stack overflow.
+func FuzzFlattenTemplate(f *testing.F) {
+	seeds := []string{
+		// Acyclic composition — must flatten fine (the common case).
+		`{{define "h"}}<h1>{{.T}}</h1>{{end}}{{template "h" .}}<p>{{.B}}</p>`,
+		// A diamond: same template invoked on non-nested paths, not a cycle.
+		`{{define "leaf"}}<span>{{.}}</span>{{end}}` +
+			`{{define "row"}}{{template "leaf" .A}}{{template "leaf" .B}}{{end}}` +
+			`{{template "row" .}}`,
+		// Direct self-recursion — previously overflowed at Parse.
+		`{{define "r"}}<li>{{.N}}{{range .C}}{{template "r" .}}{{end}}</li>{{end}}` +
+			`{{template "r" .}}`,
+		// Mutual recursion.
+		`{{define "a"}}{{template "b" .}}{{end}}` +
+			`{{define "b"}}{{template "a" .}}{{end}}` +
+			`{{template "a" .}}`,
+		// Self-referential entry point (no {{define}}).
+		`<div>{{template "main" .}}</div>`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, src string) {
+		tmpl, err := template.New("main").Parse(src)
+		if err != nil {
+			t.Skip() // Only exercise inputs Go's own parser accepts.
+		}
+		// The contract under test: returns, never panics/overflows. The result
+		// (string or error) is deliberately unused — the guard is what matters.
+		_, _ = FlattenTemplate(tmpl)
+	})
+}

--- a/internal/parse/invoke.go
+++ b/internal/parse/invoke.go
@@ -1,0 +1,81 @@
+package parse
+
+import (
+	"fmt"
+	"text/template/parse"
+)
+
+// defaultMaxInvocationDepth bounds recursive {{template}} invocation when the
+// caller has not set Context.MaxInvocationDepth. It sits well below Go's build
+// stack limit, so it trips before a self-referential data graph or a
+// pathologically deep tree can overflow walkAST.
+const defaultMaxInvocationDepth = 128
+
+// maxInvocationDepth returns the effective recursion cap: the caller's override
+// if positive, otherwise the built-in default. ctx is always non-nil here
+// (invokeTemplate dereferences it before calling this).
+func maxInvocationDepth(ctx *Context) int {
+	if ctx.MaxInvocationDepth > 0 {
+		return ctx.MaxInvocationDepth
+	}
+	return defaultMaxInvocationDepth
+}
+
+// invokeTemplate evaluates a recursive {{template "name" pipe}} node at build
+// time, returning the invoked body as a nested TreeNode occupying a single
+// dynamic slot in the caller's tree (mirroring how handleIf wraps a branch).
+//
+// Non-recursive {{template}} calls never reach here — they are inlined during
+// flattening. Only names left un-inlined by FlattenTemplate (the cycle members)
+// are present in eval.templates and routed through this path.
+func invokeTemplate(n *parse.TemplateNode, eval *evaluator, data interface{}, varCtx *varContext, ctx *Context) (*TreeNode, error) {
+	body, ok := eval.templates[n.Name]
+	if !ok {
+		// A {{template}} that survived flattening but has no registered body means
+		// detection and flattening disagreed — treat as a build error rather than
+		// silently rendering nothing.
+		return nil, &ParseError{
+			Phase: "build", NodeType: "template", Expr: n.Name,
+			Msg: fmt.Sprintf("template %q invoked at runtime but not found in the recursion registry", n.Name),
+		}
+	}
+
+	limit := maxInvocationDepth(ctx)
+	if ctx.InvocationDepth >= limit {
+		return nil, &ParseError{
+			Phase: "build", NodeType: "template", Expr: n.Name,
+			Msg: fmt.Sprintf("recursive template %q exceeded the maximum invocation depth of %d "+
+				"(possible infinite recursion in the data; raise the limit with WithMaxTemplateDepth if the "+
+				"nesting is legitimately deeper)", n.Name, limit),
+		}
+	}
+
+	// Go rebinds dot on a template call to the pipe value (defaulting to the
+	// caller's dot when the invocation is {{template "name"}} with no argument).
+	invocationDot := dot(data, varCtx)
+	if n.Pipe != nil {
+		v, err := eval.evalPipe(n.Pipe, invocationDot, varCtx)
+		if err != nil {
+			return nil, &ParseError{Phase: "eval", NodeType: "template", Expr: n.Name, Err: err}
+		}
+		invocationDot = v
+	}
+
+	// The invoked template gets a fresh scope: dot = the pipe value, and none of
+	// the caller's $variables carry over (Go hands an invoked template only its
+	// argument). A nil varCtx is exactly that clean scope — walkList lazily
+	// re-inits one rooted at invocationDot if the body declares its own vars.
+	childCtx := *ctx
+	childCtx.InvocationDepth++
+	childTree, err := walkAST(body.Root, eval, invocationDot, nil, &childCtx)
+	if err != nil {
+		return nil, err
+	}
+	// Wrap the invoked body in its own dynamic slot (createConditionalWrapper is a
+	// generic single-dynamic-slot wrapper, despite the conditional-flavored name).
+	// This isolation is why an invocation wraps where {{with}} does not: a
+	// recursive subtree's depth/shape varies with the data, so it must occupy one
+	// slot to keep those changes from restructuring the parent's statics — the
+	// same diffing rationale {{if}} wraps for.
+	return createConditionalWrapper(childTree, ctx), nil
+}

--- a/internal/parse/invoke.go
+++ b/internal/parse/invoke.go
@@ -50,11 +50,14 @@ func invokeTemplate(n *parse.TemplateNode, eval *evaluator, data interface{}, va
 		}
 	}
 
-	// Go rebinds dot on a template call to the pipe value (defaulting to the
-	// caller's dot when the invocation is {{template "name"}} with no argument).
-	invocationDot := dot(data, varCtx)
+	// Go rebinds dot on a template call to the pipe value; a no-argument
+	// {{template "name"}} rebinds dot to nil (NOT the caller's dot). Matching
+	// that keeps the tree path byte-identical to html/template Execute. The pipe,
+	// when present, still resolves against the caller's dot (e.g. {{template "x"
+	// .Field}} reads .Field from the caller).
+	var invocationDot interface{}
 	if n.Pipe != nil {
-		v, err := eval.evalPipe(n.Pipe, invocationDot, varCtx)
+		v, err := eval.evalPipe(n.Pipe, dot(data, varCtx), varCtx)
 		if err != nil {
 			return nil, &ParseError{Phase: "eval", NodeType: "template", Expr: n.Name, Err: err}
 		}

--- a/internal/parse/keys.go
+++ b/internal/parse/keys.go
@@ -122,9 +122,20 @@ func wrappedItemKey(item *TreeNode) (string, bool) {
 // (nil, false) if any item does not expose one. It is all-or-nothing so a range
 // never mixes stable data-keys with content hashes.
 func allWrappedItemKeys(items []rangeItemWithStatics) ([]string, bool) {
+	if len(items) == 0 {
+		return nil, false
+	}
+	// Probe the first item before allocating: an ordinary (non-recursive)
+	// auto-keyed range fails here, so it avoids an N-length slice thrown away on
+	// every render — only a genuine recursive-invocation range gets past item 0.
+	first, ok := wrappedItemKey(items[0].tree)
+	if !ok {
+		return nil, false
+	}
 	out := make([]string, len(items))
-	for i, item := range items {
-		key, ok := wrappedItemKey(item.tree)
+	out[0] = first
+	for i := 1; i < len(items); i++ {
+		key, ok := wrappedItemKey(items[i].tree)
 		if !ok {
 			return nil, false
 		}

--- a/internal/parse/keys.go
+++ b/internal/parse/keys.go
@@ -81,3 +81,54 @@ func generateItemHash(item *TreeNode) string {
 	}
 	return keys.GenerateItemHashFromSlice(item.Dynamics)
 }
+
+// wrappedItemKey returns the explicit data-key of a range item whose real keyed
+// element is hidden one level down inside an invocation wrapper (the shape a
+// recursive {{template}} range produces: createConditionalWrapper wraps the
+// invoked body, so the item's own statics are empty and the <li data-key> lives
+// in the single nested child). It reads the key value *through* the wrapper
+// without restructuring the item, so the item keeps a stable identity across
+// deep edits (the key is the item's path, not a content hash of its subtree).
+//
+// Returns ("", false) when the item is not this simple single-child wrapper or
+// the child carries no key attribute — callers then fall back to content hashing.
+func wrappedItemKey(item *TreeNode) (string, bool) {
+	if item == nil || hasExplicitKeyAttribute(item.Statics) {
+		return "", false
+	}
+	var child *TreeNode
+	for _, d := range item.Dynamics {
+		c, ok := d.(*TreeNode)
+		if !ok {
+			continue
+		}
+		if child != nil {
+			return "", false // more than one nested child: not the simple wrapper
+		}
+		child = c
+	}
+	if child == nil || !hasExplicitKeyAttribute(child.Statics) {
+		return "", false
+	}
+	if v, ok := child.GetDynamic(detectIDKey(child.Statics)); ok {
+		if s, ok := v.(string); ok && s != "" {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+// allWrappedItemKeys returns the through-wrapper data-key of every item, or
+// (nil, false) if any item does not expose one. It is all-or-nothing so a range
+// never mixes stable data-keys with content hashes.
+func allWrappedItemKeys(items []rangeItemWithStatics) ([]string, bool) {
+	out := make([]string, len(items))
+	for i, item := range items {
+		key, ok := wrappedItemKey(item.tree)
+		if !ok {
+			return nil, false
+		}
+		out[i] = key
+	}
+	return out, true
+}

--- a/internal/parse/range.go
+++ b/internal/parse/range.go
@@ -202,9 +202,20 @@ func buildRangeTreeWithStatics(items []rangeItemWithStatics, ctx *Context) (*Tre
 	idKey := build.PositionKey(detectIDKey(firstStatics))
 
 	if !hasExplicitKeyAttribute(firstStatics) {
-		for _, item := range items {
-			hash := generateItemHash(item.tree)
-			item.tree.AutoKey = hash
+		// When every item is an invocation wrapper hiding a real <li data-key>
+		// (the recursive {{template}} range shape), key by that data-key seen
+		// through the wrapper. Stable per-item identity lets the diff engine
+		// scope a deep edit to a nested ["u", key, …] instead of re-sending the
+		// whole enclosing branch. Require ALL items to expose a key — mixing
+		// stable keys with content hashes in one range breaks identity.
+		if wrapperKeys, ok := allWrappedItemKeys(items); ok {
+			for i, item := range items {
+				item.tree.AutoKey = wrapperKeys[i]
+			}
+		} else {
+			for _, item := range items {
+				item.tree.AutoKey = generateItemHash(item.tree)
+			}
 		}
 		idKey = "_k"
 	}

--- a/internal/parse/walker.go
+++ b/internal/parse/walker.go
@@ -40,11 +40,7 @@ func walkAST(node parse.Node, eval *evaluator, data interface{}, varCtx *varCont
 		return NewTreeNode(), nil
 
 	case *parse.TemplateNode:
-		return nil, &ParseError{
-			Phase: "build", NodeType: "template",
-			Expr: n.Name,
-			Msg:  "template invocation found - should be flattened",
-		}
+		return invokeTemplate(n, eval, data, varCtx, ctx)
 
 	default:
 		return nil, &ParseError{

--- a/recursive_template_bench_test.go
+++ b/recursive_template_bench_test.go
@@ -10,12 +10,11 @@ import (
 
 // These benchmarks characterize the runtime-invocation recursion path (C8)
 // against the status quo it replaces — a whole recursive subtree rendered as one
-// opaque html/template string and shipped as {{.FileBrowserHTML}}. They exist to
-// keep the value story honest: recursion support's unconditional win is
-// *correctness* (a recursive {{template}} renders at all, and does so as part of
-// the page's reactive tree instead of an innerHTML blob), NOT a smaller update
-// payload. The update-size numbers below show why the "minimal update" claim does
-// not yet hold for deep, narrow trees — see BenchmarkRecursiveUpdate.
+// opaque html/template string and shipped as {{.FileBrowserHTML}}. Recursion
+// support renders a recursive {{template}} at all (the flatten path overflows) AND
+// keeps it inside the page's reactive tree. With per-leaf recursive range diffing,
+// a deep edit is scoped to a nested ["u", key, …] chain down to the single changed
+// node — see BenchmarkRecursiveUpdate for the wire-size win over the opaque baseline.
 
 // benchTree builds a balanced directory tree of the given depth and branching
 // factor — a stand-in for a file browser / comment thread / org chart, the shapes
@@ -58,25 +57,18 @@ func BenchmarkRecursiveRender(b *testing.B) {
 // tree: rebuild and diff against the previous render (what the framework does on
 // every action), reporting the wire payload as "update_bytes".
 //
-// The honest finding this benchmark exists to surface: the update is NOT scoped to
-// the changed leaf. Recursive range items are keyed by a *deep content hash* (the
-// item's real <li data-key> is hidden one level down inside the invocation
-// wrapper, so range keying can't see it — see the keying caveat in
-// docs/proposals/recursive-templates-proposal.md §6). Renaming any node changes
-// every ancestor's hash, so the diff re-sends the item's whole ENCLOSING TOP-LEVEL
-// BRANCH as ["r", oldkey],["p", [full branch with statics]] — its sibling branches
-// are spared, but the branch itself comes back whole.
+// The update is scoped to the changed leaf. Recursive range items are keyed by
+// their real data-key (the <li data-key>, read through the invocation wrapper), so
+// a deep edit leaves every ancestor's key stable and the differential range diff
+// emits a nested ["u", key, …] chain down to the single renamed node — statics-free
+// and carrying no unaffected sibling.
 //
-// Concretely, for this depth-5 branch-3 shape a deep-leaf edit's update_bytes
-// (~24KB, one of three top-level branches) lands ESSENTIALLY EQUAL to
-// BenchmarkOpaqueHTMLBaseline's full_html_bytes (~23.5KB, the whole tree) — and
-// costs ~25x the CPU to produce. So for a deep, narrow tree the reactive update is
-// no smaller on the wire than shipping the entire opaque string, and much dearer to
-// compute. The update-size win only materializes when the enclosing branch is a
-// small fraction of the tree (a WIDE tree, many top-level branches) or once the
-// data-key-through-the-wrapper follow-up lands and deep edits scope to a single
-// per-leaf ["u", key, {…}]. Recursion support's win here is correctness and
-// reactive DOM-state preservation, not payload size.
+// Concretely, for this depth-5 branch-3 shape (~364 nodes) a deep-leaf edit's
+// update_bytes is ~200 B versus BenchmarkOpaqueHTMLBaseline's full_html_bytes
+// (~23.5 KB, the whole tree re-sent) — a ~100x wire-size reduction, the win
+// recursion-in-the-reactive-tree delivers over the opaque {{.FileBrowserHTML}}
+// escape hatch. The trade is CPU: the reactive path rebuilds + diffs the tree
+// (~20x an opaque Execute), buying the minimal payload and in-place DOM updates.
 func BenchmarkRecursiveUpdate(b *testing.B) {
 	parsed, err := Must(New("bench")).Parse(recursiveTreeSrc)
 	if err != nil {
@@ -114,10 +106,9 @@ func BenchmarkRecursiveUpdate(b *testing.B) {
 // which the client applies by replacing innerHTML — no tree diff, and every DOM
 // node in the region is destroyed and rebuilt (focus, scroll, and event state in
 // the subtree are lost). Its full_html_bytes is the number BenchmarkRecursiveUpdate's
-// update_bytes should be read against: for the deep-narrow shape here they are
-// ~equal in bytes, but this baseline is ~25x cheaper in CPU. Recursion support does
-// not beat it on payload or CPU for this shape — it beats it on *what the client can
-// do with the payload* (in-place reconciliation) and on rendering correctly at all.
+// update_bytes should be read against: the reactive per-leaf update is ~100x smaller
+// on the wire and preserves DOM state, at the cost of ~20x the CPU to compute the
+// diff. The baseline is cheaper per render but re-sends everything on every change.
 func BenchmarkOpaqueHTMLBaseline(b *testing.B) {
 	// A standalone recursive html/template (the workaround: recursion works, but
 	// the output is one opaque string with no tree/diff).

--- a/recursive_template_bench_test.go
+++ b/recursive_template_bench_test.go
@@ -1,0 +1,144 @@
+package livetemplate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"testing"
+)
+
+// These benchmarks characterize the runtime-invocation recursion path (C8)
+// against the status quo it replaces — a whole recursive subtree rendered as one
+// opaque html/template string and shipped as {{.FileBrowserHTML}}. They exist to
+// keep the value story honest: recursion support's unconditional win is
+// *correctness* (a recursive {{template}} renders at all, and does so as part of
+// the page's reactive tree instead of an innerHTML blob), NOT a smaller update
+// payload. The update-size numbers below show why the "minimal update" claim does
+// not yet hold for deep, narrow trees — see BenchmarkRecursiveUpdate.
+
+// benchTree builds a balanced directory tree of the given depth and branching
+// factor — a stand-in for a file browser / comment thread / org chart, the shapes
+// recursive {{template}} exists to serve.
+func benchTree(depth, branch int, prefix string) fileNode {
+	n := fileNode{Name: fmt.Sprintf("dir%s", prefix), Path: "/d" + prefix, IsDir: true}
+	if depth == 0 {
+		return fileNode{Name: fmt.Sprintf("file%s.go", prefix), Path: "/f" + prefix + ".go"}
+	}
+	for i := 0; i < branch; i++ {
+		n.Children = append(n.Children, benchTree(depth-1, branch, fmt.Sprintf("%s-%d", prefix, i)))
+	}
+	return n
+}
+
+// BenchmarkRecursiveRender measures a first render of a recursive tree through the
+// reactive tree path (parse → buildTree), the cost paid once per initial page load.
+// This is the expensive leg: building the full nested TreeNode with per-level
+// statics costs ~20-30x an opaque html/template Execute of the same tree (compare
+// ns/op and allocs/op against BenchmarkOpaqueHTMLBaseline). That CPU buys the
+// reactive tree — subsequent edits re-render in place with DOM-state preservation
+// rather than replacing an opaque innerHTML blob — but it is a real cost, not free.
+func BenchmarkRecursiveRender(b *testing.B) {
+	parsed, err := Must(New("bench")).Parse(recursiveTreeSrc)
+	if err != nil {
+		b.Fatalf("parse: %v", err)
+	}
+	data := benchTree(5, 3, "") // 3^5 leaves ≈ 364 nodes
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := parsed.buildTree(data, nil); err != nil {
+			b.Fatalf("buildTree: %v", err)
+		}
+	}
+}
+
+// BenchmarkRecursiveUpdate measures the per-update cost after a rename deep in the
+// tree: rebuild and diff against the previous render (what the framework does on
+// every action), reporting the wire payload as "update_bytes".
+//
+// The honest finding this benchmark exists to surface: the update is NOT scoped to
+// the changed leaf. Recursive range items are keyed by a *deep content hash* (the
+// item's real <li data-key> is hidden one level down inside the invocation
+// wrapper, so range keying can't see it — see the keying caveat in
+// docs/proposals/recursive-templates-proposal.md §6). Renaming any node changes
+// every ancestor's hash, so the diff re-sends the item's whole ENCLOSING TOP-LEVEL
+// BRANCH as ["r", oldkey],["p", [full branch with statics]] — its sibling branches
+// are spared, but the branch itself comes back whole.
+//
+// Concretely, for this depth-5 branch-3 shape a deep-leaf edit's update_bytes
+// (~24KB, one of three top-level branches) lands ESSENTIALLY EQUAL to
+// BenchmarkOpaqueHTMLBaseline's full_html_bytes (~23.5KB, the whole tree) — and
+// costs ~25x the CPU to produce. So for a deep, narrow tree the reactive update is
+// no smaller on the wire than shipping the entire opaque string, and much dearer to
+// compute. The update-size win only materializes when the enclosing branch is a
+// small fraction of the tree (a WIDE tree, many top-level branches) or once the
+// data-key-through-the-wrapper follow-up lands and deep edits scope to a single
+// per-leaf ["u", key, {…}]. Recursion support's win here is correctness and
+// reactive DOM-state preservation, not payload size.
+func BenchmarkRecursiveUpdate(b *testing.B) {
+	parsed, err := Must(New("bench")).Parse(recursiveTreeSrc)
+	if err != nil {
+		b.Fatalf("parse: %v", err)
+	}
+	base := benchTree(5, 3, "")
+	mutated := benchTree(5, 3, "")
+	// Rename one leaf deep in the tree.
+	mutated.Children[0].Children[0].Children[0].Children[0].Children[0].Name = "renamed.go"
+
+	first, err := parsed.buildTree(base, nil)
+	if err != nil {
+		b.Fatalf("build base: %v", err)
+	}
+
+	var updateBytes int
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		parsed.lastTree = first
+		next, err := parsed.buildTree(mutated, nil)
+		if err != nil {
+			b.Fatalf("build mutated: %v", err)
+		}
+		changes := parsed.compareTreesAndGetChanges(first, next)
+		js, _ := json.Marshal(changes.ToMap())
+		updateBytes = len(js)
+	}
+	b.ReportMetric(float64(updateBytes), "update_bytes")
+}
+
+// BenchmarkOpaqueHTMLBaseline is the status-quo comparison: rendering the same tree
+// as a single opaque html/template string (the {{.FileBrowserHTML}} escape hatch
+// recursion replaces). Every change re-executes and re-sends the ENTIRE string,
+// which the client applies by replacing innerHTML — no tree diff, and every DOM
+// node in the region is destroyed and rebuilt (focus, scroll, and event state in
+// the subtree are lost). Its full_html_bytes is the number BenchmarkRecursiveUpdate's
+// update_bytes should be read against: for the deep-narrow shape here they are
+// ~equal in bytes, but this baseline is ~25x cheaper in CPU. Recursion support does
+// not beat it on payload or CPU for this shape — it beats it on *what the client can
+// do with the payload* (in-place reconciliation) and on rendering correctly at all.
+func BenchmarkOpaqueHTMLBaseline(b *testing.B) {
+	// A standalone recursive html/template (the workaround: recursion works, but
+	// the output is one opaque string with no tree/diff).
+	src := `{{define "treeNode"}}<li data-key="{{.Path}}"><span>{{.Name}}</span>` +
+		`{{if .IsDir}}<ul>{{range .Children}}{{template "treeNode" .}}{{end}}</ul>{{end}}` +
+		`</li>{{end}}<ul>{{template "treeNode" .}}</ul>`
+	ht, err := template.New("baseline").Parse(src)
+	if err != nil {
+		b.Fatalf("parse baseline: %v", err)
+	}
+	data := benchTree(5, 3, "")
+
+	var fullBytes int
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		if err := ht.Execute(&buf, data); err != nil {
+			b.Fatalf("execute baseline: %v", err)
+		}
+		fullBytes = buf.Len()
+	}
+	b.ReportMetric(float64(fullBytes), "full_html_bytes")
+}

--- a/recursive_template_diff_test.go
+++ b/recursive_template_diff_test.go
@@ -5,7 +5,26 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/livetemplate/livetemplate/internal/render"
 )
+
+// Keying note for recursive-template range items: each {{range}} item is a
+// {{template …}} invocation, so its top-level tree is the invocation wrapper (empty
+// statics). buildRangeTreeWithStatics inspects those top-level statics for a
+// data-key attribute; the wrapper hides the item's real <li data-key="…">, so
+// keying falls back to a content hash over the item's dynamics. That is still
+// *correct* identity — the data-key value (.Path) is one of the hashed dynamics, so
+// distinct items get distinct keys and the diff emits granular i/r/o/a ops for
+// direct-child edits (proven below).
+//
+// Consequence, pinned by _DescendantBranchRebuild: because the hash is DEEP (a
+// directory item's dynamics include its whole nested subtree), editing a deep
+// descendant changes the enclosing branch's key, so that branch is re-sent whole
+// (its unaffected siblings are not). Honoring the explicit data-key through the
+// wrapper — which would let a deep edit re-send only the changed leaf — needs
+// diff-engine work and is tracked as a follow-up, not a C8 blocker. Renders are
+// always correct either way; this is update size, not correctness.
 
 // TestRecursiveTemplate_MinimalUpdate_AddChild is the correctness proof for the
 // UPDATE path (not just first render): adding one child to a recursive tree must
@@ -115,6 +134,251 @@ func TestRecursiveTemplate_MinimalUpdate_DepthGrows(t *testing.T) {
 	}
 	if _, hasStatics := cond["s"]; !hasStatics {
 		t.Errorf("newly-appearing level must resend its statics (\"s\"), got:\n%s", update)
+	}
+}
+
+// dirWith builds the standard root directory holding the given leaf children, so
+// the keying tests below differ only in their child list.
+func dirWith(children ...fileNode) fileNode {
+	return fileNode{Name: "root", Path: "/", IsDir: true, Children: children}
+}
+
+// leaf is a childless file node keyed by its path.
+func leaf(name, path string) fileNode {
+	return fileNode{Name: name, Path: path}
+}
+
+// recursiveUpdateJSON parses recursiveTreeSrc, builds t1 then t2, and returns the
+// diff between them as a JSON string. Each child is a {{template "treeNode" .}}
+// invocation, so the range op the diff emits is the proof that range keying
+// descends THROUGH the invocation wrapper.
+func recursiveUpdateJSON(t *testing.T, t1, t2 fileNode) string {
+	t.Helper()
+	tmpl, err := Must(New("test")).Parse(recursiveTreeSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	first, err := tmpl.buildTree(t1, nil)
+	if err != nil {
+		t.Fatalf("build t1: %v", err)
+	}
+	second, err := tmpl.buildTree(t2, nil)
+	if err != nil {
+		t.Fatalf("build t2: %v", err)
+	}
+	tmpl.lastTree = first
+	js, _ := json.Marshal(tmpl.compareTreesAndGetChanges(first, second).ToMap())
+	return string(js)
+}
+
+// itemKeys returns the range-item keys (the "_k" values) of the direct children
+// of a recursive tree's root, in order. It reaches through the invocation wrapper
+// each child sits behind, so a non-empty, correctly-ordered result is itself proof
+// that range keying descends through that wrapper.
+func itemKeys(t *testing.T, tmpl *Template, data fileNode) []string {
+	t.Helper()
+	tree, err := tmpl.buildTree(data, nil)
+	if err != nil {
+		t.Fatalf("build for keys: %v", err)
+	}
+	m := tree.ToMap()
+	root, _ := m["0"].(map[string]interface{})    // the treeNode subtree
+	cond, _ := root["2"].(map[string]interface{}) // the {{if .IsDir}} branch
+	rng, _ := cond["0"].(map[string]interface{})  // the {{range .Children}} node
+	items, _ := rng["d"].([]interface{})          // range item list
+	keys := make([]string, 0, len(items))
+	for _, it := range items {
+		if im, ok := it.(map[string]interface{}); ok {
+			if k, ok := im["_k"].(string); ok {
+				keys = append(keys, k)
+			}
+		}
+	}
+	return keys
+}
+
+// TestRecursiveTemplate_MinimalUpdate_InsertMiddle is the discriminating keying
+// test that append (_AddChild) cannot exercise: inserting a child in the MIDDLE
+// of the list forces the diff to emit an ["i", after-id, …] op, whose after-id is
+// the key of the preceding sibling. That key only resolves if range keying reaches
+// through the {{template}} invocation wrapper down to the item's identity —
+// appending always lands at the tail (the ["a"] fast path) and never resolves an
+// after-id, so it proves nothing about mid-list keying. (Keys are content hashes,
+// not the raw data-key value, because the wrapper hides the item's top-level
+// statics from hasExplicitKeyAttribute; identity is still exact since the data-key
+// value is itself one of the hashed dynamics — see the file-level note.)
+func TestRecursiveTemplate_MinimalUpdate_InsertMiddle(t *testing.T) {
+	tmpl, err := Must(New("test")).Parse(recursiveTreeSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	before := dirWith(leaf("a.go", "/a.go"), leaf("c.go", "/c.go"))
+	after := dirWith(leaf("a.go", "/a.go"), leaf("b.go", "/b.go"), leaf("c.go", "/c.go"))
+
+	// a.go's key from the "before" tree is the after-id the insert must anchor on.
+	wantAfter := itemKeys(t, tmpl, before)[0]
+
+	first, err := tmpl.buildTree(before, nil)
+	if err != nil {
+		t.Fatalf("build before: %v", err)
+	}
+	next, err := tmpl.buildTree(after, nil)
+	if err != nil {
+		t.Fatalf("build after: %v", err)
+	}
+	tmpl.lastTree = first
+	js, _ := json.Marshal(tmpl.compareTreesAndGetChanges(first, next).ToMap())
+	update := string(js)
+	t.Logf("insert-middle update JSON:\n%s", update)
+
+	if !strings.Contains(update, `"i"`) {
+		t.Errorf("mid-list insert must emit an [\"i\", after-id, …] op, got:\n%s", update)
+	}
+	// The after-id must be a.go's key resolved through the wrapper — not empty,
+	// not a wrong sibling. This is the airtight wrapper-descent proof.
+	if !strings.Contains(update, `"`+wantAfter+`"`) {
+		t.Errorf("insert op must anchor on the preceding sibling's key %q, got:\n%s", wantAfter, update)
+	}
+	if !strings.Contains(update, "b.go") {
+		t.Errorf("update must carry the inserted node b.go, got:\n%s", update)
+	}
+	// The stable siblings' text content must NOT be resent — only the new item.
+	if strings.Contains(update, ">a.go<") || strings.Contains(update, ">c.go<") {
+		t.Errorf("stable siblings must not be re-rendered on a granular insert:\n%s", update)
+	}
+}
+
+// TestRecursiveTemplate_MinimalUpdate_Reorder proves the marquee keying promise
+// for recursive lists: reordering children (no content change) emits a single
+// ["o", [ids…]] permutation carrying only the keys — not a teardown/rebuild of
+// every invoked subtree. A correct 3-distinct-key permutation is itself proof that
+// range keying descends through the invocation wrapper (the keys are content
+// hashes, not the raw data-key value — see the file-level note).
+func TestRecursiveTemplate_MinimalUpdate_Reorder(t *testing.T) {
+	before := dirWith(leaf("a.go", "/a.go"), leaf("b.go", "/b.go"), leaf("c.go", "/c.go"))
+	after := dirWith(leaf("c.go", "/c.go"), leaf("a.go", "/a.go"), leaf("b.go", "/b.go"))
+
+	update := recursiveUpdateJSON(t, before, after)
+	t.Logf("reorder update JSON:\n%s", update)
+
+	if !strings.Contains(update, `"o"`) {
+		t.Errorf("a pure reorder must emit an [\"o\", [ids]] op, got:\n%s", update)
+	}
+	// A reorder moves keys, it does not re-render item bodies — none of the
+	// unchanged <span> contents should reappear in the update.
+	if strings.Contains(update, ">a.go<") || strings.Contains(update, ">b.go<") || strings.Contains(update, ">c.go<") {
+		t.Errorf("reorder must not re-render item bodies (keys only):\n%s", update)
+	}
+}
+
+// TestRecursiveTemplate_MinimalUpdate_Remove proves removal emits a granular
+// ["r", id] op keyed by the removed item's data-key, leaving the surviving
+// siblings untouched (not resent).
+func TestRecursiveTemplate_MinimalUpdate_Remove(t *testing.T) {
+	before := dirWith(leaf("a.go", "/a.go"), leaf("b.go", "/b.go"), leaf("c.go", "/c.go"))
+	after := dirWith(leaf("a.go", "/a.go"), leaf("c.go", "/c.go"))
+
+	tmpl, err := Must(New("test")).Parse(recursiveTreeSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// b.go is the middle child of the "before" tree; its key must be the id named
+	// by the ["r", id] op.
+	wantRemoved := itemKeys(t, tmpl, before)[1]
+
+	first, err := tmpl.buildTree(before, nil)
+	if err != nil {
+		t.Fatalf("build before: %v", err)
+	}
+	next, err := tmpl.buildTree(after, nil)
+	if err != nil {
+		t.Fatalf("build after: %v", err)
+	}
+	tmpl.lastTree = first
+	js, _ := json.Marshal(tmpl.compareTreesAndGetChanges(first, next).ToMap())
+	update := string(js)
+	t.Logf("remove update JSON:\n%s", update)
+
+	if !strings.Contains(update, `"r"`) {
+		t.Errorf("removal must emit an [\"r\", id] op, got:\n%s", update)
+	}
+	if !strings.Contains(update, `"`+wantRemoved+`"`) {
+		t.Errorf("remove op must name the removed item's key %q, got:\n%s", wantRemoved, update)
+	}
+	// Surviving siblings must not be re-rendered.
+	if strings.Contains(update, ">a.go<") || strings.Contains(update, ">c.go<") {
+		t.Errorf("surviving siblings must not be resent on a granular remove:\n%s", update)
+	}
+}
+
+// TestRecursiveTemplate_DescendantBranchRebuild pins the confirmed content-hash
+// keying consequence for DEEP edits (distinct from the direct-child i/r/o/a ops
+// above): renaming a grandchild under a nested directory changes that directory's
+// deep item hash, so the enclosing branch (/sub) is re-sent whole — while its
+// unaffected sibling is NOT. This documents the known limitation in code: honoring
+// the explicit data-key through the invocation wrapper (which would re-send only
+// the changed leaf) is a tracked follow-up, not a C8 blocker. The render is always
+// correct; only the update size differs.
+func TestRecursiveTemplate_DescendantBranchRebuild(t *testing.T) {
+	tmpl, err := Must(New("test")).Parse(recursiveTreeSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	mk := func(grandchild string) fileNode {
+		return dirWith(
+			fileNode{Name: "sub", Path: "/sub", IsDir: true, Children: []fileNode{
+				leaf(grandchild, "/sub/g.go"),
+			}},
+			leaf("sibling.go", "/sibling.go"),
+		)
+	}
+	first, err := tmpl.buildTree(mk("g.go"), nil)
+	if err != nil {
+		t.Fatalf("build first: %v", err)
+	}
+	next, err := tmpl.buildTree(mk("g-RENAMED.go"), nil)
+	if err != nil {
+		t.Fatalf("build next: %v", err)
+	}
+	tmpl.lastTree = first
+	js, _ := json.Marshal(tmpl.compareTreesAndGetChanges(first, next).ToMap())
+	update := string(js)
+	t.Logf("descendant-mutation update JSON:\n%s", update)
+
+	// The renamed grandchild is carried (the change reaches the wire).
+	if !strings.Contains(update, "g-RENAMED.go") {
+		t.Errorf("update must carry the renamed grandchild, got:\n%s", update)
+	}
+	// The unaffected sibling branch is NOT re-sent — the churn is scoped to the
+	// branch containing the edit, not the whole list.
+	if strings.Contains(update, "sibling.go") {
+		t.Errorf("unaffected sibling branch must not be re-sent (scoped rebuild):\n%s", update)
+	}
+}
+
+// TestRecursiveTemplate_FirstRenderOverLimit documents the first-render leg of the
+// depth-guard asymmetry (the update leg is covered by _ConfigurableDepth): a
+// finite tree deeper than the configured cap does NOT error on first render — it
+// degrades to the html/template structural fallback, still yielding a usable page
+// (just without the reactive tree for the over-limit levels). This pins the
+// documented "working-but-non-reactive first render, rejected update" behavior.
+func TestRecursiveTemplate_FirstRenderOverLimit(t *testing.T) {
+	tmpl, err := Must(New("test", WithMaxTemplateDepth(3))).Parse(recursiveTreeSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// depth-6 tree > cap of 3, but finite. First render must not error.
+	tree, err := tmpl.buildTree(chainDir(6), nil)
+	if err != nil {
+		t.Fatalf("first render over the depth cap must degrade, not error, got: %v", err)
+	}
+	html, err := render.TreeToHTML(tree.ToMap())
+	if err != nil {
+		t.Fatalf("fallback tree must still reconstruct to HTML, got: %v", err)
+	}
+	// The page is usable: at least the shallow levels rendered.
+	if !strings.Contains(html, "data-key=") {
+		t.Errorf("degraded first render must still produce a usable page, got:\n%s", html)
 	}
 }
 

--- a/recursive_template_diff_test.go
+++ b/recursive_template_diff_test.go
@@ -11,20 +11,17 @@ import (
 
 // Keying note for recursive-template range items: each {{range}} item is a
 // {{template …}} invocation, so its top-level tree is the invocation wrapper (empty
-// statics). buildRangeTreeWithStatics inspects those top-level statics for a
-// data-key attribute; the wrapper hides the item's real <li data-key="…">, so
-// keying falls back to a content hash over the item's dynamics. That is still
-// *correct* identity — the data-key value (.Path) is one of the hashed dynamics, so
-// distinct items get distinct keys and the diff emits granular i/r/o/a ops for
-// direct-child edits (proven below).
+// statics) that hides the item's real <li data-key="…"> one level down.
+// buildRangeTreeWithStatics reads that data-key *through* the wrapper
+// (allWrappedItemKeys) and uses it as the item's stable key, so an item keeps its
+// identity across deep edits instead of keying on a content hash of its subtree.
 //
-// Consequence, pinned by _DescendantBranchRebuild: because the hash is DEEP (a
-// directory item's dynamics include its whole nested subtree), editing a deep
-// descendant changes the enclosing branch's key, so that branch is re-sent whole
-// (its unaffected siblings are not). Honoring the explicit data-key through the
-// wrapper — which would let a deep edit re-send only the changed leaf — needs
-// diff-engine work and is tracked as a follow-up, not a C8 blocker. Renders are
-// always correct either way; this is update size, not correctness.
+// Consequence, pinned by _DescendantScopesToLeaf: because the key is stable, a deep
+// descendant edit leaves every ancestor's key unchanged, so the diff engine's
+// per-item recursive diff scopes it to a nested chain of ["u", key, …] ops down to
+// the single changed leaf — no ancestor branch, and no unaffected sibling (top-level
+// or in-branch), is re-sent. Direct-child edits still emit granular i/r/o/a ops
+// (proven below). Renders are always correct; this is the delivered update-size win.
 
 // TestRecursiveTemplate_MinimalUpdate_AddChild is the correctness proof for the
 // UPDATE path (not just first render): adding one child to a recursive tree must
@@ -311,15 +308,14 @@ func TestRecursiveTemplate_MinimalUpdate_Remove(t *testing.T) {
 	}
 }
 
-// TestRecursiveTemplate_DescendantBranchRebuild pins the confirmed content-hash
-// keying consequence for DEEP edits (distinct from the direct-child i/r/o/a ops
-// above): renaming a grandchild under a nested directory changes that directory's
-// deep item hash, so the enclosing branch (/sub) is re-sent whole — while its
-// unaffected sibling is NOT. This documents the known limitation in code: honoring
-// the explicit data-key through the invocation wrapper (which would re-send only
-// the changed leaf) is a tracked follow-up, not a C8 blocker. The render is always
-// correct; only the update size differs.
-func TestRecursiveTemplate_DescendantBranchRebuild(t *testing.T) {
+// TestRecursiveTemplate_DescendantScopesToLeaf pins the delivered per-leaf update
+// for DEEP edits: renaming a grandchild deep under a nested directory is encoded as
+// a nested chain of ["u", key, …] ops down to the single changed leaf. Neither the
+// unaffected top-level sibling branch NOR an unaffected sibling grandchild in the
+// SAME branch is re-sent — the churn is scoped to the changed leaf, not its
+// enclosing branch. This is the payload win from keying recursive items by their
+// data-key through the invocation wrapper plus the differential per-item diff.
+func TestRecursiveTemplate_DescendantScopesToLeaf(t *testing.T) {
 	tmpl, err := Must(New("test")).Parse(recursiveTreeSrc)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
@@ -328,8 +324,9 @@ func TestRecursiveTemplate_DescendantBranchRebuild(t *testing.T) {
 		return dirWith(
 			fileNode{Name: "sub", Path: "/sub", IsDir: true, Children: []fileNode{
 				leaf(grandchild, "/sub/g.go"),
+				leaf("g-sibling.go", "/sub/g-sibling.go"), // sibling IN the edited branch
 			}},
-			leaf("sibling.go", "/sibling.go"),
+			leaf("sibling.go", "/sibling.go"), // unaffected top-level branch
 		)
 	}
 	first, err := tmpl.buildTree(mk("g.go"), nil)
@@ -349,10 +346,68 @@ func TestRecursiveTemplate_DescendantBranchRebuild(t *testing.T) {
 	if !strings.Contains(update, "g-RENAMED.go") {
 		t.Errorf("update must carry the renamed grandchild, got:\n%s", update)
 	}
-	// The unaffected sibling branch is NOT re-sent — the churn is scoped to the
-	// branch containing the edit, not the whole list.
-	if strings.Contains(update, "sibling.go") {
-		t.Errorf("unaffected sibling branch must not be re-sent (scoped rebuild):\n%s", update)
+	// The unaffected top-level sibling branch is NOT re-sent.
+	if strings.Contains(update, "sibling.go") && !strings.Contains(update, "g-sibling.go") {
+		t.Errorf("unaffected top-level sibling branch must not be re-sent:\n%s", update)
+	}
+	// Per-leaf scoping: the sibling grandchild IN the edited branch is NOT re-sent
+	// either — the update reaches only the changed leaf, not its enclosing branch.
+	if strings.Contains(update, "g-sibling.go") {
+		t.Errorf("sibling grandchild in the edited branch must not be re-sent (per-leaf scope):\n%s", update)
+	}
+	// No statics in the wire — a deep content edit is a pure dynamics-only chain.
+	if strings.Contains(update, `"s":[`) {
+		t.Errorf("deep content edit must not re-send statics:\n%s", update)
+	}
+}
+
+// TestRecursiveTemplate_FullDocument_Reactive is a regression guard for a silent
+// C8 bug: FlattenTemplate appends the recursion cycle members as {{define}} blocks
+// AFTER the document, and body extraction for a FULL HTML document used to drop
+// them — leaving the recursion registry empty at serve time, so the whole template
+// degraded to HTML-string diffing (hasInitialTree=false) with none of the reactive
+// tree or per-leaf machinery running. A fragment kept the defines and worked, so
+// the gap was invisible to every fragment-based test. This asserts a full document
+// takes the reactive AST path AND scopes a deep edit to a per-leaf ["u"] chain.
+func TestRecursiveTemplate_FullDocument_Reactive(t *testing.T) {
+	const fullDoc = `<!DOCTYPE html><html><head><title>T</title></head><body>` +
+		`{{define "treeNode"}}<li data-key="{{.Path}}"><span>{{.Name}}</span>` +
+		`{{if .IsDir}}<ul>{{range .Children}}{{template "treeNode" .}}{{end}}</ul>{{end}}</li>{{end}}` +
+		`<ul id="tree">{{template "treeNode" .Root}}</ul></body></html>`
+	type fullDocState struct{ Root fileNode }
+
+	tmpl, err := Must(New("fulldoc")).Parse(fullDoc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	mk := func(deepName string) fullDocState {
+		return fullDocState{Root: dirWith(
+			fileNode{Name: "sub", Path: "/sub", IsDir: true, Children: []fileNode{
+				leaf(deepName, "/sub/g.go"),
+			}},
+			leaf("sibling.go", "/sibling.go"),
+		)}
+	}
+	if _, err := tmpl.buildTree(mk("g.go"), nil); err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	// The reactive AST path must be active — a fallback to HTML-string diffing
+	// (hasInitialTree=false) is the exact silent regression this test guards.
+	if !tmpl.hasInitialTree {
+		t.Fatal("full-document recursive template fell back to HTML-structure diffing (registry drop regressed)")
+	}
+	update, _ := tmpl.buildTree(mk("g-RENAMED.go"), nil)
+	js, _ := json.Marshal(update.ToMap())
+	s := string(js)
+	t.Logf("full-doc deep-edit update:\n%s", s)
+	if !strings.Contains(s, "g-RENAMED.go") {
+		t.Errorf("update must carry the renamed deep node:\n%s", s)
+	}
+	if strings.Contains(s, "sibling.go") {
+		t.Errorf("unaffected sibling must not be re-sent (per-leaf scope):\n%s", s)
+	}
+	if strings.Contains(s, `"s":[`) {
+		t.Errorf("deep content edit must not re-send statics:\n%s", s)
 	}
 }
 

--- a/recursive_template_diff_test.go
+++ b/recursive_template_diff_test.go
@@ -200,10 +200,9 @@ func itemKeys(t *testing.T, tmpl *Template, data fileNode) []string {
 // the key of the preceding sibling. That key only resolves if range keying reaches
 // through the {{template}} invocation wrapper down to the item's identity —
 // appending always lands at the tail (the ["a"] fast path) and never resolves an
-// after-id, so it proves nothing about mid-list keying. (Keys are content hashes,
-// not the raw data-key value, because the wrapper hides the item's top-level
-// statics from hasExplicitKeyAttribute; identity is still exact since the data-key
-// value is itself one of the hashed dynamics — see the file-level note.)
+// after-id, so it proves nothing about mid-list keying. (The key is the item's raw
+// data-key value — its path — read through the wrapper by allWrappedItemKeys, not a
+// content hash of the subtree; see the file-level note.)
 func TestRecursiveTemplate_MinimalUpdate_InsertMiddle(t *testing.T) {
 	tmpl, err := Must(New("test")).Parse(recursiveTreeSrc)
 	if err != nil {
@@ -249,8 +248,8 @@ func TestRecursiveTemplate_MinimalUpdate_InsertMiddle(t *testing.T) {
 // for recursive lists: reordering children (no content change) emits a single
 // ["o", [ids…]] permutation carrying only the keys — not a teardown/rebuild of
 // every invoked subtree. A correct 3-distinct-key permutation is itself proof that
-// range keying descends through the invocation wrapper (the keys are content
-// hashes, not the raw data-key value — see the file-level note).
+// range keying descends through the invocation wrapper (each key is the item's raw
+// data-key value read through the wrapper, not a content hash — see the file-level note).
 func TestRecursiveTemplate_MinimalUpdate_Reorder(t *testing.T) {
 	before := dirWith(leaf("a.go", "/a.go"), leaf("b.go", "/b.go"), leaf("c.go", "/c.go"))
 	after := dirWith(leaf("c.go", "/c.go"), leaf("a.go", "/a.go"), leaf("b.go", "/b.go"))

--- a/recursive_template_diff_test.go
+++ b/recursive_template_diff_test.go
@@ -1,0 +1,161 @@
+package livetemplate
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRecursiveTemplate_MinimalUpdate_AddChild is the correctness proof for the
+// UPDATE path (not just first render): adding one child to a recursive tree must
+// produce a minimal update — a granular range op for the new node — not a
+// full-subtree resend of the unchanged siblings. Range items here are each a
+// {{template "treeNode" .}} invocation (a nested wrapper subtree), so this also
+// verifies data-key extraction descends through the invocation wrapper.
+func TestRecursiveTemplate_MinimalUpdate_AddChild(t *testing.T) {
+	tmpl, err := Must(New("test")).Parse(recursiveTreeSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	t1Data := fileNode{
+		Name: "root", Path: "/", IsDir: true,
+		Children: []fileNode{
+			{Name: "a.go", Path: "/a.go"},
+			{Name: "b.go", Path: "/b.go"},
+		},
+	}
+	t2Data := fileNode{
+		Name: "root", Path: "/", IsDir: true,
+		Children: []fileNode{
+			{Name: "a.go", Path: "/a.go"},
+			{Name: "b.go", Path: "/b.go"},
+			{Name: "c.go", Path: "/c.go"}, // added at end
+		},
+	}
+
+	t1, err := tmpl.buildTree(t1Data, nil)
+	if err != nil {
+		t.Fatalf("build t1: %v", err)
+	}
+	t2, err := tmpl.buildTree(t2Data, nil)
+	if err != nil {
+		t.Fatalf("build t2: %v", err)
+	}
+
+	tmpl.lastTree = t1
+	changes := tmpl.compareTreesAndGetChanges(t1, t2)
+	js, _ := json.Marshal(changes.ToMap())
+	update := string(js)
+	t.Logf("update JSON:\n%s", update)
+
+	// The new node must be present in the update.
+	if !strings.Contains(update, "c.go") {
+		t.Errorf("update must carry the added node c.go, got:\n%s", update)
+	}
+	// The unchanged siblings' text content must NOT be resent (minimal update).
+	// If a.go/b.go appear, the whole list was re-rendered instead of a granular op.
+	if strings.Contains(update, "a.go") || strings.Contains(update, "b.go") {
+		t.Errorf("unchanged siblings should not be resent (non-minimal update):\n%s", update)
+	}
+}
+
+// TestRecursiveTemplate_MinimalUpdate_DepthGrows verifies the second half of the
+// diff contract: when the data grows a NEW nesting level (a leaf becomes a
+// directory with children), the newly-appearing structure must carry its statics
+// ("s") — the client has never seen that level, so it can't have them cached.
+func TestRecursiveTemplate_MinimalUpdate_DepthGrows(t *testing.T) {
+	tmpl, err := Must(New("test")).Parse(recursiveTreeSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// T1: a single leaf (IsDir=false) — the {{if .IsDir}} branch is empty, so no
+	// <ul>/child structure exists on the client yet.
+	t1Data := fileNode{Name: "root", Path: "/", IsDir: false}
+	// T2: same node becomes a directory with one child — a new nested level.
+	t2Data := fileNode{
+		Name: "root", Path: "/", IsDir: true,
+		Children: []fileNode{{Name: "a.go", Path: "/a.go"}},
+	}
+
+	t1, err := tmpl.buildTree(t1Data, nil)
+	if err != nil {
+		t.Fatalf("build t1: %v", err)
+	}
+	t2, err := tmpl.buildTree(t2Data, nil)
+	if err != nil {
+		t.Fatalf("build t2: %v", err)
+	}
+
+	tmpl.lastTree = t1
+	changes := tmpl.compareTreesAndGetChanges(t1, t2)
+	m := changes.ToMap()
+	js, _ := json.Marshal(m)
+	update := string(js)
+	t.Logf("depth-grows update JSON:\n%s", update)
+
+	// The new child must be present.
+	if !strings.Contains(update, "a.go") {
+		t.Errorf("update must carry the new child a.go, got:\n%s", update)
+	}
+
+	// The newly-appearing nesting level (the {{if .IsDir}} branch at position 2,
+	// previously empty) must include its own statics — the client has never seen
+	// this structure, so it can't have them cached. Inspect the map structurally
+	// rather than string-matching JSON-escaped HTML.
+	root, ok := m["0"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nested root node at \"0\", got: %s", update)
+	}
+	cond, ok := root["2"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected the newly-populated {{if}} branch at \"0\".\"2\", got: %s", update)
+	}
+	if _, hasStatics := cond["s"]; !hasStatics {
+		t.Errorf("newly-appearing level must resend its statics (\"s\"), got:\n%s", update)
+	}
+}
+
+// TestRecursiveTemplate_ExecuteInitialHTML covers the initial page-load path:
+// html/template Execute (t.tmpl, which carries the appended {{define}} blocks)
+// must render a recursive template correctly. This is the HTML the browser gets
+// on first load, before the reactive tree takes over.
+func TestRecursiveTemplate_ExecuteInitialHTML(t *testing.T) {
+	tmpl, err := Must(New("test")).Parse(recursiveTreeSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	data := fileNode{
+		Name: "root", Path: "/", IsDir: true,
+		Children: []fileNode{
+			{Name: "a.go", Path: "/a.go"},
+			{Name: "sub", Path: "/sub", IsDir: true, Children: []fileNode{
+				{Name: "b.go", Path: "/sub/b.go"},
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("Execute on a recursive template must succeed, got: %v", err)
+	}
+	html := buf.String()
+
+	// Every node must be present, nested correctly (root contains sub contains b.go).
+	for _, want := range []string{
+		`data-key="/"`, `<span>root</span>`,
+		`data-key="/a.go"`, `<span>a.go</span>`,
+		`data-key="/sub"`, `<span>sub</span>`,
+		`data-key="/sub/b.go"`, `<span>b.go</span>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("Execute output missing %q in:\n%s", want, html)
+		}
+	}
+	// The deepest node must appear after its parent (nesting order preserved).
+	if strings.Index(html, "/sub/b.go") < strings.Index(html, `data-key="/sub"`) {
+		t.Errorf("nesting order wrong — /sub/b.go should follow /sub:\n%s", html)
+	}
+}

--- a/recursive_template_test.go
+++ b/recursive_template_test.go
@@ -1,0 +1,58 @@
+package livetemplate
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParse_RecursiveTemplate_ReturnsErrorNotCrash exercises the real
+// user-facing path: New(...).Parse(recursiveSrc). Before the parse-time cycle
+// guard, a self-referential {{template}} inlined forever and stack-overflowed
+// here (a fatal, unrecoverable runtime error). The guard turns it into a clean
+// error. A stack overflow cannot be recover()'d, so if the guard regresses this
+// test binary dies outright — itself an unambiguous failure signal; there is no
+// need for (and no point in) a recover()-based assertion.
+func TestParse_RecursiveTemplate_ReturnsErrorNotCrash(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "direct self-recursion (file tree)",
+			src: `{{define "treeNode"}}<li data-key="{{.Path}}"><span>{{.Name}}</span>` +
+				`{{if .IsDir}}<ul>{{range .Children}}{{template "treeNode" .}}{{end}}</ul>{{end}}` +
+				`</li>{{end}}` +
+				`<ul>{{template "treeNode" .}}</ul>`,
+		},
+		{
+			name: "mutual recursion",
+			src: `{{define "a"}}<div>{{template "b" .}}</div>{{end}}` +
+				`{{define "b"}}<span>{{template "a" .}}</span>{{end}}` +
+				`{{template "a" .}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Must(New("test")).Parse(tt.src)
+			if err == nil {
+				t.Fatal("expected an error for a recursive template, got nil")
+			}
+			if !strings.Contains(err.Error(), "recursive") {
+				t.Errorf("error should explain the recursion, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestParse_NonRecursiveComposition_StillWorks is the companion positive gate:
+// ordinary (acyclic) {{define}}/{{template}} composition must keep parsing
+// through the public API exactly as before the guard.
+func TestParse_NonRecursiveComposition_StillWorks(t *testing.T) {
+	src := `{{define "header"}}<h1>{{.Title}}</h1>{{end}}` +
+		`{{template "header" .}}<main>{{.Body}}</main>`
+
+	if _, err := Must(New("test")).Parse(src); err != nil {
+		t.Fatalf("non-recursive composition must parse cleanly, got: %v", err)
+	}
+}

--- a/recursive_template_test.go
+++ b/recursive_template_test.go
@@ -1,58 +1,231 @@
 package livetemplate
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/livetemplate/livetemplate/internal/compat"
+	"github.com/livetemplate/livetemplate/internal/render"
 )
 
-// TestParse_RecursiveTemplate_ReturnsErrorNotCrash exercises the real
-// user-facing path: New(...).Parse(recursiveSrc). Before the parse-time cycle
-// guard, a self-referential {{template}} inlined forever and stack-overflowed
-// here (a fatal, unrecoverable runtime error). The guard turns it into a clean
-// error. A stack overflow cannot be recover()'d, so if the guard regresses this
-// test binary dies outright — itself an unambiguous failure signal; there is no
-// need for (and no point in) a recover()-based assertion.
-func TestParse_RecursiveTemplate_ReturnsErrorNotCrash(t *testing.T) {
-	tests := []struct {
-		name string
-		src  string
-	}{
-		{
-			name: "direct self-recursion (file tree)",
-			src: `{{define "treeNode"}}<li data-key="{{.Path}}"><span>{{.Name}}</span>` +
-				`{{if .IsDir}}<ul>{{range .Children}}{{template "treeNode" .}}{{end}}</ul>{{end}}` +
-				`</li>{{end}}` +
-				`<ul>{{template "treeNode" .}}</ul>`,
-		},
-		{
-			name: "mutual recursion",
-			src: `{{define "a"}}<div>{{template "b" .}}</div>{{end}}` +
-				`{{define "b"}}<span>{{template "a" .}}</span>{{end}}` +
-				`{{template "a" .}}`,
+// chainDir builds a linear chain of `depth` nested directories, each holding the
+// next as its single child (the leaf is a file). Used to exercise the depth cap
+// with a finite-but-deep tree.
+func chainDir(depth int) fileNode {
+	n := fileNode{Name: fmt.Sprint(depth), Path: fmt.Sprintf("/%d", depth)}
+	if depth > 0 {
+		n.IsDir = true
+		n.Children = []fileNode{chainDir(depth - 1)}
+	}
+	return n
+}
+
+// fileNode is a self-referential tree, the canonical recursive-template case
+// (a file browser / comment thread / org chart). Rendering it requires the
+// {{template "treeNode" .}} call inside the {{range .Children}} to be evaluated
+// recursively at build time.
+type fileNode struct {
+	Name     string
+	Path     string
+	IsDir    bool
+	Children []fileNode
+}
+
+const recursiveTreeSrc = `{{define "treeNode"}}<li data-key="{{.Path}}"><span>{{.Name}}</span>` +
+	`{{if .IsDir}}<ul>{{range .Children}}{{template "treeNode" .}}{{end}}</ul>{{end}}` +
+	`</li>{{end}}` +
+	`<ul>{{template "treeNode" .}}</ul>`
+
+// buildTreeHTML parses src, builds the tree through the reactive tree path
+// (parse.BuildTree → walkAST → invokeTemplate — NOT html/template Execute, which
+// would render recursion natively and thus not exercise our code), and
+// reconstructs the HTML the client would render from that tree.
+func buildTreeHTML(t *testing.T, src string, data interface{}) (string, error) {
+	t.Helper()
+	tmpl, err := Must(New("test")).Parse(src)
+	if err != nil {
+		return "", err
+	}
+	tree, err := tmpl.buildTree(data, nil)
+	if err != nil {
+		return "", err
+	}
+	return render.TreeToHTML(tree.ToMap())
+}
+
+// TestRecursiveTemplate_RendersNestedTree is the core proof for C8: a recursive
+// {{template}} now renders through the reactive tree path instead of crashing at
+// parse time. The reconstructed HTML must reproduce the full nested structure.
+func TestRecursiveTemplate_RendersNestedTree(t *testing.T) {
+	data := fileNode{
+		Name: "root", Path: "/", IsDir: true,
+		Children: []fileNode{
+			{Name: "a.go", Path: "/a.go"},
+			{
+				Name: "sub", Path: "/sub", IsDir: true,
+				Children: []fileNode{
+					{Name: "b.go", Path: "/sub/b.go"},
+				},
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := Must(New("test")).Parse(tt.src)
-			if err == nil {
-				t.Fatal("expected an error for a recursive template, got nil")
-			}
-			if !strings.Contains(err.Error(), "recursive") {
-				t.Errorf("error should explain the recursion, got: %v", err)
-			}
-		})
+	html, err := buildTreeHTML(t, recursiveTreeSrc, data)
+	if err != nil {
+		t.Fatalf("recursive template must render, got error: %v", err)
+	}
+
+	want := `<ul><li data-key="/"><span>root</span><ul>` +
+		`<li data-key="/a.go"><span>a.go</span></li>` +
+		`<li data-key="/sub"><span>sub</span><ul>` +
+		`<li data-key="/sub/b.go"><span>b.go</span></li>` +
+		`</ul></li>` +
+		`</ul></li></ul>`
+	if html != want {
+		t.Errorf("recursive render mismatch\nwant: %s\ngot:  %s", want, html)
+	}
+}
+
+// TestRecursiveTemplate_SingleLevel is the base case: a "directory" with no
+// children must terminate cleanly (the {{range}} over an empty slice invokes
+// nothing), proving recursion stops when the data does.
+func TestRecursiveTemplate_SingleLevel(t *testing.T) {
+	data := fileNode{Name: "empty", Path: "/empty", IsDir: true}
+
+	html, err := buildTreeHTML(t, recursiveTreeSrc, data)
+	if err != nil {
+		t.Fatalf("render error: %v", err)
+	}
+	want := `<ul><li data-key="/empty"><span>empty</span><ul></ul></li></ul>`
+	if html != want {
+		t.Errorf("base-case mismatch\nwant: %s\ngot:  %s", want, html)
+	}
+}
+
+// TestRecursiveTemplate_MutualRecursion proves the registry holds more than one
+// cycle member: two templates that call each other, terminated by the data.
+func TestRecursiveTemplate_MutualRecursion(t *testing.T) {
+	// a renders a <div> then, if it has a child, delegates to b; b renders a
+	// <span> then delegates back to a. Termination is by nil child.
+	src := `{{define "a"}}<div>{{.Name}}{{with .Next}}{{template "b" .}}{{end}}</div>{{end}}` +
+		`{{define "b"}}<span>{{.Name}}{{with .Next}}{{template "a" .}}{{end}}</span>{{end}}` +
+		`{{template "a" .}}`
+
+	type chain struct {
+		Name string
+		Next interface{}
+	}
+	data := chain{Name: "1", Next: chain{Name: "2", Next: chain{Name: "3"}}}
+
+	html, err := buildTreeHTML(t, src, data)
+	if err != nil {
+		t.Fatalf("mutual recursion must render, got error: %v", err)
+	}
+	want := `<div>1<span>2<div>3</div></span></div>`
+	if html != want {
+		t.Errorf("mutual-recursion mismatch\nwant: %s\ngot:  %s", want, html)
+	}
+}
+
+// TestRecursiveTemplate_DepthGuard_TreePath proves the reactive depth guard is
+// the sole thing standing between unbounded recursion and a Go stack overflow on
+// the tree-build path that does NOT go through html/template Execute (which has
+// its own depth limit). compat.ParseTemplateToTree walks straight into
+// parse.BuildTree → invokeTemplate, so our guard must fire on infinite data.
+func TestRecursiveTemplate_DepthGuard_TreePath(t *testing.T) {
+	type loopNode struct {
+		Name string
+		Self interface{}
+	}
+	n := &loopNode{Name: "x"}
+	n.Self = n // infinite: Self is always non-nil
+
+	// The {{define}} block is present in the source, so parse.Parse registers
+	// "loop" as a recursive template even without the flatten step.
+	src := `{{define "loop"}}<div>{{.Name}}{{with .Self}}{{template "loop" .}}{{end}}</div>{{end}}` +
+		`{{template "loop" .}}`
+
+	_, err := compat.ParseTemplateToTree("test", src, n)
+	if err == nil {
+		t.Fatal("expected the reactive depth guard to stop unbounded recursion, got nil")
+	}
+	if !strings.Contains(err.Error(), "depth") {
+		t.Errorf("error should explain the depth limit, got: %v", err)
+	}
+}
+
+// TestRecursiveTemplate_DepthGuard_NoCrash proves the full public path
+// (buildTree → Execute → tree) never crashes on unbounded recursion — it returns
+// a clean depth error instead. (On this path html/template Execute's own depth
+// limit trips first; either way the outcome is a bounded error, not overflow.)
+func TestRecursiveTemplate_DepthGuard_NoCrash(t *testing.T) {
+	type loopNode struct {
+		Name string
+		Self interface{}
+	}
+	n := &loopNode{Name: "x"}
+	n.Self = n
+
+	src := `{{define "loop"}}<div>{{.Name}}{{with .Self}}{{template "loop" .}}{{end}}</div>{{end}}` +
+		`{{template "loop" .}}`
+
+	_, err := buildTreeHTML(t, src, n)
+	if err == nil {
+		t.Fatal("expected a depth-limit error for unbounded recursion, got nil")
+	}
+	if !strings.Contains(err.Error(), "depth") {
+		t.Errorf("error should explain the depth limit, got: %v", err)
+	}
+}
+
+// TestRecursiveTemplate_ConfigurableDepth proves WithMaxTemplateDepth is wired
+// end-to-end from Option → Config → build.Context → invokeTemplate. A first
+// render within the limit establishes the reactive tree; a subsequent update
+// that grows past the limit is rejected with a depth error (the update path
+// propagates the guard, unlike the first-render path which degrades to the HTML
+// fallback). The default (128) renders the same deep tree without complaint.
+func TestRecursiveTemplate_ConfigurableDepth(t *testing.T) {
+	// Default limit: a depth-6 tree renders fine (well under 128).
+	if _, err := buildTreeHTML(t, recursiveTreeSrc, chainDir(6)); err != nil {
+		t.Fatalf("depth-6 tree must render under the default limit, got: %v", err)
+	}
+
+	// Lowered limit of 3: first render a shallow tree (within the limit) to
+	// establish the reactive baseline, then update to a deep tree.
+	tmpl, err := Must(New("test", WithMaxTemplateDepth(3))).Parse(recursiveTreeSrc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := tmpl.buildTree(chainDir(2), nil); err != nil {
+		t.Fatalf("shallow first render (within limit) must succeed, got: %v", err)
+	}
+	_, err = tmpl.buildTree(chainDir(6), nil)
+	if err == nil {
+		t.Fatal("expected a depth error updating past WithMaxTemplateDepth(3), got nil")
+	}
+	if !strings.Contains(err.Error(), "depth") {
+		t.Errorf("error should explain the depth limit, got: %v", err)
 	}
 }
 
 // TestParse_NonRecursiveComposition_StillWorks is the companion positive gate:
-// ordinary (acyclic) {{define}}/{{template}} composition must keep parsing
-// through the public API exactly as before the guard.
+// ordinary (acyclic) {{define}}/{{template}} composition must keep parsing and
+// rendering exactly as before the recursion feature landed.
 func TestParse_NonRecursiveComposition_StillWorks(t *testing.T) {
 	src := `{{define "header"}}<h1>{{.Title}}</h1>{{end}}` +
 		`{{template "header" .}}<main>{{.Body}}</main>`
+	data := struct {
+		Title string
+		Body  string
+	}{Title: "Hi", Body: "world"}
 
-	if _, err := Must(New("test")).Parse(src); err != nil {
-		t.Fatalf("non-recursive composition must parse cleanly, got: %v", err)
+	html, err := buildTreeHTML(t, src, data)
+	if err != nil {
+		t.Fatalf("non-recursive composition must render, got: %v", err)
+	}
+	want := `<h1>Hi</h1><main>world</main>`
+	if html != want {
+		t.Errorf("non-recursive composition mismatch\nwant: %s\ngot:  %s", want, html)
 	}
 }

--- a/template.go
+++ b/template.go
@@ -1618,10 +1618,19 @@ func (t *Template) buildTreeWithCache(data interface{}, ctx *build.Context) (*tr
 // NOTE: This method modifies template state. Caller must hold t.mu write lock.
 // Errors from buildTreeWithCache are absorbed via the HTML structure-based fallback,
 // so this method never propagates failure to the caller.
-func (t *Template) generateInitialTreeWithoutRegistry(data interface{}, extractedContent string) *treeNode {
+// newBuildContext returns a build context seeded from the template's config. Both
+// tree-build entry points use it, so a config field that must reach the build
+// (DevMode, MaxInvocationDepth) is projected in one place and can't drift between
+// the first-render and update paths.
+func (t *Template) newBuildContext() *build.Context {
 	ctx := build.NewContext()
 	ctx.DevMode = t.config.DevMode
 	ctx.MaxInvocationDepth = t.config.MaxTemplateDepth
+	return ctx
+}
+
+func (t *Template) generateInitialTreeWithoutRegistry(data interface{}, extractedContent string) *treeNode {
+	ctx := t.newBuildContext()
 
 	tree, err := t.buildTreeWithCache(data, ctx)
 	if err != nil {
@@ -1653,9 +1662,7 @@ func (t *Template) generateDiffBasedTree(oldHTML, newHTML string, newData interf
 		// Note: t.lastHTML is intentionally not updated here — it holds stale data from
 		// the first render. This is safe because lastHTML is only consumed by the fallback
 		// path below, which is unreachable once hasInitialTree is true.
-		ctx := build.NewContext()
-		ctx.DevMode = t.config.DevMode
-		ctx.MaxInvocationDepth = t.config.MaxTemplateDepth
+		ctx := t.newBuildContext()
 
 		newTree, err := t.buildTreeWithCache(newData, ctx)
 		if err != nil {

--- a/template.go
+++ b/template.go
@@ -155,6 +155,7 @@ type Config struct {
 	TemplateBaseDir        string                              // Base directory for template auto-discovery (default: directory of calling code via runtime.Caller)
 	IgnoreTemplateDirs     []string                            // Additional directories to ignore during auto-discovery
 	DevMode                bool                                // Development mode: allows ALL WebSocket origins (disables the same-origin/CSRF check — never in production), exposes {{.lvt.DevMode}} to templates, enables debug logging
+	MaxTemplateDepth       int                                 // Max recursive {{template}} nesting depth during tree generation (0 = built-in default of 128)
 	MaxConnections         int64                               // Maximum total connections (0 = unlimited)
 	MaxConnectionsPerGroup int64                               // Maximum connections per group (0 = unlimited)
 	MessageRateLimit       float64                             // Messages per second per connection (0 = unlimited, default 10)
@@ -420,6 +421,17 @@ func WithLoadingDisabled() Option {
 func WithDevMode(enabled bool) Option {
 	return func(c *Config) {
 		c.DevMode = enabled
+	}
+}
+
+// WithMaxTemplateDepth sets the maximum nesting depth for recursive {{template}}
+// invocations during reactive tree generation. Beyond this depth, tree building
+// fails with a clear error rather than overflowing the stack — a guard against
+// unbounded recursion in the data. A non-positive value keeps the built-in
+// default (128). Raise it only when the data is legitimately deeper.
+func WithMaxTemplateDepth(depth int) Option {
+	return func(c *Config) {
+		c.MaxTemplateDepth = depth
 	}
 }
 
@@ -1609,6 +1621,7 @@ func (t *Template) buildTreeWithCache(data interface{}, ctx *build.Context) (*tr
 func (t *Template) generateInitialTreeWithoutRegistry(data interface{}, extractedContent string) *treeNode {
 	ctx := build.NewContext()
 	ctx.DevMode = t.config.DevMode
+	ctx.MaxInvocationDepth = t.config.MaxTemplateDepth
 
 	tree, err := t.buildTreeWithCache(data, ctx)
 	if err != nil {
@@ -1642,6 +1655,7 @@ func (t *Template) generateDiffBasedTree(oldHTML, newHTML string, newData interf
 		// path below, which is unreachable once hasInitialTree is true.
 		ctx := build.NewContext()
 		ctx.DevMode = t.config.DevMode
+		ctx.MaxInvocationDepth = t.config.MaxTemplateDepth
 
 		newTree, err := t.buildTreeWithCache(newData, ctx)
 		if err != nil {


### PR DESCRIPTION
**Stacked on #494 (Phase 1).** Base is `tierc-c8-phase1-cycle-guard`; merge #494 first, then this retargets to `main` cleanly.

Turns the Phase 1 parse-time *rejection* of recursive `{{template}}` into full **runtime support** — the last genuine capability gap from the boilerplate-reduction sweep (issue #483, item C8). A recursive `{{template}}` (file trees, comment threads, org charts) now renders through the reactive tree path and gets **minimal, dynamics-only updates** instead of a full-string resend.

### How it works (all inside `internal/parse` — no cross-package threading)
- **Detection** — `detectRecursiveTemplates` runs a reachable-from-self DFS over the `{{template}}` invocation graph to find cycle members. Non-recursive composition still inlines exactly as before.
- **Registry via appended defines** — `walkAndFlatten` emits recursive calls **verbatim** (un-inlined); `FlattenTemplate` appends each flattened body as a `{{define}}` block. The un-wrapped flattened string carries them, so `parse.Parse` reconstructs a `name→AST` registry on `parse.Template` from the associated templates for free.
- **Runtime invocation** — `invokeTemplate` (new `invoke.go`), dispatched from `walkAST`'s `TemplateNode` case, evaluates the pipe, rebinds dot to the pipe value in a fresh scope (Go resets `.`/`$` on a template call), re-walks the registered body, and wraps the result in a single dynamic slot (mirroring `{{if}}`).
- **Backstop** — `checkFlattenCycle` (Phase 1) stays: an under-detected cycle re-enters and errors cleanly instead of overflowing.
- **Depth guard** — `build.Context` gains `InvocationDepth`/`MaxInvocationDepth`, incremented in a per-invocation copy before the check, so a pointer cycle in the data trips the ceiling rather than overflowing `walkAST`. Configurable via `WithMaxTemplateDepth(n)` / `LVT_MAX_TEMPLATE_DEPTH` (default 128).

### Tests
- **Render parity** — exact HTML for nested / single-level / **mutual** recursion.
- **Minimal update** — add-child emits a single granular range op carrying only the new node (key extraction descends through the invocation wrapper); a depth-grows change resends only the new level's statics.
- **Initial HTML** — `Execute` renders recursion natively.
- **Depth guard** — sole protection on the tree-only path; no-crash on the full path; `WithMaxTemplateDepth(3)` rejects a deep tree on update that the default renders.
- Phase-1 flatten tests flipped to assert emit-verbatim + a `checkFlattenCycle` backstop test.

### Known behavior note
The depth guard's error propagates on the **update** path but degrades to the HTML-structure fallback on **first render** (the framework's general AST-build-failure behavior); infinite data trips html/template `Execute`'s own limit first. Documented in the proposal (Open question 2 / Phase 4).

### Follow-up (not in this PR)
Phase 5 tail — benchmarks, chromedp e2e (lvt repo), support-matrix ❌→✅ flip, recipe — and companions #6/#7 (prereview, tinkerdown) land after a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)