### PR TITLE
fix(release,ci): survive an aborted release, and stop interpolating the tag into shell

### DIFF
--- a/.github/workflows/dispatch-docs-sync.yml
+++ b/.github/workflows/dispatch-docs-sync.yml
@@ -19,13 +19,28 @@ jobs:
           # Same PAT used by all four source repos. Setup once via:
           #   gh secret set DOCS_DISPATCH_TOKEN --repo livetemplate/<this> --body <token>
           GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+          # A tag name is chosen by whoever pushes the tag, so it does not go
+          # into the script body via ${{ }} — that would be shell injection into
+          # a job holding a cross-repo write token. It arrives as an environment
+          # variable and is quoted at every use. github.repository is set by the
+          # runner rather than by user input, but travels the same path so no
+          # interpolation remains in this run: block at all.
+          SOURCE_REPO: https://github.com/${{ github.repository }}
+          SOURCE_REF: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then
             echo "::warning::DOCS_DISPATCH_TOKEN not set; skipping docs sync dispatch"
             exit 0
           fi
+          # The docs sync rejects refs outside this shape too; failing here means
+          # a bad tag never spends the token.
+          if ! printf '%s' "$SOURCE_REF" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo "::error::refusing to dispatch an unsafe ref: $SOURCE_REF"
+            exit 1
+          fi
           gh api -X POST /repos/livetemplate/docs/dispatches \
             -F event_type=sync-source \
-            -F "client_payload[source_repo]=https://github.com/${{ github.repository }}" \
-            -F "client_payload[ref]=${{ github.ref_name }}"
-          echo "::notice::dispatched docs sync for ${{ github.ref_name }}"
+            -F "client_payload[source_repo]=$SOURCE_REPO" \
+            -F "client_payload[ref]=$SOURCE_REF"
+          echo "::notice::dispatched docs sync for $SOURCE_REF"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -79,11 +79,32 @@ bump_version() {
     echo "${major}.${minor}.${patch}"
 }
 
+# Restore VERSION / CHANGELOG.md if the release aborts after they are written
+# but before the release commit lands. Without this, an abort (a flaky test, a
+# failed tag) leaves a dirty tree — and main() refuses to run on a dirty tree,
+# so the retry is blocked until someone works out what to revert.
+release_files_written=false
+release_committed=false
+
+restore_release_files() {
+    if [ "$release_files_written" = true ] && [ "$release_committed" = false ]; then
+        log_warn "Release aborted before committing — restoring VERSION and CHANGELOG.md"
+        # Restore from HEAD, not from the index: commit_and_tag stages both files
+        # before committing, so if the commit itself fails they are already
+        # staged and a plain `git checkout --` would restore them from the index
+        # — copying the modified versions back over themselves.
+        git checkout HEAD -- VERSION CHANGELOG.md 2>/dev/null || \
+            log_warn "Could not restore VERSION / CHANGELOG.md; revert them by hand before retrying"
+    fi
+}
+trap restore_release_files EXIT
+
 # Update all version files
 update_versions() {
     local new_version=$1
 
     log_step "Updating VERSION file to $new_version"
+    release_files_written=true
     echo "$new_version" > VERSION
 
     log_info "VERSION file updated to $new_version"
@@ -149,6 +170,10 @@ Related repositories:
 - Examples: https://github.com/livetemplate/examples
 
 🤖 Generated with automated release script"
+
+    # VERSION / CHANGELOG.md now live in a commit; restoring them on a later
+    # failure would discard the release commit itself, so stand the guard down.
+    release_committed=true
 
     log_step "Creating git tag v$new_version"
     git tag -a "v$new_version" -m "Release v$new_version"
@@ -395,10 +420,13 @@ main() {
     log_info "Starting release process..."
     echo ""
 
-    # Execute release steps
+    # Execute release steps. Tests run FIRST, before anything is written: no Go
+    # code reads the VERSION file, so the bump cannot change the result, and a
+    # failure (a flaky test especially) then leaves the tree untouched instead
+    # of half-bumped.
+    build_and_test
     update_versions "$new_version"
     generate_changelog "$new_version"
-    build_and_test
     commit_and_tag "$new_version"
     publish_github "$new_version"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -107,8 +107,16 @@ restore_release_files() {
         if git cat-file -e "HEAD:$f" 2>/dev/null; then
             git checkout HEAD -- "$f" || \
                 log_warn "Could not restore $f; revert it by hand before retrying"
-        else
-            log_warn "$f is not in HEAD — this run created it; delete it by hand before retrying"
+        elif [ -f "$f" ]; then
+            # Absent from HEAD but on disk means this run created it: main()
+            # refuses to start on a dirty tree and `git status --porcelain`
+            # lists untracked files, so it cannot have pre-existed. Removing it
+            # restores the exact pre-run state. Both steps are needed —
+            # commit_and_tag may already have staged it, and a bare `rm` would
+            # leave an "A " entry that still counts as dirty.
+            git rm -f --quiet --ignore-unmatch -- "$f" 2>/dev/null || true
+            rm -f "$f"
+            log_warn "Removed $f, which this run created"
         fi
     done
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -87,15 +87,30 @@ release_files_written=false
 release_committed=false
 
 restore_release_files() {
-    if [ "$release_files_written" = true ] && [ "$release_committed" = false ]; then
-        log_warn "Release aborted before committing — restoring VERSION and CHANGELOG.md"
-        # Restore from HEAD, not from the index: commit_and_tag stages both files
-        # before committing, so if the commit itself fails they are already
-        # staged and a plain `git checkout --` would restore them from the index
-        # — copying the modified versions back over themselves.
-        git checkout HEAD -- VERSION CHANGELOG.md 2>/dev/null || \
-            log_warn "Could not restore VERSION / CHANGELOG.md; revert them by hand before retrying"
-    fi
+    [ "$release_files_written" = true ] || return 0
+    [ "$release_committed" = false ] || return 0
+
+    log_warn "Release aborted before committing — restoring VERSION and CHANGELOG.md"
+
+    # Restore from HEAD, not from the index: commit_and_tag stages both files
+    # before committing, so if the commit itself fails they are already staged
+    # and a plain `git checkout --` would restore them from the index — copying
+    # the modified versions back over themselves.
+    #
+    # One path per invocation. `git checkout HEAD -- a b` resolves the pathspec
+    # first and bails before touching the worktree if any entry is missing from
+    # HEAD, so a single call would restore *neither* file when one is untracked.
+    # git's stderr is left visible; a generic "couldn't restore" would send the
+    # next person down the wrong trail.
+    local f
+    for f in VERSION CHANGELOG.md; do
+        if git cat-file -e "HEAD:$f" 2>/dev/null; then
+            git checkout HEAD -- "$f" || \
+                log_warn "Could not restore $f; revert it by hand before retrying"
+        else
+            log_warn "$f is not in HEAD — this run created it; delete it by hand before retrying"
+        fi
+    done
 }
 trap restore_release_files EXIT
 


### PR DESCRIPTION
Both problems surfaced while releasing v0.19.1.

## 1. An aborted release left a half-bumped tree

The v0.19.1 release aborted at `build_and_test` on a test failure that did not reproduce (the same suite passed three times afterwards). The abort itself was fine. The state it left behind was not:

```
 M CHANGELOG.md
 M VERSION
```

Because the order was `update_versions` → `generate_changelog` → `build_and_test`, both files were already rewritten when the tests ran. And `main()` refuses to start on a dirty tree — so the retry was blocked until someone worked out what to revert. That is a confusing trap at exactly the wrong moment.

**`build_and_test` now runs first.** No Go code reads the `VERSION` file, so the bump cannot change the test result, and a failure leaves the tree untouched.

**A trap covers the remaining window** — a failed changelog step, a rejected commit, a tag clash. It restores from `HEAD`, not the index:

> `commit_and_tag` stages both files before committing, so on a failed commit they are already staged. A plain `git checkout --` restores from the index — copying the modified versions back over themselves, achieving nothing.

The first version of this fix had precisely that bug. The abort test below is what caught it, which is the argument for having written the test rather than eyeballing the diff.

## 2. `${{ github.ref_name }}` interpolated into a `run:` block

```yaml
-F "client_payload[ref]=${{ github.ref_name }}"
```

A tag name is chosen by whoever pushes the tag, and this job holds a PAT with write access to `livetemplate/docs`. Values now arrive via `env:` and are quoted; **no interpolation remains in the `run:` block**. The ref is validated against `[A-Za-z0-9._/-]+` before the token is spent, mirroring what the docs sync gained in livetemplate/docs#115.

Exploiting it needs tag-push access, so this is hardening rather than an open door.

## Verification

Both paths exercised in a throwaway clone with `publish_github` stubbed out, so nothing escaped:

| Scenario | Result |
|---|---|
| Forced failure after the bump | `VERSION` restored, **0 dirty files**, retry unblocked |
| Successful run | release commit + tag intact, trap correctly stood down |

Also confirmed the reorder in the log output — `Running Go tests…` now precedes `Updating VERSION file`.

## Note on scope

An audit of every `run:` block across the repo's workflows found one other interpolation, `benchmark.yml` line 148. It is **not** a vulnerability — `message` is set to hardcoded literals a few lines above — so I left it alone rather than churn it under a security banner.

lvt has the identical `release.sh` ordering bug; fixed separately in livetemplate/lvt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG