### PR TITLE
fix(release): refuse to bump on top of an unpublished release (closes #500)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -423,7 +423,21 @@ main() {
         echo "Finish that release first:"
         echo ""
         echo "  git push origin $branch"
-        echo "  git push origin v$pending"
+        # An absent tag is a real state, not just a defensive branch:
+        # commit_and_tag sets release_committed immediately after the commit and
+        # tags afterwards, so a failure at the tag step leaves a release commit
+        # with no tag. Printing the push unconditionally would hand over a
+        # command that just fails, hiding the step that actually needs redoing.
+        if git rev-parse -q --verify "refs/tags/v$pending" >/dev/null 2>&1; then
+            echo "  git push origin v$pending"
+        else
+            echo ""
+            echo "  # No v$pending tag exists locally — the tag step never completed."
+            echo "  # Recreate it before pushing:"
+            echo "  git tag -a v$pending -m \"Release v$pending\""
+            echo "  git push origin v$pending"
+        fi
+        echo ""
         echo "  gh release view v$pending    # if this reports no release, create it:"
         echo "  gh release create v$pending --title \"v$pending\" --notes-file <notes>"
         echo ""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,6 +41,44 @@ check_prerequisites() {
     fi
 }
 
+# Detect a release that was committed locally but never reached origin — a push
+# or `gh release create` failure after commit_and_tag. Left undetected, the next
+# run reads the already-bumped VERSION and offers to bump *on top of it*,
+# skipping a version in the published sequence and leaving a local tag on a
+# commit the remote has never seen. See issue #500.
+#
+# This runs on every release while the state it catches is rare, so it fails
+# toward "proceed with the normal release": any check it cannot complete returns
+# 1 (not detected) rather than guessing. A false positive would block a healthy
+# release; a false negative only restores the previous behaviour.
+check_unpublished_release() {
+    local branch=$1
+    local version
+    version=$(get_current_version)
+
+    # Only meaningful when HEAD is this version's release commit.
+    [ "$(git log -1 --pretty=%s 2>/dev/null)" = "chore(release): v$version" ] || return 1
+
+    # Deciding this needs an up-to-date origin/$branch. Immediately after a
+    # SUCCESSFUL release the HEAD subject and VERSION look identical to the
+    # unpublished case, so the ancestry test below is the only thing telling
+    # them apart — on a stale ref it would report a published release as
+    # unpublished. A fetch that fails therefore means "cannot tell", not
+    # "unpublished".
+    git fetch --quiet origin "$branch" 2>/dev/null || return 1
+
+    # An ancestor of the remote branch means it is published.
+    if git merge-base --is-ancestor HEAD "refs/remotes/origin/$branch" 2>/dev/null; then
+        return 1
+    fi
+
+    # Not an ancestor — but merge-base also fails when the ref is missing
+    # entirely (a branch never pushed), which is not this bug.
+    git rev-parse -q --verify "refs/remotes/origin/$branch" >/dev/null 2>&1 || return 1
+
+    return 0
+}
+
 # Get current version
 get_current_version() {
     if [ ! -f VERSION ]; then
@@ -370,6 +408,29 @@ main() {
         log_error "Repository is in a detached HEAD state. Please check out a branch before running this script."
         exit 1
     fi
+    # Before pulling: a rebase would move the release commit out from under its
+    # tag, leaving the tag on an orphaned commit.
+    if check_unpublished_release "$branch"; then
+        local pending
+        pending=$(get_current_version)
+        echo ""
+        log_error "v$pending is committed locally but has not reached origin/$branch"
+        echo ""
+        echo "A previous release committed and tagged v$pending, then failed before"
+        echo "publishing it. Releasing again from here would bump on top of v$pending"
+        echo "and skip it in the published sequence."
+        echo ""
+        echo "Finish that release first:"
+        echo ""
+        echo "  git push origin $branch"
+        echo "  git push origin v$pending"
+        echo "  gh release view v$pending    # if this reports no release, create it:"
+        echo "  gh release create v$pending --title \"v$pending\" --notes-file <notes>"
+        echo ""
+        echo "Then re-run this script to release the next version."
+        exit 1
+    fi
+
     if [ "$dry_run_mode" = true ]; then
         log_info "[dry-run] Would pull latest from origin/$branch"
     else


### PR DESCRIPTION
Closes #500.

If a release got as far as `commit_and_tag` and then failed to publish — a push error, a `gh release create` failure — the tree held a release commit and tag the remote had never seen, and **nothing said so**. The next run read the already-bumped `VERSION` as current and offered to bump *on top of it*:

```
VERSION = 0.19.2        ← tagged locally, never pushed
next run offers         → 0.19.3
result                  → 0.19.2 skipped in the published sequence,
                          local tag on a commit the remote never saw
```

`main()` now detects that state and refuses, printing the commands that finish the interrupted release.

## Two design decisions worth stating

**Detect before the pull.** `git pull --rebase` would move the release commit out from under its tag, leaving the tag on an orphaned commit. The check runs first.

**Detect-and-refuse, not resume-automatically.** `publish_github` is not idempotent — `gh release create` fails outright when the release already exists — so an automatic resume would break at one of the *likeliest* ways to reach this state (release-create failing after the pushes succeeded). Making it idempotent is a larger change than this bug warrants; refusing solves the actual problem with no new failure modes.

## Failing toward the safe side

This check runs on **every** release, while the state it catches is rare and has never bitten. So a false positive (blocking a healthy release) is strictly worse than a false negative (restoring today's behaviour). Every branch fails toward "proceed with the normal release."

The load-bearing case is the fetch:

> Immediately after a **successful** release, the HEAD subject and `VERSION` are *identical* to the unpublished case. The ancestry test is the only thing distinguishing them.

So a failed fetch returns "not detected" rather than testing ancestry against a stale `origin/<branch>` — stale data could otherwise refuse a perfectly healthy release. A missing `origin/<branch>` ref is treated the same way.

## Verification

Against a **bare origin** so nothing escaped, covering every state:

| State | Expected | Result |
|---|---|---|
| Healthy tree | proceeds to version prompt | ✅ |
| Unpublished release commit | refuses, `VERSION` unchanged | ✅ |
| After pushing commit + tag | refusal clears, proceeds | ✅ |
| Broken remote (fetch fails) | no false positive | ✅ |
| `--dry-run` on unpublished | refuses | ✅ |

The third row matters most — it proves the check doesn't get stuck, and that the ancestry test correctly separates published from unpublished when nothing else can.

## Not included

lvt's `scripts/release.sh` shares this structure and presumably the gap. Left for a follow-up rather than folded in unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG