### PR TITLE
refactor(parse): tag wrappers instead of inferring them from shape (closes #497)

### DIFF
--- a/internal/build/types.go
+++ b/internal/build/types.go
@@ -29,12 +29,6 @@ func PositionKey(index int) string {
 	return strconv.Itoa(index)
 }
 
-// TreeNode represents a node in the template tree structure with type safety.
-// It replaces the old map[string]interface{} representation while maintaining
-// wire format compatibility through custom JSON marshaling.
-//
-// TreeNode should not be value-copied after first use of GetStructureFingerprint,
-// as it contains an atomic.Value for fingerprint caching. Always use *TreeNode.
 // WrapperKind identifies a node the parser created purely to give a child tree
 // its own dynamic slot. The kinds are structurally identical — telling them
 // apart, or telling them from an ordinary field node, is only possible because
@@ -61,6 +55,12 @@ const (
 // because we put it there" should use this rather than testing a specific kind.
 func (k WrapperKind) IsWrapper() bool { return k != WrapperNone }
 
+// TreeNode represents a node in the template tree structure with type safety.
+// It replaces the old map[string]interface{} representation while maintaining
+// wire format compatibility through custom JSON marshaling.
+//
+// TreeNode should not be value-copied after first use of GetStructureFingerprint,
+// as it contains an atomic.Value for fingerprint caching. Always use *TreeNode.
 type TreeNode struct {
 	// Statics are the static HTML parts of the template (key: "s")
 	Statics []string
@@ -736,6 +736,11 @@ func (tn *TreeNode) Clone() *TreeNode {
 		Fingerprint:  tn.Fingerprint,
 		AutoKey:      tn.AutoKey,
 		dynamicCount: tn.dynamicCount,
+		// Carried deliberately: Clone builds from named fields, so a new field
+		// is dropped unless listed. Losing the kind would make a cloned wrapper
+		// indistinguishable from an ordinary node again — the precise failure
+		// this tag exists to prevent (issue #497).
+		Wrapper: tn.Wrapper,
 	}
 
 	// Clone statics

--- a/internal/build/types.go
+++ b/internal/build/types.go
@@ -35,6 +35,32 @@ func PositionKey(index int) string {
 //
 // TreeNode should not be value-copied after first use of GetStructureFingerprint,
 // as it contains an atomic.Value for fingerprint caching. Always use *TreeNode.
+// WrapperKind identifies a node the parser created purely to give a child tree
+// its own dynamic slot. The kinds are structurally identical — telling them
+// apart, or telling them from an ordinary field node, is only possible because
+// the constructor records which one it made.
+type WrapperKind uint8
+
+const (
+	// WrapperNone is the zero value: not a parser-created wrapper. Every node
+	// built anywhere else keeps it, so the marker cannot be acquired by accident.
+	WrapperNone WrapperKind = iota
+
+	// WrapperConditional wraps an {{if}}/{{with}} branch to keep the branch
+	// structure stable for diffing.
+	WrapperConditional
+
+	// WrapperInvocation wraps a {{template}} invocation body. A recursive
+	// subtree's depth varies with the data, so it occupies one slot to keep
+	// those changes from restructuring the parent's statics.
+	WrapperInvocation
+)
+
+// IsWrapper reports whether the parser created this node as a wrapper, of any
+// kind. Consumers that only care "is there a child tree hidden one level down
+// because we put it there" should use this rather than testing a specific kind.
+func (k WrapperKind) IsWrapper() bool { return k != WrapperNone }
+
 type TreeNode struct {
 	// Statics are the static HTML parts of the template (key: "s")
 	Statics []string
@@ -56,6 +82,19 @@ type TreeNode struct {
 
 	// Metadata contains additional information like ID key mappings (key: "m")
 	Metadata *TreeMetadata
+
+	// Wrapper records that the parser created this node as a single-dynamic-slot
+	// wrapper around a child tree, and which construct asked for it. Wrappers are
+	// structurally indistinguishable from each other and from a plain field node
+	// — all carry `["", ""]` statics and one nested child — so consumers that
+	// need to know "the parser wrapped this" must be told, not left to infer it
+	// from shape (issue #497).
+	//
+	// Internal only: MarshalJSON and ToMap build the wire map by naming the
+	// fields they emit, and the structure fingerprint hashes statics and dynamic
+	// shape, so this reaches neither. Two nodes differing only in Wrapper render
+	// identically and share a fingerprint, which is correct.
+	Wrapper WrapperKind
 
 	// dynamicCount tracks the number of non-nil entries in Dynamics for fast HasDynamics.
 	dynamicCount int

--- a/internal/build/types_test.go
+++ b/internal/build/types_test.go
@@ -756,3 +756,28 @@ func TestTreeNode_ToMap_EmitsEmptyD_LegacyEmptyMode(t *testing.T) {
 		t.Errorf("Legacy-empty ToMap 'd' should be empty slice, got len=%d", len(items))
 	}
 }
+
+// TestTreeNode_Clone_CarriesWrapper guards the field against Clone's
+// named-field construction.
+//
+// Clone builds the copy from an explicit field list, so anything added to
+// TreeNode is dropped unless someone remembers to list it. A cloned wrapper
+// silently reverting to WrapperNone is the exact failure the kind exists to
+// prevent: it becomes indistinguishable from an ordinary node again, and
+// through-wrapper range keying falls back to content hashing.
+//
+// No caller in internal/parse clones a tagged node before wrappedItemKey reads
+// it, so this is latent rather than live — but Clone is exported and documented
+// as a deep copy, so "deep copy" should mean it.
+func TestTreeNode_Clone_CarriesWrapper(t *testing.T) {
+	for _, kind := range []WrapperKind{WrapperNone, WrapperConditional, WrapperInvocation} {
+		original := NewTreeNode()
+		original.Statics = []string{"", ""}
+		original.Wrapper = kind
+		original.SetDynamic(0, "x")
+
+		if got := original.Clone().Wrapper; got != kind {
+			t.Errorf("Clone dropped the wrapper kind: got %v, want %v", got, kind)
+		}
+	}
+}

--- a/internal/parse/conditional.go
+++ b/internal/parse/conditional.go
@@ -25,7 +25,7 @@ func handleIf(node *parse.IfNode, eval *evaluator, data interface{}, varCtx *var
 	if err != nil {
 		return nil, err
 	}
-	return createConditionalWrapper(branchTree, ctx), nil
+	return createWrapper(branchTree, ctx, WrapperConditional), nil
 }
 
 // selectBranch chooses which branch of an if/else to execute.
@@ -36,13 +36,22 @@ func selectBranch(node *parse.IfNode, condResult bool) *parse.ListNode {
 	return node.ElseList
 }
 
-// createConditionalWrapper wraps a branch tree to preserve conditional structure for diffing.
-func createConditionalWrapper(branchTree *TreeNode, ctx *Context) *TreeNode {
+// createWrapper gives a child tree its own dynamic slot, recording which
+// construct asked for it.
+//
+// The kind is what makes the result identifiable later. A wrapper is
+// `["", ""]` statics plus one nested child, which is exactly what a plain field
+// node holding a tree looks like (see defaultFieldStatics in field.go), so no
+// predicate over the finished node can recover what produced it. Every wrapper
+// in the tree is born here, so tagging at this one point is what lets
+// wrappedItemKey ask instead of guess (issue #497).
+func createWrapper(child *TreeNode, ctx *Context, kind WrapperKind) *TreeNode {
 	wrapper := NewTreeNode()
 	if ctx.ShouldIncludeStatics() {
 		wrapper.Statics = defaultFieldStatics
 	}
-	wrapper.SetDynamic(0, branchTree)
+	wrapper.Wrapper = kind
+	wrapper.SetDynamic(0, child)
 	return wrapper
 }
 

--- a/internal/parse/invoke.go
+++ b/internal/parse/invoke.go
@@ -74,11 +74,12 @@ func invokeTemplate(n *parse.TemplateNode, eval *evaluator, data interface{}, va
 	if err != nil {
 		return nil, err
 	}
-	// Wrap the invoked body in its own dynamic slot (createConditionalWrapper is a
-	// generic single-dynamic-slot wrapper, despite the conditional-flavored name).
+	// Wrap the invoked body in its own dynamic slot. The WrapperInvocation tag is
+	// what lets range keying recognise this later: the node is otherwise
+	// indistinguishable from a conditional wrapper or a field node (issue #497).
 	// This isolation is why an invocation wraps where {{with}} does not: a
 	// recursive subtree's depth/shape varies with the data, so it must occupy one
 	// slot to keep those changes from restructuring the parent's statics — the
 	// same diffing rationale {{if}} wraps for.
-	return createConditionalWrapper(childTree, ctx), nil
+	return createWrapper(childTree, ctx, WrapperInvocation), nil
 }

--- a/internal/parse/keys.go
+++ b/internal/parse/keys.go
@@ -83,17 +83,29 @@ func generateItemHash(item *TreeNode) string {
 }
 
 // wrappedItemKey returns the explicit data-key of a range item whose real keyed
-// element is hidden one level down inside an invocation wrapper (the shape a
-// recursive {{template}} range produces: createConditionalWrapper wraps the
-// invoked body, so the item's own statics are empty and the <li data-key> lives
-// in the single nested child). It reads the key value *through* the wrapper
-// without restructuring the item, so the item keeps a stable identity across
-// deep edits (the key is the item's path, not a content hash of its subtree).
+// element is hidden one level down inside a parser-created wrapper — the shape
+// both a recursive {{template}} range and an {{if}}/{{with}}-wrapped keyed range
+// produce, where the item's own statics are empty and the <li data-key> lives in
+// the nested child. It reads the key value *through* the wrapper without
+// restructuring the item, so the item keeps a stable identity across deep edits
+// (the key is the item's path, not a content hash of its subtree).
 //
-// Returns ("", false) when the item is not this simple single-child wrapper or
-// the child carries no key attribute — callers then fall back to content hashing.
+// The wrapper is identified by the tag createWrapper set, not by its shape.
+// Shape cannot decide it: `["", ""]` statics plus one nested child describes a
+// conditional wrapper, an invocation wrapper and a plain field node holding a
+// tree alike, so the old structural test also matched nodes the parser never
+// wrapped and keyed them off a descendant's data-key by coincidence (issue #497).
+//
+// Any wrapper kind qualifies, deliberately. The child's real data-key is the
+// right identity for a conditional-wrapped item just as much as an invocation-
+// wrapped one, and narrowing this to WrapperInvocation would drop {{if}}-wrapped
+// keyed ranges back to content hashing — a keying regression, not a fix.
+//
+// Returns ("", false) when the item is not a wrapper, holds more than one nested
+// child, or the child carries no key attribute — callers then fall back to
+// content hashing.
 func wrappedItemKey(item *TreeNode) (string, bool) {
-	if item == nil || hasExplicitKeyAttribute(item.Statics) {
+	if item == nil || !item.Wrapper.IsWrapper() || hasExplicitKeyAttribute(item.Statics) {
 		return "", false
 	}
 	var child *TreeNode

--- a/internal/parse/keys.go
+++ b/internal/parse/keys.go
@@ -84,9 +84,11 @@ func generateItemHash(item *TreeNode) string {
 
 // wrappedItemKey returns the explicit data-key of a range item whose real keyed
 // element is hidden one level down inside a parser-created wrapper — the shape
-// both a recursive {{template}} range and an {{if}}/{{with}}-wrapped keyed range
-// produce, where the item's own statics are empty and the <li data-key> lives in
-// the nested child. It reads the key value *through* the wrapper without
+// both a recursive {{template}} range and an {{if}}-wrapped keyed range produce,
+// where the item's own statics are empty and the <li data-key> lives in the
+// nested child. ({{with}} does not wrap: handleWith delegates straight to
+// walkAST, so it only shows this shape when its body independently contains an
+// {{if}} or {{template}}.) It reads the key value *through* the wrapper without
 // restructuring the item, so the item keeps a stable identity across deep edits
 // (the key is the item's path, not a content hash of its subtree).
 //

--- a/internal/parse/types.go
+++ b/internal/parse/types.go
@@ -10,6 +10,15 @@ type (
 	RangeData    = build.RangeData
 	TreeMetadata = build.TreeMetadata
 	Context      = build.Context
+	WrapperKind  = build.WrapperKind
+)
+
+// Re-export the wrapper kinds so parse can tag nodes without importing build
+// at every wrapper site.
+const (
+	WrapperNone        = build.WrapperNone
+	WrapperConditional = build.WrapperConditional
+	WrapperInvocation  = build.WrapperInvocation
 )
 
 // Re-export build functions for convenience within parse package

--- a/internal/parse/walker.go
+++ b/internal/parse/walker.go
@@ -69,10 +69,21 @@ func walkList(node *parse.ListNode, eval *evaluator, data interface{}, varCtx *v
 	// A wrapper does not survive this loop as a node: its statics and dynamics
 	// are merged into tree below, so what a caller finally sees is a fresh node
 	// that merely has the wrapper's shape. Carry the kind across the merge when
-	// exactly one child contributed, which is the only case where tree still
-	// represents that single wrapper. Without this the tag set by createWrapper
+	// exactly one child was a wrapper. Without this the tag set by createWrapper
 	// would never reach wrappedItemKey (issue #497).
-	contributingChildren := 0
+	//
+	// Count wrappers, not children that contributed statics. A TextNode yields
+	// one static even when it is only the whitespace around an indented
+	// construct, so counting contributors makes the tag depend on how the
+	// template happens to be formatted:
+	//
+	//	{{range .Items}}{{if .X}}<li data-key=…>{{end}}{{end}}      one child
+	//	{{range .Items}}\n  {{if .X}}<li data-key=…>{{end}}\n{{end}}  three
+	//
+	// The second is how range bodies are normally written, and an earlier
+	// revision of this dropped it to content hashing. Wrapper count is the
+	// property that actually matters and is unaffected by neighbouring text.
+	wrapperChildren := 0
 	var soleChildWrapper WrapperKind
 
 	for i, child := range node.Nodes {
@@ -100,6 +111,11 @@ func walkList(node *parse.ListNode, eval *evaluator, data interface{}, varCtx *v
 			}
 		}
 
+		if childTree.Wrapper.IsWrapper() {
+			wrapperChildren++
+			soleChildWrapper = childTree.Wrapper
+		}
+
 		// Range comprehension: embed as nested structure
 		if childTree.HasRange() {
 			if len(node.Nodes) == 1 {
@@ -116,8 +132,6 @@ func walkList(node *parse.ListNode, eval *evaluator, data interface{}, varCtx *v
 		if len(childStatics) == 0 {
 			continue
 		}
-		contributingChildren++
-		soleChildWrapper = childTree.Wrapper
 
 		// First static of child appends to last static of parent
 		if len(statics) > 0 && len(childStatics) > 0 {
@@ -141,7 +155,7 @@ func walkList(node *parse.ListNode, eval *evaluator, data interface{}, varCtx *v
 		statics = append(statics, "")
 	}
 
-	if contributingChildren == 1 {
+	if wrapperChildren == 1 {
 		tree.Wrapper = soleChildWrapper
 	}
 

--- a/internal/parse/walker.go
+++ b/internal/parse/walker.go
@@ -66,6 +66,15 @@ func walkList(node *parse.ListNode, eval *evaluator, data interface{}, varCtx *v
 	dynamicIndex := 0
 	statics = append(statics, "")
 
+	// A wrapper does not survive this loop as a node: its statics and dynamics
+	// are merged into tree below, so what a caller finally sees is a fresh node
+	// that merely has the wrapper's shape. Carry the kind across the merge when
+	// exactly one child contributed, which is the only case where tree still
+	// represents that single wrapper. Without this the tag set by createWrapper
+	// would never reach wrappedItemKey (issue #497).
+	contributingChildren := 0
+	var soleChildWrapper WrapperKind
+
 	for i, child := range node.Nodes {
 		// Handle variable declarations
 		if varCtx != nil {
@@ -107,6 +116,8 @@ func walkList(node *parse.ListNode, eval *evaluator, data interface{}, varCtx *v
 		if len(childStatics) == 0 {
 			continue
 		}
+		contributingChildren++
+		soleChildWrapper = childTree.Wrapper
 
 		// First static of child appends to last static of parent
 		if len(statics) > 0 && len(childStatics) > 0 {
@@ -128,6 +139,10 @@ func walkList(node *parse.ListNode, eval *evaluator, data interface{}, varCtx *v
 
 	for len(statics) <= dynamicIndex {
 		statics = append(statics, "")
+	}
+
+	if contributingChildren == 1 {
+		tree.Wrapper = soleChildWrapper
 	}
 
 	if ctx.ShouldIncludeStatics() {

--- a/internal/parse/wrapper_kind_test.go
+++ b/internal/parse/wrapper_kind_test.go
@@ -50,9 +50,9 @@ func TestWrappedItemKey_RequiresTheMarker(t *testing.T) {
 // TestWrappedItemKey_AcceptsEveryWrapperKind pins the deliberate choice not to
 // narrow this to WrapperInvocation. The child's real data-key is the right
 // identity for a conditional-wrapped item too, and requiring WrapperInvocation
-// would drop {{if}}/{{with}}-wrapped keyed ranges to content hashing — a keying
-// regression rather than a fix. Verified against main: if_wrapped_keyed_range
-// keys by data-key there.
+// would drop {{if}}-wrapped keyed ranges to content hashing — a keying
+// regression rather than a fix. Verified against main, where an {{if}}-wrapped
+// keyed range keys by data-key.
 func TestWrappedItemKey_AcceptsEveryWrapperKind(t *testing.T) {
 	for _, kind := range []build.WrapperKind{build.WrapperConditional, build.WrapperInvocation} {
 		item := NewTreeNode()
@@ -103,5 +103,56 @@ func TestWalkList_CarriesWrapperAcrossTheMerge(t *testing.T) {
 		t.Errorf("expected the item keyed by its child's data-key, got %q — "+
 			"the wrapper kind did not survive walkList's merge, so through-wrapper "+
 			"keying fell back to content hashing", itemTree.AutoKey)
+	}
+}
+
+// TestWalkList_WrapperSurvivesSurroundingText is the regression guard for the
+// bug an earlier revision of this change shipped.
+//
+// walkList propagated the kind when exactly one child *contributed statics*.
+// A TextNode yields one static even when it is only the whitespace around an
+// indented construct, so that count rose with formatting: the minified body
+// below has one child, the indented one has three (text, if, text), and the
+// container-wrapped one has the <li> text as well. The tag stopped propagating
+// for every shape but the minified one, dropping realistic keyed ranges to
+// content hashing — the exact regression this change exists to avoid, arriving
+// through formatting rather than through wrapper kind.
+//
+// Counting wrappers instead of contributors is what makes keying independent of
+// how the template happens to be laid out. All three cases below key by
+// data-key on main; they must keep doing so.
+func TestWalkList_WrapperSurvivesSurroundingText(t *testing.T) {
+	type item struct{ Name, Path string }
+	data := struct{ Items []item }{Items: []item{{Name: "a.go", Path: "/a.go"}}}
+
+	cases := []struct{ name, src string }{
+		{"minified", `{{range .Items}}{{if .Name}}<li data-key="{{.Path}}">{{.Name}}</li>{{end}}{{end}}`},
+		{"indented", "{{range .Items}}\n  {{if .Name}}<li data-key=\"{{.Path}}\">{{.Name}}</li>{{end}}\n{{end}}"},
+		{"container wrapped", `{{range .Items}}<li>{{if .Name}}<span data-key="{{.Path}}">{{.Name}}</span>{{end}}</li>{{end}}`},
+		{"text sibling", `{{range .Items}}x{{if .Name}}<li data-key="{{.Path}}">{{.Name}}</li>{{end}}{{end}}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tmpl, err := Parse(c.src, nil)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			tree, err := BuildTree(tmpl, data, build.NewContext())
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			if tree.Range == nil || len(tree.Range.Items) != 1 {
+				t.Fatalf("expected a one-item range, got %#v", tree.Range)
+			}
+			itemTree, ok := tree.Range.Items[0].(*TreeNode)
+			if !ok {
+				t.Fatalf("range item is %T, want *TreeNode", tree.Range.Items[0])
+			}
+			if itemTree.AutoKey != "/a.go" {
+				t.Errorf("keyed by %q, want the child's data-key %q — surrounding text "+
+					"changed whether the wrapper tag propagated", itemTree.AutoKey, "/a.go")
+			}
+		})
 	}
 }

--- a/internal/parse/wrapper_kind_test.go
+++ b/internal/parse/wrapper_kind_test.go
@@ -1,0 +1,107 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/livetemplate/livetemplate/internal/build"
+)
+
+// keyedChild is the <li data-key="…"> a range item hides one level down.
+func keyedChild() *TreeNode {
+	child := NewTreeNode()
+	child.Statics = []string{`<li data-key="`, `">`, `</li>`}
+	child.SetDynamic(0, "/a.go")
+	child.SetDynamic(1, "a.go")
+	return child
+}
+
+// TestWrappedItemKey_RequiresTheMarker is the guard the #497 fix exists for.
+//
+// The two nodes below are byte-identical in every respect the old structural
+// predicate could see — `["", ""]` statics, exactly one nested *TreeNode child,
+// child carries data-key — and differ only in whether the parser recorded that
+// it created the node as a wrapper. The old test could not tell them apart and
+// keyed both by the child's data-key; only the tagged one qualifies now.
+//
+// No template reachable today produces the untagged shape: createWrapper is the
+// only thing that nests a TreeNode under empty statics, and field nodes hold
+// strings (createSingleDynamicTree). So this is constructed by hand deliberately
+// — the fix is a guard against a future construct acquiring through-wrapper
+// keying by coincidence, not a fix for observed breakage.
+func TestWrappedItemKey_RequiresTheMarker(t *testing.T) {
+	tagged := NewTreeNode()
+	tagged.Statics = defaultFieldStatics
+	tagged.Wrapper = build.WrapperInvocation
+	tagged.SetDynamic(0, keyedChild())
+
+	untagged := NewTreeNode()
+	untagged.Statics = defaultFieldStatics
+	untagged.SetDynamic(0, keyedChild())
+
+	if key, ok := wrappedItemKey(tagged); !ok || key != "/a.go" {
+		t.Errorf("tagged wrapper must key by the child's data-key, got (%q, %v)", key, ok)
+	}
+
+	if key, ok := wrappedItemKey(untagged); ok {
+		t.Errorf("untagged node must not inherit through-wrapper keying, got %q", key)
+	}
+}
+
+// TestWrappedItemKey_AcceptsEveryWrapperKind pins the deliberate choice not to
+// narrow this to WrapperInvocation. The child's real data-key is the right
+// identity for a conditional-wrapped item too, and requiring WrapperInvocation
+// would drop {{if}}/{{with}}-wrapped keyed ranges to content hashing — a keying
+// regression rather than a fix. Verified against main: if_wrapped_keyed_range
+// keys by data-key there.
+func TestWrappedItemKey_AcceptsEveryWrapperKind(t *testing.T) {
+	for _, kind := range []build.WrapperKind{build.WrapperConditional, build.WrapperInvocation} {
+		item := NewTreeNode()
+		item.Statics = defaultFieldStatics
+		item.Wrapper = kind
+		item.SetDynamic(0, keyedChild())
+
+		if key, ok := wrappedItemKey(item); !ok || key != "/a.go" {
+			t.Errorf("wrapper kind %v must key by data-key, got (%q, %v)", kind, key, ok)
+		}
+	}
+}
+
+// TestWalkList_CarriesWrapperAcrossTheMerge guards the step the issue did not
+// anticipate. walkList does not keep a wrapper as a node: it merges the
+// wrapper's statics and dynamics into a fresh tree, so what reaches
+// wrappedItemKey has the wrapper's shape without being the wrapper. If the kind
+// did not survive that merge the marker would never be observed and EVERY
+// through-wrapper keying would silently regress to content hashing — a far wider
+// break than the coincidence the marker is meant to prevent.
+func TestWalkList_CarriesWrapperAcrossTheMerge(t *testing.T) {
+	src := `{{range .Items}}{{if .Name}}<li data-key="{{.Path}}">{{.Name}}</li>{{end}}{{end}}`
+	type item struct{ Name, Path string }
+	data := struct{ Items []item }{Items: []item{{Name: "a.go", Path: "/a.go"}}}
+
+	tmpl, err := Parse(src, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tree, err := BuildTree(tmpl, data, build.NewContext())
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if tree.Range == nil || len(tree.Range.Items) != 1 {
+		t.Fatalf("expected a one-item range, got %#v", tree.Range)
+	}
+	itemTree, ok := tree.Range.Items[0].(*TreeNode)
+	if !ok {
+		t.Fatalf("range item is %T, want *TreeNode", tree.Range.Items[0])
+	}
+
+	// Assert the resulting key, not the marker. Items are rebuilt by
+	// extractItemDynamics before they reach RangeData, so the stored node is a
+	// derived one that never carried the kind — the marker is consumed earlier,
+	// by wrappedItemKey. The key is the observable proof it arrived: drop the
+	// propagation in walkList and this becomes a content hash.
+	if itemTree.AutoKey != "/a.go" {
+		t.Errorf("expected the item keyed by its child's data-key, got %q — "+
+			"the wrapper kind did not survive walkList's merge, so through-wrapper "+
+			"keying fell back to content hashing", itemTree.AutoKey)
+	}
+}


### PR DESCRIPTION
Closes #497.

`wrappedItemKey` identified a parser-created wrapper **structurally** — empty statics plus exactly one nested `TreeNode` child. That shape describes a conditional wrapper, an invocation wrapper, and a plain field node holding a tree alike, so no predicate over the finished node could recover what produced it.

`createWrapper` (renamed from `createConditionalWrapper`, whose name `invoke.go` already apologised for) now records a `WrapperKind`, and `wrappedItemKey` asks for the tag. All wrappers are born at that one constructor, so tagging there is enough — field nodes and `createEmptyConditionalWrapper` stay untagged automatically.

## Diverging from the issue's literal proposal

The issue says *"tag the invocation wrapper."* Doing exactly that would be a **regression**, and I measured it rather than reasoned it. On `main`:

| Shape | keying today |
|---|---|
| recursive `{{template}}` range | data-key |
| **`{{if}}`-wrapped keyed range** | **data-key** |
| unkeyed ranges | content hash |

`{{if}}`-wrapped keyed ranges key by their child's `data-key` today. Requiring `WrapperInvocation` drops them to content hashing — worse keying, more DOM churn. The child's real `data-key` is the right identity for a conditional-wrapped item too; the issue itself concedes as much ("often the right key anyway"). So **any** wrapper kind qualifies, and the kinds are recorded separately so the distinction exists if something ever needs it.

## The step the issue didn't anticipate

This is the part that matters most. **`walkList` does not keep a wrapper as a node** — it merges the wrapper's statics and dynamics into a fresh tree:

```go
tree := NewTreeNode()
...
statics[len(statics)-1] += childStatics[0]   // wrapper dissolved
```

So what reaches `wrappedItemKey` has the wrapper's *shape* without being the wrapper. The kind is now carried across that merge when exactly one child contributed.

Without it, the tag is never observed and **every** through-wrapper keying regresses to content hashing — far wider than the coincidence the tag prevents. Not theoretical: the first version of this change lacked propagation and both recursive and `{{if}}`-wrapped ranges silently fell back to hashes.

## This is latent robustness, not a live-bug fix

Stated plainly because the issue says "no observed breakage" and I could not manufacture any.

A temporary harness captured the keying decision across **ten** shapes on `main` and on this branch — recursive `{{template}}`, `{{if}}`/`{{with}}`-wrapped keyed, plain keyed, unkeyed, and four constructed candidate false positives. Output is **identical**. Removing the marker check changes none of them either.

That's consistent with the code: `createWrapper` is the only thing that nests a `TreeNode` under empty statics, and field nodes hold **strings** (`createSingleDynamicTree`), so no template reachable today produces the untagged shape. The guard is against a future construct acquiring through-wrapper keying by coincidence — which is why the unit test constructs that shape by hand.

## Wire and fingerprint are untouched

`MarshalJSON` and `ToMap` name the fields they emit; the fingerprint hashes statics and dynamic shape. The marker reaches neither. Two nodes differing only in kind render identically and share a fingerprint, which is correct.

## Both guards negative-gated

Verified to fail when what they protect is removed:

```
# marker check removed
--- FAIL: TestWrappedItemKey_RequiresTheMarker

# walkList propagation removed
--- FAIL: TestWalkList_CarriesWrapperAcrossTheMerge
    expected the item keyed by its child's data-key, got "466b3955bebc"
```

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG