### PR TITLE
docs: correct recursive-template support, stale since v0.19.0 shipped it

### DIFF
--- a/docs/references/CONFIGURATION.md
+++ b/docs/references/CONFIGURATION.md
@@ -173,6 +173,18 @@ Base directory for template auto-discovery.
 
 **Use case**: Override automatic template directory detection. Useful in containerized deployments where `runtime.Caller` may resolve to an unexpected path.
 
+#### `LVT_MAX_TEMPLATE_DEPTH`
+
+Maximum nesting depth for recursive `{{template}}` invocations while building the reactive tree.
+
+- **Type**: Integer
+- **Default**: `128`
+- **Example**: `LVT_MAX_TEMPLATE_DEPTH=256`
+- **Validation**: Must be a positive integer; an invalid value is a hard startup error
+- **Option**: `WithMaxTemplateDepth(n)`
+
+**Use case**: Recursive templates (file trees, comment threads, nested navigation) render self-referential data. This cap stops a *cycle in the data* — a node whose children contain itself — from overflowing the stack, surfacing an error instead. Raise it only when your data is legitimately deeper than the default; the cap is a safety net, not a tuning knob. See [Template Support Matrix — Recursion depth](template-support-matrix.md#recursion-depth) for the first-render versus update behavior.
+
 ### Graceful Shutdown
 
 #### `LVT_SHUTDOWN_TIMEOUT`

--- a/docs/references/template-support-matrix.md
+++ b/docs/references/template-support-matrix.md
@@ -173,10 +173,29 @@ Stripping uses the HTML tokenizer (not a regex), so it is context-aware:
 |---------|--------|-------|
 | `{{define}}` / `{{template}}` | ✅ | Automatically flattened via `FlattenTemplate()` in `internal/parse/flatten.go` |
 | `{{block}}` | ✅ | Resolved during flattening; equivalent to `{{define}}` + `{{template}}` |
-| Recursive / circular template references | ❌ | Rejected at parse time with a clear `ParseError` naming the cycle (e.g. `treeNode -> treeNode`). Because `{{template}}` calls are inlined during flattening, a self-referential template cannot be inlined; runtime invocation of recursive templates is a planned feature (see `docs/proposals/recursive-templates-proposal.md`). |
+| Recursive / circular template references | ✅ | Supported since v0.19.0 — direct self-recursion (`node -> node`), mutual recursion (`a -> b -> a`), longer cycles, and a self-referential entry point all render. `{{template}}` calls are normally inlined during flattening, which a cycle cannot survive, so `FlattenTemplate` detects templates reachable from themselves and leaves those invocations un-inlined, evaluating them at build time as nested `TreeNode`s. The recursive region stays inside the reactive tree, so updates diff per-leaf rather than re-sending the branch. Depth is capped — see [Recursion depth](#recursion-depth). |
 | Undefined template invocation | ❌ | Returns error from Go template engine |
 
-Template composition is fully supported through automatic AST flattening. `FlattenTemplate()` walks the parsed template tree, identifies the entry point, and inlines all `{{template}}` invocations into a single flat template before tree generation.
+Template composition is fully supported through automatic AST flattening. `FlattenTemplate()` walks the parsed template tree, identifies the entry point, and inlines all `{{template}}` invocations into a single flat template before tree generation. Templates that are reachable from themselves are the exception: they are left un-inlined and invoked at build time instead.
+
+### Recursion depth
+
+Recursive invocation is capped so that self-referential *data* (a node whose child list contains itself) surfaces an error instead of overflowing the stack. The cap defaults to **128** and is configurable:
+
+```go
+lt.New("tree", lt.WithMaxTemplateDepth(256))
+```
+
+```bash
+export LVT_MAX_TEMPLATE_DEPTH=256   # must be a positive integer
+```
+
+Exceeding the cap on a **reactive update** returns a build-phase `ParseError` naming the template and the limit. Raise the cap only if your data is legitimately deeper — the default exists to catch cycles in data, not to constrain real nesting.
+
+Two behaviours differ from that and are worth knowing:
+
+- **First render with finite data deeper than the cap does not error.** The build degrades and still produces a usable, keyed page, so a too-low cap can go unnoticed until the first update fails.
+- **If the initial tree build errors outright** — genuinely self-referential data, where a node's children contain the node itself — the initial render falls back to an HTML-structure-based tree and logs `Template parsing failed, falling back to HTML structure-based tree`. That region then stays on HTML-string diffing for the life of the template rather than the reactive path. A recursive region that renders but never updates reactively is the symptom; that warning in the server log is the confirmation.
 
 ## Custom Functions
 

--- a/internal/parse/flatten.go
+++ b/internal/parse/flatten.go
@@ -390,11 +390,9 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 			return fmt.Errorf("template %q has no parse tree", n.Name)
 		}
 
-		// Cycle detection: if this template is already being inlined on the
-		// current path, inlining its body again would recurse forever and
-		// stack-overflow during Parse (livetemplate inlines {{template}} calls
-		// at parse time; it does not yet evaluate recursive invocations at
-		// runtime). Return a structured error naming the cycle instead.
+		// Backstop only: recursive names were already marked above and returned
+		// verbatim, so a name on the active path here means the recursive set
+		// disagrees with this walk. Erroring beats overflowing the stack.
 		if err := checkFlattenCycle(n, stack); err != nil {
 			return err
 		}
@@ -444,11 +442,15 @@ func walkAndFlatten(node parse.Node, templates map[string]*template.Template, bu
 	return nil
 }
 
-// checkFlattenCycle reports a self-referential {{template}} invocation. If the
-// invoked name already appears on the active-path stack, inlining it again
-// would expand forever, so it returns a ParseError naming the cycle (the path
-// from the name's first appearance back to itself, e.g. "page -> row -> page").
-// Returns nil when the invocation is acyclic and safe to inline.
+// checkFlattenCycle is a backstop against inlining a cycle forever. It is not
+// reachable through FlattenTemplate: detectRecursiveTemplates runs first over
+// the same invocation edges this walk follows, so any name on a cycle is marked
+// recursive and emitted verbatim rather than pushed onto the stack. It stays as
+// a guard for direct walkAndFlatten callers (and any future traversal that
+// drifts from detectRecursiveTemplates), where an under-populated recursive set
+// would otherwise expand forever and overflow the stack.
+//
+// Recursion itself is supported — see invokeTemplate for the runtime path.
 func checkFlattenCycle(n *parse.TemplateNode, stack []string) error {
 	i := slices.Index(stack, n.Name)
 	if i < 0 {
@@ -460,9 +462,10 @@ func checkFlattenCycle(n *parse.TemplateNode, stack []string) error {
 		NodeType: "template",
 		Expr:     n.Name,
 		Pos:      int(n.Position()),
-		Msg: fmt.Sprintf("recursive template invocation is not supported (cycle: %s); "+
-			"livetemplate inlines {{template}} calls at parse time, so a self-referential "+
-			"template would expand infinitely", cycle),
+		Msg: fmt.Sprintf("internal: reached the flatten-cycle backstop for %s; "+
+			"recursive templates should have been detected before inlining "+
+			"(this indicates detectRecursiveTemplates and walkAndFlatten "+
+			"disagree about the invocation graph)", cycle),
 	}
 }
 


### PR DESCRIPTION
`docs/references/template-support-matrix.md` still told users recursive templates don't work — in the release that shipped them.

```
| Recursive / circular template references | ❌ | Rejected at parse time ...
  runtime invocation of recursive templates is a planned feature |
```

That row was updated by the C8 work to the **Phase 1** wording (parse-time rejection), and the later runtime-support phase never revised it. So v0.19.0 went out documenting the opposite of its headline feature.

## What's actually supported

Verified by reading the code and the tests that pin each shape:

| Shape | Supported | Pinned by |
|---|---|---|
| Direct self-recursion `node -> node` | ✅ | `TestRecursiveTemplate_RendersNestedTree` |
| Mutual recursion `a -> b -> a` | ✅ | `TestRecursiveTemplate_MutualRecursion` |
| Longer cycles `a -> b -> c -> a` | ✅ | by construction (`reachableFromSelf` is a general cycle DFS) |
| Self-referential entry point | ✅ | `TestFlattenTemplate_RecursionEmittedForRuntime` |

## Changes

- **`template-support-matrix.md`** — flip the row, describe the mechanism (`detectRecursiveTemplates` leaves cycle members un-inlined; they're evaluated at build time as nested `TreeNode`s), and add a **Recursion depth** section.
- **`CONFIGURATION.md`** — document `LVT_MAX_TEMPLATE_DEPTH` / `WithMaxTemplateDepth`, which had no reference entry at all.
- **`flatten.go`** — `checkFlattenCycle`'s error said *"recursive template invocation is not supported"* and its comment said livetemplate *"does not yet evaluate recursive invocations at runtime"*. Both false. The check is also no longer reachable through `FlattenTemplate`: `detectRecursiveTemplates` runs first over the same invocation edges the walk follows, so a cycle member is marked recursive and emitted verbatim rather than pushed onto the inlining stack. Reworded as the internal backstop it now is. `TestFlattenTemplate_CycleBackstop` still passes — it reaches the guard by calling `walkAndFlatten` directly with an empty recursive set.

## Two behaviors worth documenting

Both are easy to hit and neither is obvious:

1. A **finite tree deeper than the cap does not error on first render** — it degrades and still produces a usable keyed page, so a too-low cap goes unnoticed until the first update fails.
2. If the initial tree build **errors outright** (genuinely self-referential data), the render falls back to an HTML-structure-based tree and logs `Template parsing failed, falling back to HTML structure-based tree`. That region then stays on HTML-string diffing for the life of the template — it renders, but never updates reactively.

Verified against `TestRecursiveTemplate_FirstRenderOverLimit`, `TestRecursiveTemplate_ConfigurableDepth`, and the fallback in `generateInitialTreeWithoutRegistry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG