### PR TITLE
refactor(parse): hand recursion defines back from FlattenTemplate (closes #496)

### DIFF
--- a/docs/proposals/recursive-templates-proposal.md
+++ b/docs/proposals/recursive-templates-proposal.md
@@ -436,10 +436,15 @@ Three categories, each a hard gate — no phase merges with a category left as "
         them for full HTML documents — leaving the recursion registry empty at serve time, so the whole
         template silently degraded to HTML-string diffing (none of the reactive tree / per-leaf path
         ran). `ExtractTemplateBodyContent` now re-attaches trailing `{{define}}` blocks; pinned by
-        `TestRecursiveTemplate_FullDocument_Reactive`.
-      - [ ] **Release-gated docs:** flip the `template-support-matrix.md` "Recursive / circular template
-        references" row from ❌ to ✅, update `current-limitations.md`, add a recipe. Matrix reflects
-        *released* behavior, so this lands with the release, not before.
+        `TestRecursiveTemplate_FullDocument_Reactive`. **Superseded by #496:** that re-attachment was a
+        `strings.Index("{{define")` rescan inside a pure HTML slicer, so `FlattenTemplate` now returns
+        `(document, defines)` and the caller re-attaches. The guarantee is unchanged; only where it
+        lives moved.
+      - [x] **Release-gated docs:** landed with v0.19.0/v0.19.1 — `template-support-matrix.md`'s
+        "Recursive / circular template references" row is ✅ with a **Recursion depth** section,
+        `CONFIGURATION.md` documents `LVT_MAX_TEMPLATE_DEPTH` (#498), and the `file-tree` recipe ships
+        in the docs site (livetemplate/docs#114). `current-limitations.md` needed no change — it never
+        claimed recursion was unsupported.
 
 ### Companion migrations (dependent repos — land per the lockstep convention once a release ships)
 

--- a/internal/build/wrapper.go
+++ b/internal/build/wrapper.go
@@ -193,40 +193,46 @@ func injectWrapperDivStringBased(htmlDoc string, wrapperID string, loadingDisabl
 // <body class="dark">). Uses html.Tokenizer (see locateBodyAndFirstScript)
 // to avoid being fooled by '<body' substrings in head content.
 //
-// It also re-attaches any trailing {{define}} blocks that FlattenTemplate appends
-// AFTER the document (past </body></html>) for recursive {{template}} support: the
-// body's {{template}} calls reference those defines, and the extracted content is
-// parsed on its own for reactive tree generation, so dropping them would leave the
-// recursion registry empty and silently degrade recursive templates to HTML-string
-// diffing.
+// This is purely a slice between the body tags and knows nothing about what
+// produced the template. Recursive {{template}} support needs FlattenTemplate's
+// {{define}} blocks, which sit after </html> and so fall outside this slice —
+// the caller appends them, having received them from FlattenTemplate directly.
+// This function used to rescan for them, which quietly made an HTML slicer
+// depend on FlattenTemplate's output layout (issue #496).
 func ExtractTemplateBodyContent(templateStr string) string {
+	body, _ := ExtractTemplateBodyContentSliced(templateStr)
+	return body
+}
+
+// ExtractTemplateBodyContentSliced is ExtractTemplateBodyContent plus whether a
+// <body>…</body> region was actually sliced out — meaning anything after the
+// body close was dropped from the result.
+//
+// Callers holding template source that belongs after the document need this to
+// know whether to re-attach it. FlattenTemplate's recursion {{define}} blocks
+// are the case in point: they sit past </html>, so a real slice drops them and
+// they must be appended back, while the paths that return the input unchanged
+// still contain them and must not have them appended twice.
+//
+// Reporting the fact is the point — a caller inferring it by comparing strings
+// or rescanning for "{{define" is how this function ended up encoding
+// FlattenTemplate's output layout in the first place (issue #496).
+func ExtractTemplateBodyContentSliced(templateStr string) (body string, sliced bool) {
 	bodyOpenStart, bodyOpenEnd, bodyCloseStart, _ := locateBodyAndFirstScript(templateStr)
 	if bodyOpenStart < 0 {
-		return templateStr
+		return templateStr, false
 	}
 	// bodyCloseStart < 0 covers "no </body> at all".
 	// bodyOpenEnd > bodyCloseStart covers pathological input like
 	// "</body><body>x" where the only </body> precedes the body open
 	// tag — slicing [open:close] would panic. Treat both as "no usable
-	// close" and fall through to TrimSpace from body open onward.
+	// close" and fall through to TrimSpace from body open onward. That keeps
+	// everything from the body open to the end, tail included, so nothing was
+	// dropped and sliced stays false.
 	if bodyCloseStart < 0 || bodyOpenEnd > bodyCloseStart {
-		return strings.TrimSpace(templateStr[bodyOpenEnd:])
+		return strings.TrimSpace(templateStr[bodyOpenEnd:]), false
 	}
-	body := strings.TrimSpace(templateStr[bodyOpenEnd:bodyCloseStart])
-	return body + trailingDefineBlocks(templateStr[bodyCloseStart:])
-}
-
-// trailingDefineBlocks returns the {{define}} blocks (from the first {{define
-// onward) found in the content after the body close, or "" if there are none.
-// FlattenTemplate appends recursion cycle members there; Go templates collect
-// {{define}} regardless of position, so appending them to the body content keeps
-// the extracted template self-contained.
-func trailingDefineBlocks(afterBody string) string {
-	idx := strings.Index(afterBody, "{{define")
-	if idx < 0 {
-		return ""
-	}
-	return strings.TrimRight(afterBody[idx:], " \t\r\n")
+	return strings.TrimSpace(templateStr[bodyOpenEnd:bodyCloseStart]), true
 }
 
 // ExtractTemplateContent extracts template content using wrapper ID with proper HTML parsing.

--- a/internal/build/wrapper_test.go
+++ b/internal/build/wrapper_test.go
@@ -362,47 +362,55 @@ func TestNormalizeTemplateSpacing(t *testing.T) {
 }
 
 // TestExtractTemplateBodyContent_WithAttributes tests body tags with attributes.
-// TestExtractTemplateBodyContent_TrailingDefines pins the recursion-registry
-// re-attachment: FlattenTemplate appends the recursive {{define}} cycle members
-// AFTER </body></html>, and body extraction must carry them along or a full-doc
-// recursive template silently degrades to HTML-structure diffing.
-func TestExtractTemplateBodyContent_TrailingDefines(t *testing.T) {
+// TestExtractTemplateBodyContentSliced pins the pure-slicer contract and the
+// sliced flag. Extraction no longer knows anything about recursion {{define}}
+// blocks — it reports whether a <body> region was cut out, and the caller uses
+// that to decide whether the tail it owns needs re-attaching (issue #496).
+// The re-attachment itself is pinned a layer up by
+// TestRecursiveTemplate_BodyContentCarriesDefines.
+func TestExtractTemplateBodyContentSliced(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name       string
+		input      string
+		expected   string
+		wantSliced bool
 	}{
 		{
-			"full doc, no trailing define",
+			"full doc slices the body and reports it",
 			`<html><body><ul><li>x</li></ul></body></html>`,
 			`<ul><li>x</li></ul>`,
+			true,
 		},
 		{
-			"full doc, one trailing define re-attached",
+			"content after </html> is dropped, not rescued",
 			`<html><body><ul>{{template "n" .}}</ul></body></html>{{define "n"}}<li>{{.}}</li>{{end}}`,
-			`<ul>{{template "n" .}}</ul>{{define "n"}}<li>{{.}}</li>{{end}}`,
-		},
-		{
-			"full doc, multiple trailing defines re-attached",
-			`<html><body><ul>{{template "a" .}}</ul></body></html>{{define "a"}}A{{end}}{{define "b"}}B{{end}}`,
-			`<ul>{{template "a" .}}</ul>{{define "a"}}A{{end}}{{define "b"}}B{{end}}`,
-		},
-		{
-			"trailing whitespace before/after the define is trimmed to the block",
-			"<html><body>X</body></html>\n{{define \"a\"}}A{{end}}\n",
-			`X{{define "a"}}A{{end}}`,
+			`<ul>{{template "n" .}}</ul>`,
+			true,
 		},
 		{
 			"fragment (no body) returned as-is, defines and all",
 			`{{define "n"}}<li>{{.}}</li>{{end}}<ul>{{template "n" .}}</ul>`,
 			`{{define "n"}}<li>{{.}}</li>{{end}}<ul>{{template "n" .}}</ul>`,
+			false,
+		},
+		{
+			// Nothing was cut, so the caller must not append a tail the result
+			// already contains.
+			"no </body> keeps everything from the body open onward",
+			`<html><body>X{{define "a"}}A{{end}}`,
+			`X{{define "a"}}A{{end}}`,
+			false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if result := ExtractTemplateBodyContent(tt.input); result != tt.expected {
-				t.Errorf("Expected %q, got: %q", tt.expected, result)
+			result, sliced := ExtractTemplateBodyContentSliced(tt.input)
+			if result != tt.expected {
+				t.Errorf("body: expected %q, got %q", tt.expected, result)
+			}
+			if sliced != tt.wantSliced {
+				t.Errorf("sliced: expected %v, got %v", tt.wantSliced, sliced)
 			}
 		})
 	}

--- a/internal/compat/tree.go
+++ b/internal/compat/tree.go
@@ -27,6 +27,11 @@ func ExtractTemplateBodyContent(templateStr string) string {
 	return build.ExtractTemplateBodyContent(templateStr)
 }
 
+// ExtractTemplateBodyContentSliced wraps internal/build.ExtractTemplateBodyContentSliced.
+func ExtractTemplateBodyContentSliced(templateStr string) (body string, sliced bool) {
+	return build.ExtractTemplateBodyContentSliced(templateStr)
+}
+
 // extractTemplateContent wraps internal/build.ExtractTemplateContent for backward compatibility
 func ExtractTemplateContent(input string, wrapperID string) string {
 	return build.ExtractTemplateContent(input, wrapperID)

--- a/internal/parse/flatten.go
+++ b/internal/parse/flatten.go
@@ -15,10 +15,24 @@ import (
 // This allows tree generation to work with templates that use Go's template composition features.
 //
 // The function:
-// 1. Identifies the main executable template (entry point)
-// 2. Walks the AST and inlines all {{template}} invocations
-// 3. Returns a single flattened template string
-func FlattenTemplate(tmpl *template.Template) (string, error) {
+//  1. Identifies the main executable template (entry point)
+//  2. Walks the AST and inlines all {{template}} invocations
+//  3. Returns the flattened document, plus any recursion {{define}} blocks separately
+//
+// The two returns are deliberately not concatenated here. Templates on an
+// invocation cycle cannot be inlined, so their bodies are re-emitted as
+// {{define}} blocks for the build-time registry to pick up. Callers need those
+// blocks in two different places — appended to the document for html/template,
+// and appended to the extracted <body> content for the reactive parse — and
+// handing them back separately lets each caller assemble what it needs. The
+// alternative, concatenating them onto the document and having the body
+// extractor scan them back out, made a pure HTML slicer encode this function's
+// private output layout: appending anything after them would silently sweep it
+// into the template and degrade recursion with no error (issue #496).
+//
+// defines is "" when nothing recursive was found, which is every
+// non-recursive template.
+func FlattenTemplate(tmpl *template.Template) (document string, defines string, err error) {
 	// The main template is the one that was explicitly named when calling New()
 	// This is the entry point for execution
 	mainTemplate := tmpl
@@ -55,7 +69,7 @@ func FlattenTemplate(tmpl *template.Template) (string, error) {
 	}
 
 	if mainTemplate.Tree == nil || mainTemplate.Tree.Root == nil {
-		return "", fmt.Errorf("template has no parse tree")
+		return "", "", fmt.Errorf("template has no parse tree")
 	}
 
 	// Build map of all template definitions
@@ -79,29 +93,33 @@ func FlattenTemplate(tmpl *template.Template) (string, error) {
 	// instead of overflowing the stack.
 	var buf bytes.Buffer
 	if err := walkAndFlatten(mainTemplate.Tree.Root, templates, &buf, []string{mainTemplate.Name()}, recursive); err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	// Append each recursive template's flattened body as a {{define}} block. On
-	// re-parse these become associated templates that parse.Parse collects into
-	// the recursion registry; at build time invokeTemplate walks them per call.
-	// Bodies are flattened with the same recursive set, so their own recursive
-	// calls stay verbatim while any non-recursive {{template}} calls inline.
+	// Emit each recursive template's flattened body as a {{define}} block, into a
+	// buffer of its own. On re-parse these become associated templates that
+	// parse.Parse collects into the recursion registry; at build time
+	// invokeTemplate walks them per call. Bodies are flattened with the same
+	// recursive set, so their own recursive calls stay verbatim while any
+	// non-recursive {{template}} calls inline.
 	// Sorted for deterministic output (stable fingerprints and caching).
 	// detectRecursiveTemplates only records names whose templates have a non-nil
 	// Tree/Root, so templates[name] is safe to dereference here.
+	var defBuf bytes.Buffer
 	for _, name := range slices.Sorted(maps.Keys(recursive)) {
 		body := templates[name].Tree.Root
-		buf.WriteString("{{define ")
-		buf.WriteString(strconv.Quote(name))
-		buf.WriteString("}}")
-		if err := walkAndFlatten(body, templates, &buf, []string{name}, recursive); err != nil {
-			return "", err
+		defBuf.WriteString("{{define ")
+		defBuf.WriteString(strconv.Quote(name))
+		defBuf.WriteString("}}")
+		if err := walkAndFlatten(body, templates, &defBuf, []string{name}, recursive); err != nil {
+			return "", "", err
 		}
-		buf.WriteString("{{end}}")
+		defBuf.WriteString("{{end}}")
 	}
 
-	return buf.String(), nil
+	// document + defines reproduces exactly what this function used to return as
+	// a single string; callers that need both simply concatenate.
+	return buf.String(), defBuf.String(), nil
 }
 
 // detectRecursiveTemplates returns the set of template names that participate in

--- a/internal/parse/flatten_cycle_test.go
+++ b/internal/parse/flatten_cycle_test.go
@@ -32,9 +32,14 @@ func TestFlattenTemplate_Diamond(t *testing.T) {
 		`{{define "page"}}{{template "row" .}}{{template "leaf" .C}}{{end}}` +
 		`{{template "page" .}}`
 
-	out, err := FlattenTemplate(mustParse(t, src))
+	out, defines, err := FlattenTemplate(mustParse(t, src))
 	if err != nil {
 		t.Fatalf("diamond composition must flatten without error, got: %v", err)
+	}
+	// A diamond is acyclic, so nothing is left un-inlined and no registry
+	// {{define}} blocks are emitted.
+	if defines != "" {
+		t.Errorf("acyclic composition must emit no recursion defines, got:\n%s", defines)
 	}
 	// leaf's statics appear once per invocation (3×): proves each was inlined.
 	if got := strings.Count(out, "<span>"); got != 3 {
@@ -83,24 +88,37 @@ func TestFlattenTemplate_RecursionEmittedForRuntime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := FlattenTemplate(mustParse(t, tt.src))
+			out, defines, err := FlattenTemplate(mustParse(t, tt.src))
 			if err != nil {
 				t.Fatalf("recursive template must flatten for runtime invocation, got: %v", err)
 			}
+			// "Left un-inlined" is a property of the flattened result as a whole,
+			// so assert against the assembly. Under mutual recursion the call to
+			// "b" lives inside {{define "a"}} — i.e. in defines, not the
+			// document — and pinning it to either half alone would encode which
+			// cycle member happens to be the entry point.
+			assembled := out + defines
 			for _, want := range tt.wantVerbatim {
-				if !strings.Contains(out, want) {
-					t.Errorf("expected verbatim invocation %q (recursion left un-inlined) in:\n%s", want, out)
+				if !strings.Contains(assembled, want) {
+					t.Errorf("expected verbatim invocation %q (recursion left un-inlined) in:\n%s", want, assembled)
 				}
 			}
+			// Registry blocks belong to the SECOND return, not the document —
+			// asserting against defines is what keeps the split honest. Checking
+			// out+defines instead would still pass if the two were re-merged.
 			for _, want := range tt.wantDefines {
-				if !strings.Contains(out, want) {
-					t.Errorf("expected registry define %q appended in:\n%s", want, out)
+				if !strings.Contains(defines, want) {
+					t.Errorf("expected registry define %q in the defines return, got:\n%s", want, defines)
+				}
+				if strings.Contains(out, want) {
+					t.Errorf("registry define %q leaked into the document return:\n%s", want, out)
 				}
 			}
-			// The flattened string must re-parse (it feeds parse.Parse), which
-			// also confirms the appended defines are well-formed.
-			if _, err := template.New("verify").Parse(out); err != nil {
-				t.Errorf("flattened output must re-parse, got: %v\n%s", err, out)
+			// The assembled string must re-parse (callers concatenate the two and
+			// feed that to parse.Parse), which also confirms the defines are
+			// well-formed and that concatenation is a valid template.
+			if _, err := template.New("verify").Parse(out + defines); err != nil {
+				t.Errorf("document+defines must re-parse, got: %v\n%s", err, out+defines)
 			}
 		})
 	}
@@ -143,9 +161,12 @@ func TestFlattenTemplate_NonRecursiveUnaffected(t *testing.T) {
 		`{{define "footer"}}<footer>{{.Year}}</footer>{{end}}` +
 		`{{template "header" .}}<main>{{.Body}}</main>{{template "footer" .}}`
 
-	out, err := FlattenTemplate(mustParse(t, src))
+	out, defines, err := FlattenTemplate(mustParse(t, src))
 	if err != nil {
 		t.Fatalf("non-recursive composition must flatten cleanly, got: %v", err)
+	}
+	if defines != "" {
+		t.Errorf("non-recursive composition must emit no recursion defines, got:\n%s", defines)
 	}
 	for _, want := range []string{"<h1>", "<main>", "<footer>"} {
 		if !strings.Contains(out, want) {

--- a/internal/parse/flatten_fuzz_test.go
+++ b/internal/parse/flatten_fuzz_test.go
@@ -40,6 +40,6 @@ func FuzzFlattenTemplate(f *testing.F) {
 		}
 		// The contract under test: returns, never panics/overflows. The result
 		// (string or error) is deliberately unused — the guard is what matters.
-		_, _ = FlattenTemplate(tmpl)
+		_, _, _ = FlattenTemplate(tmpl)
 	})
 }

--- a/recursion_defines_handoff_test.go
+++ b/recursion_defines_handoff_test.go
@@ -1,0 +1,100 @@
+package livetemplate
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRecursiveTemplate_BodyContentCarriesDefines is the rehomed half of the
+// guarantee that used to live in internal/build's TrailingDefines test.
+//
+// Body extraction is now a pure <body>…</body> slice, so the recursion
+// {{define}} blocks — which FlattenTemplate emits for cycle members and which
+// sit past </html> — are re-attached by the caller from FlattenTemplate's second
+// return rather than rescanned out of the template string (issue #496). The
+// behaviour being pinned is unchanged: the content handed to the reactive parse
+// must carry them, or a full-document recursive template silently degrades to
+// HTML-string diffing.
+func TestRecursiveTemplate_BodyContentCarriesDefines(t *testing.T) {
+	const fullDoc = `<!DOCTYPE html><html><head><title>T</title></head><body>` +
+		`{{define "node"}}<li data-key="{{.Path}}">{{.Name}}` +
+		`{{if .IsDir}}<ul>{{range .Children}}{{template "node" .}}{{end}}</ul>{{end}}</li>{{end}}` +
+		`<ul>{{template "node" .Root}}</ul></body></html>`
+
+	tmpl, err := Must(New("handoff")).Parse(fullDoc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	tmpl.mu.Lock()
+	body := tmpl.getOrComputeBodyContent()
+	tmpl.mu.Unlock()
+
+	if !strings.Contains(body, `{{define "node"}}`) {
+		t.Errorf("body content dropped the recursion define; the reactive parse would see an empty registry:\n%s", body)
+	}
+	// Exactly once — the block lives in templateStr's tail as well, so appending
+	// it unconditionally rather than only when a body was sliced would duplicate
+	// every definition.
+	if got := strings.Count(body, `{{define "node"}}`); got != 1 {
+		t.Errorf("expected the recursion define exactly once, got %d:\n%s", got, body)
+	}
+	// The <body> region itself must still be sliced — this is body content, not
+	// the whole document.
+	if strings.Contains(body, "<title>") {
+		t.Errorf("body content leaked <head> content:\n%s", body)
+	}
+}
+
+// TestRecursiveTemplate_CloneCarriesDefines guards the specific way this
+// refactor could regress invisibly. recursionDefines is a parse-time field, and
+// Clone copies fields by explicit enumeration rather than struct assignment — so
+// a clone that lost it would recompute body content without the defines and
+// silently fall back to HTML-string diffing. Production renders through
+// per-session clones, never the master, so a master-only assertion would not
+// catch it.
+func TestRecursiveTemplate_CloneCarriesDefines(t *testing.T) {
+	const fullDoc = `<!DOCTYPE html><html><body>` +
+		`{{define "node"}}<li data-key="{{.Path}}">{{.Name}}` +
+		`{{if .IsDir}}<ul>{{range .Children}}{{template "node" .}}{{end}}</ul>{{end}}</li>{{end}}` +
+		`<ul>{{template "node" .Root}}</ul></body></html>`
+
+	master, err := Must(New("handoff-clone")).Parse(fullDoc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	clone, err := master.Clone()
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	if clone.recursionDefines != master.recursionDefines {
+		t.Fatalf("Clone dropped recursionDefines:\nmaster: %q\nclone:  %q",
+			master.recursionDefines, clone.recursionDefines)
+	}
+
+	// Force the clone to recompute from scratch rather than inherit the cached
+	// string, which is the path that actually depends on the field.
+	clone.mu.Lock()
+	clone.cachedBodyContent = ""
+	clone.cachedBodyContentValid = false
+	body := clone.getOrComputeBodyContent()
+	clone.mu.Unlock()
+
+	if !strings.Contains(body, `{{define "node"}}`) {
+		t.Errorf("clone recomputed body content without the recursion define:\n%s", body)
+	}
+
+	// End to end: the clone must take the reactive AST path, not the fallback.
+	data := struct{ Root fileNode }{Root: fileNode{
+		Name: "root", Path: "/", IsDir: true,
+		Children: []fileNode{{Name: "a.go", Path: "/a.go"}},
+	}}
+	if _, err := clone.buildTree(data, nil); err != nil {
+		t.Fatalf("clone first render: %v", err)
+	}
+	if !clone.hasInitialTree {
+		t.Fatal("clone fell back to HTML-structure diffing — the recursion registry was empty")
+	}
+}

--- a/template.go
+++ b/template.go
@@ -241,7 +241,7 @@ type Template struct {
 	config                 Config              // Template configuration
 	uploadRegistry         interface{}         // Upload registry for this connection (*upload.Registry)
 	cachedParseTemplate    *parse.Template     // Cached AST to avoid re-parsing on every render
-	cachedBodyContent      string              // Cached result of ExtractTemplateBodyContent(t.templateStr)
+	cachedBodyContent      string              // Cached body content for the reactive parse: the <body> slice of templateStr, plus recursionDefines when a body region was actually sliced out (see getOrComputeBodyContent)
 	cachedBodyContentValid bool                // Whether cachedBodyContent has been computed (empty string is valid)
 	recursionDefines       string              // FlattenTemplate's {{define}} blocks for templates on an invocation cycle. They sit past </html> in templateStr, so extracting the body drops them; the reactive parse needs them to populate the recursion registry. Held here rather than rescanned out of templateStr (issue #496). Empty for every non-recursive template. MUST be copied in Clone — production renders through per-session clones, so a clone that loses it silently degrades recursion to HTML-string diffing.
 	formSchema             *FormSchema         // Cached schema extracted from templateStr; nil if no rules

--- a/template.go
+++ b/template.go
@@ -243,6 +243,7 @@ type Template struct {
 	cachedParseTemplate    *parse.Template     // Cached AST to avoid re-parsing on every render
 	cachedBodyContent      string              // Cached result of ExtractTemplateBodyContent(t.templateStr)
 	cachedBodyContentValid bool                // Whether cachedBodyContent has been computed (empty string is valid)
+	recursionDefines       string              // FlattenTemplate's {{define}} blocks for templates on an invocation cycle. They sit past </html> in templateStr, so extracting the body drops them; the reactive parse needs them to populate the recursion registry. Held here rather than rescanned out of templateStr (issue #496). Empty for every non-recursive template. MUST be copied in Clone — production renders through per-session clones, so a clone that loses it silently degrades recursion to HTML-string diffing.
 	formSchema             *FormSchema         // Cached schema extracted from templateStr; nil if no rules
 	wiredActions           map[string]struct{} // Cached set of client-wired action names (form/button name=, lvt-on:) extracted from templateStr; immutable after parse; drives the Publish symmetry-collision warning
 	wiredCollisionWarned   *sync.Map           // action -> struct{}: dedups the Publish symmetry-collision slog.Warn to once per action name; shared by pointer across per-session clones so the warning is app-global, not per-connection
@@ -1126,6 +1127,7 @@ func (t *Template) Clone() (*Template, error) {
 	cachedParse := t.cachedParseTemplate
 	bodyContent := t.cachedBodyContent
 	bodyContentValid := t.cachedBodyContentValid
+	recursionDefines := t.recursionDefines
 	formSchema := t.formSchema
 	wiredActions := t.wiredActions
 	wiredCollisionWarned := t.wiredCollisionWarned
@@ -1146,10 +1148,15 @@ func (t *Template) Clone() (*Template, error) {
 		cachedParseTemplate:    cachedParse, // Share parsed AST + builtins
 		cachedBodyContent:      bodyContent, // Share extracted body content
 		cachedBodyContentValid: bodyContentValid,
-		formSchema:             formSchema,           // Share extracted form schema (immutable)
-		wiredActions:           wiredActions,         // Share extracted wired-action set (immutable)
-		wiredCollisionWarned:   wiredCollisionWarned, // Share dedup store by pointer (app-global once-per-action warn)
-		precomputeAllow:        precomputeAllow,      // Share referenced-identifier set (immutable after parse)
+		// Without this the clone recomputes body content with no recursion
+		// defines, silently degrading recursive templates to HTML-string
+		// diffing — and production renders through clones, so a master-only
+		// test would not notice.
+		recursionDefines:     recursionDefines,
+		formSchema:           formSchema,           // Share extracted form schema (immutable)
+		wiredActions:         wiredActions,         // Share extracted wired-action set (immutable)
+		wiredCollisionWarned: wiredCollisionWarned, // Share dedup store by pointer (app-global once-per-action warn)
+		precomputeAllow:      precomputeAllow,      // Share referenced-identifier set (immutable after parse)
 		// Don't copy lastData, lastHTML, lastTree, etc. - start fresh per session
 	}
 
@@ -1205,17 +1212,26 @@ func (t *Template) Parse(text string) (*Template, error) {
 // parseInternal handles the common logic for parsing templates:
 // flattening, wrapper injection, final parsing, and validation.
 func (t *Template) parseInternal(text string, baseTemplate *template.Template) (*Template, error) {
+	// recursionDefines holds the {{define}} blocks FlattenTemplate emits for
+	// templates on an invocation cycle, which cannot be inlined. They are needed
+	// in two places — appended to the document below so html/template can resolve
+	// the recursive calls, and appended to the extracted <body> content so the
+	// reactive parse populates the recursion registry — so keep them addressable
+	// rather than re-deriving them from the assembled string later (issue #496).
+	var recursionDefines string
+
 	// Check if template uses composition features and flatten if needed
 	if parse.HasTemplateComposition(baseTemplate) {
 		// Flatten the template to resolve all {{define}}/{{template}}/{{block}}
-		flattenedStr, err := parse.FlattenTemplate(baseTemplate)
+		flattenedStr, defines, err := parse.FlattenTemplate(baseTemplate)
 		if err != nil {
 			return nil, fmt.Errorf("template flattening failed: %w", err)
 		}
 
 		// Store flattened version for tree generation (WITHOUT wrapper)
 		// This ensures updates use the flattened template
-		text = flattenedStr
+		text = flattenedStr + defines
+		recursionDefines = defines
 	}
 
 	// Determine if this is a full HTML document. Computed here (after any
@@ -1265,8 +1281,10 @@ func (t *Template) parseInternal(text string, baseTemplate *template.Template) (
 	t.templateStr = text
 	t.tmpl = tmpl
 	t.cachedParseTemplate = nil // Invalidate cached AST when template source changes
-	t.cachedBodyContent = ""    // Invalidate cached body content
+
+	t.cachedBodyContent = "" // Invalidate cached body content
 	t.cachedBodyContentValid = false
+	t.recursionDefines = recursionDefines
 	t.formSchema = extractFormSchemaFromTemplateStr(text)
 	t.precomputeAllow = parse.CollectReferencedIdentsFromTemplate(tmpl)
 	t.wiredActions = extractWiredActionNames(text)
@@ -1588,7 +1606,16 @@ func (t *Template) ExecuteUpdates(wr io.Writer, data interface{}, messages ...ma
 func (t *Template) getOrComputeBodyContent() string {
 	if !t.cachedBodyContentValid {
 		if t.wrapperID != "" {
-			t.cachedBodyContent = compat.ExtractTemplateBodyContent(t.templateStr)
+			// Re-attach the recursion {{define}} blocks only when a body region
+			// was actually sliced out, because that is exactly when the tail
+			// they live in got dropped. templateStr still ends with them, so the
+			// paths returning it unchanged (a fragment has no <body>) would
+			// otherwise carry every block twice.
+			body, sliced := compat.ExtractTemplateBodyContentSliced(t.templateStr)
+			if sliced {
+				body += t.recursionDefines
+			}
+			t.cachedBodyContent = body
 		} else {
 			t.cachedBodyContent = t.templateStr
 		}

--- a/template_test.go
+++ b/template_test.go
@@ -1181,9 +1181,16 @@ func TestFlattenTemplate_Simple(t *testing.T) {
 		t.Fatalf("Failed to parse template: %v", err)
 	}
 
-	flattened, err := parse.FlattenTemplate(tmpl)
+	flattened, defines, err := parse.FlattenTemplate(tmpl)
 	if err != nil {
 		t.Fatalf("Failed to flatten template: %v", err)
+	}
+
+	// This composition is acyclic, so everything inlines and no recursion
+	// registry blocks are emitted — the assertion below that the document holds
+	// no {{define}} would otherwise be satisfiable by them merely moving.
+	if defines != "" {
+		t.Errorf("acyclic composition must emit no recursion defines, got: %s", defines)
 	}
 
 	// Should contain the h1 with title
@@ -1225,7 +1232,7 @@ func TestFlattenTemplate_WithLayout(t *testing.T) {
 		t.Fatalf("Failed to parse template: %v", err)
 	}
 
-	flattened, err := parse.FlattenTemplate(tmpl)
+	flattened, _, err := parse.FlattenTemplate(tmpl)
 	if err != nil {
 		t.Fatalf("Failed to flatten template: %v", err)
 	}
@@ -1263,7 +1270,7 @@ func TestFlattenTemplate_NestedTemplates(t *testing.T) {
 		t.Fatalf("Failed to parse template: %v", err)
 	}
 
-	flattened, err := parse.FlattenTemplate(tmpl)
+	flattened, _, err := parse.FlattenTemplate(tmpl)
 	if err != nil {
 		t.Fatalf("Failed to flatten template: %v", err)
 	}
@@ -1296,7 +1303,7 @@ func TestFlattenTemplate_WithConditionals(t *testing.T) {
 		t.Fatalf("Failed to parse template: %v", err)
 	}
 
-	flattened, err := parse.FlattenTemplate(tmpl)
+	flattened, _, err := parse.FlattenTemplate(tmpl)
 	if err != nil {
 		t.Fatalf("Failed to flatten template: %v", err)
 	}
@@ -1332,7 +1339,7 @@ func TestFlattenTemplate_WithRange(t *testing.T) {
 		t.Fatalf("Failed to parse template: %v", err)
 	}
 
-	flattened, err := parse.FlattenTemplate(tmpl)
+	flattened, _, err := parse.FlattenTemplate(tmpl)
 	if err != nil {
 		t.Fatalf("Failed to flatten template: %v", err)
 	}
@@ -1425,7 +1432,7 @@ func TestFlattenTemplate_IntegrationWithTreeGeneration(t *testing.T) {
 		t.Fatalf("Failed to parse template: %v", err)
 	}
 
-	flattened, err := parse.FlattenTemplate(tmpl)
+	flattened, _, err := parse.FlattenTemplate(tmpl)
 	if err != nil {
 		t.Fatalf("Failed to flatten template: %v", err)
 	}
@@ -1498,7 +1505,7 @@ func TestFlattenTemplate_ComponentPattern(t *testing.T) {
 		t.Fatalf("Failed to parse template: %v", err)
 	}
 
-	flattened, err := parse.FlattenTemplate(tmpl)
+	flattened, _, err := parse.FlattenTemplate(tmpl)
 	if err != nil {
 		t.Fatalf("Failed to flatten template: %v", err)
 	}
@@ -1566,7 +1573,7 @@ func TestFlattenTemplate_ErrorCases(t *testing.T) {
 				t.Fatalf("Failed to parse template: %v", err)
 			}
 
-			_, err = parse.FlattenTemplate(tmpl)
+			_, _, err = parse.FlattenTemplate(tmpl)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parse.FlattenTemplate() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
Closes #496.

`FlattenTemplate` emits `{{define}}` blocks for templates on an invocation cycle, which cannot be inlined. They were concatenated onto the flattened document, and `ExtractTemplateBodyContent` — a pure HTML body slicer — rescanned them back out:

```go
idx := strings.Index(afterBody, "{{define")
```

That made an HTML slicer encode `FlattenTemplate`'s private output layout. Appending anything after the defines — a trailing script, a diagnostic comment — would sweep it into the template and silently degrade recursion to HTML-string diffing, with no error anywhere.

## The change

**`FlattenTemplate` returns `(document, defines)`.** Callers assemble what they need: `document+defines` for `html/template`, body slice + defines for the reactive parse. The rescan is gone.

**Body extraction reports whether it sliced.** `ExtractTemplateBodyContentSliced` returns the body plus whether a `<body>` region was actually cut out — which is exactly when the tail gets dropped. The caller re-attaches only then.

That last part isn't defensive coding. `templateStr` still ends with the defines, so the paths returning it unchanged (a fragment has no `<body>`) would carry every block twice. **The first version of this change appended unconditionally and doubled every define on fragments** — caught by the byte-identity check below, not by any existing test.

## Byte identity as the acceptance bar

The issue notes this renders correctly today, so the refactor is only a win if it's *provably* behaviour-preserving. A temporary harness captured the two assembled strings — what `html/template` parses, and what the reactive parse consumes — across six shapes on `main` and on this branch:

| Shape | Result |
|---|---|
| full-document recursive | identical |
| fragment recursive | identical |
| mutual recursion | identical |
| non-recursive composition | identical |
| full-document, no composition | identical |
| fragment, no composition | identical |

Byte-for-byte, all six. The harness was deleted before commit.

## Why a field, not eager computation

An earlier version computed body content eagerly in `parseInternal` to avoid adding a field. That turned a lazily-computed, invalidatable cache into one that goes stale if `templateStr` is reassigned — which two existing tests do directly, and both broke. Keeping it lazy preserves the invalidation semantics exactly, and both tests pass **unchanged**.

`recursionDefines` is therefore a `Template` field. `Clone` copies fields by explicit enumeration rather than struct assignment, so a dropped field would silently degrade recursion — and since production renders through per-session clones, a master-only assertion would never notice. `TestRecursiveTemplate_CloneCarriesDefines` guards it, **verified to fail** when that `Clone` line is removed:

```
--- FAIL: TestRecursiveTemplate_CloneCarriesDefines
    Clone dropped recursionDefines:
```

## Coverage moved, not deleted

- `internal/build` now pins the pure-slicer contract and the `sliced` flag, including that content after `</html>` is dropped rather than rescued
- `TestRecursiveTemplate_BodyContentCarriesDefines` pins re-attachment a layer up, asserting the define appears **exactly once**
- The flatten cycle tests now assert registry blocks land in the `defines` return **and do not leak into the document** — a stronger claim than the previous substring check against the concatenation, which would still pass if the two were re-merged

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG