### PR TITLE
fix(discovery): survive a path vanishing mid-walk (closes #502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to LiveTemplate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Template auto-discovery no longer fails when a directory disappears while it
+  is being searched.** `livetemplate.New()` walks the template directory, and any
+  error from that walk aborted it — including a transient directory being removed
+  by something else at that moment, which surfaced as
+  `template auto-discovery failed: readdirent …: no such file or directory` from
+  an unrelated part of the app. A path vanishing underneath the walk is now
+  skipped rather than fatal. Deliberately narrow: a missing *base* directory
+  still errors, since that means the caller pointed at somewhere that does not
+  exist, and non-ENOENT failures such as permissions still surface. `.uploads` is
+  also skipped outright, being uploaded files rather than templates. (#502)
+
 ## [v0.19.1] - 2026-07-18
 
 Documentation-only. No library behavior changes; released so the docs site,

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -12,6 +13,42 @@ var ignoredTemplateDirs = map[string]struct{}{
 	"node_modules": {},
 	"vendor":       {},
 	".git":         {},
+	// Uploaded files, never templates. Skipping it also avoids walking a tree
+	// that is being written and torn down concurrently — the upload temp dirs
+	// are the observed source of the vanishing-path race walkErrAction handles.
+	// That race is why this entry is a complement and not the fix: the upload
+	// directory is configurable, so only walkErrAction covers the general case.
+	".uploads": {},
+}
+
+// walkErrAction decides what a WalkDir error means for template discovery.
+//
+// A path disappearing mid-walk is not a discovery failure. Anything may be
+// writing and removing directories under the tree being searched while it is
+// searched — in this repo it is the upload tests tearing down .uploads, which
+// intermittently failed unrelated tests with
+// "template auto-discovery failed: readdirent .../.uploads/...: no such file or
+// directory" (issue #502). The old callback returned every error, so one
+// vanished temp directory aborted the whole walk and livetemplate.New() failed.
+//
+// The root is the exception. WalkDir reports a missing root through this same
+// callback, and that one means the caller asked to search a directory that does
+// not exist — a real error worth surfacing rather than reporting as "no
+// templates found". Errors that are not ErrNotExist (a permissions problem, say)
+// always surface too: this widens tolerance to exactly the concurrent-removal
+// case and nothing else.
+func walkErrAction(root, path string, d fs.DirEntry, err error) error {
+	if !errors.Is(err, fs.ErrNotExist) || path == root {
+		return err
+	}
+	// SkipDir on a non-directory would skip the rest of the containing
+	// directory, silently dropping sibling templates; it is only correct for a
+	// directory. d is nil when the failure is on the root, which is already
+	// handled above.
+	if d != nil && d.IsDir() {
+		return fs.SkipDir
+	}
+	return nil
 }
 
 // DiscoverTemplateFiles searches for template files in the specified directory and subdirectories.
@@ -67,7 +104,7 @@ func DiscoverTemplateFiles(baseDir string, customIgnoreDirs []string) ([]string,
 
 		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
-				return err
+				return walkErrAction(dir, path, d, err)
 			}
 
 			if d.IsDir() {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -13,38 +13,35 @@ var ignoredTemplateDirs = map[string]struct{}{
 	"node_modules": {},
 	"vendor":       {},
 	".git":         {},
-	// Uploaded files, never templates. Skipping it also avoids walking a tree
-	// that is being written and torn down concurrently — the upload temp dirs
-	// are the observed source of the vanishing-path race walkErrAction handles.
-	// That race is why this entry is a complement and not the fix: the upload
-	// directory is configurable, so only walkErrAction covers the general case.
+	// Uploaded files, never templates, and a tree that is written and removed
+	// while the app runs — so skipping it also keeps discovery out of the way of
+	// the churn walkErrAction tolerates. A complement rather than the fix: the
+	// upload directory is configurable, so only walkErrAction covers the general
+	// case. Note this shadows a real template directory literally named
+	// .uploads, which is why the general fix carries the weight.
 	".uploads": {},
 }
 
 // walkErrAction decides what a WalkDir error means for template discovery.
 //
-// A path disappearing mid-walk is not a discovery failure. Anything may be
-// writing and removing directories under the tree being searched while it is
-// searched — in this repo it is the upload tests tearing down .uploads, which
-// intermittently failed unrelated tests with
-// "template auto-discovery failed: readdirent .../.uploads/...: no such file or
-// directory" (issue #502). The old callback returned every error, so one
-// vanished temp directory aborted the whole walk and livetemplate.New() failed.
+// A path disappearing mid-walk is not a discovery failure: anything may be
+// writing and removing directories under the tree while it is searched, and
+// aborting the walk over one of them fails template construction outright.
 //
-// The root is the exception. WalkDir reports a missing root through this same
-// callback, and that one means the caller asked to search a directory that does
-// not exist — a real error worth surfacing rather than reporting as "no
-// templates found". Errors that are not ErrNotExist (a permissions problem, say)
-// always surface too: this widens tolerance to exactly the concurrent-removal
-// case and nothing else.
+// The root is the exception — WalkDir reports a missing root through this same
+// callback, and that means the caller asked to search a directory that does not
+// exist, which is worth surfacing rather than reporting as "no templates found".
+// Errors that are not ErrNotExist, a permissions problem say, always surface
+// too, so tolerance widens to the concurrent-removal case and nothing else.
 func walkErrAction(root, path string, d fs.DirEntry, err error) error {
 	if !errors.Is(err, fs.ErrNotExist) || path == root {
 		return err
 	}
 	// SkipDir on a non-directory would skip the rest of the containing
-	// directory, silently dropping sibling templates; it is only correct for a
-	// directory. d is nil when the failure is on the root, which is already
-	// handled above.
+	// directory, silently dropping sibling templates, so it is only correct for
+	// a directory. The non-directory path is defensive: WalkDir currently pairs
+	// a non-nil error only with a directory entry or with a nil entry at the
+	// root, so nothing reaches it today.
 	if d != nil && d.IsDir() {
 		return fs.SkipDir
 	}

--- a/internal/discovery/walk_race_test.go
+++ b/internal/discovery/walk_race_test.go
@@ -1,0 +1,179 @@
+package discovery
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestWalkErrAction covers the decision table directly, since the states it
+// distinguishes are awkward to provoke through a real walk.
+func TestWalkErrAction(t *testing.T) {
+	dirEntry := fakeDirEntry{name: "gone", dir: true}
+	fileEntry := fakeDirEntry{name: "gone.tmpl", dir: false}
+	notExist := &fs.PathError{Op: "readdirent", Path: "/root/sub", Err: fs.ErrNotExist}
+	denied := &fs.PathError{Op: "open", Path: "/root/sub", Err: fs.ErrPermission}
+
+	tests := []struct {
+		name     string
+		root     string
+		path     string
+		d        fs.DirEntry
+		err      error
+		want     error
+		wantSame bool // want the original error back
+	}{
+		{
+			name: "vanished subdirectory is skipped",
+			root: "/root", path: "/root/sub", d: dirEntry, err: notExist,
+			want: fs.SkipDir,
+		},
+		{
+			// SkipDir here would skip the rest of the containing directory and
+			// silently drop sibling templates.
+			name: "vanished file is ignored without skipping its siblings",
+			root: "/root", path: "/root/sub/x.tmpl", d: fileEntry, err: notExist,
+			want: nil,
+		},
+		{
+			// The caller asked to search somewhere that does not exist; reporting
+			// "no templates found" would hide that.
+			name: "missing root still surfaces",
+			root: "/root", path: "/root", d: nil, err: notExist,
+			wantSame: true,
+		},
+		{
+			name: "non-ENOENT errors always surface",
+			root: "/root", path: "/root/sub", d: dirEntry, err: denied,
+			wantSame: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := walkErrAction(tt.root, tt.path, tt.d, tt.err)
+			if tt.wantSame {
+				if !errors.Is(got, tt.err) {
+					t.Errorf("expected the original error back, got %v", got)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDiscoverTemplateFiles_ToleratesVanishingPaths reproduces issue #502: a
+// sibling process removing a directory tree while discovery walks it used to
+// abort the whole walk, so livetemplate.New() failed with
+// "template auto-discovery failed: readdirent …: no such file or directory" in
+// whichever unrelated test happened to be constructing a Template at the time.
+//
+// The churning directory is deliberately NOT named .uploads. That name is now in
+// ignoredTemplateDirs, so using it here would make this pass by never walking
+// the tree at all — proving the skip rather than the tolerance. This pins the
+// general property: discovery survives any path vanishing underneath it.
+func TestDiscoverTemplateFiles_ToleratesVanishingPaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "page.tmpl"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+	churn := filepath.Join(root, "scratch")
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// Deep enough that a walk is likely to be inside it when it goes.
+			deep := filepath.Join(churn, "tmp", "session-1", "field")
+			_ = os.MkdirAll(deep, 0o755)
+			_ = os.WriteFile(filepath.Join(deep, "part.tmpl"), []byte("x"), 0o644)
+			_ = os.RemoveAll(churn)
+		}
+	}()
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
+
+	for i := 0; i < 400; i++ {
+		files, err := DiscoverTemplateFiles(root, nil)
+		if err != nil {
+			t.Fatalf("iteration %d: discovery failed while a sibling tree was being removed: %v", i, err)
+		}
+		// The seeded template must still be found — tolerating the vanished path
+		// must not cost us the files that are actually there.
+		var found bool
+		for _, f := range files {
+			if filepath.Base(f) == "page.tmpl" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("iteration %d: lost page.tmpl; got %v", i, files)
+		}
+	}
+}
+
+// TestDiscoverTemplateFiles_SkipsUploadsDir pins the cheap half of the fix.
+// Upload directories hold uploaded files, never templates, so walking them is
+// pure cost plus exposure to the teardown race above.
+func TestDiscoverTemplateFiles_SkipsUploadsDir(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "page.tmpl"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+	uploaded := filepath.Join(root, ".uploads", ".tmp", "session-1")
+	if err := os.MkdirAll(uploaded, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A file that would be picked up as a template if the directory were walked.
+	if err := os.WriteFile(filepath.Join(uploaded, "upload.html"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed upload: %v", err)
+	}
+
+	files, err := DiscoverTemplateFiles(root, nil)
+	if err != nil {
+		t.Fatalf("discovery: %v", err)
+	}
+	for _, f := range files {
+		if filepath.Base(f) == "upload.html" {
+			t.Errorf("discovery walked .uploads and picked up %s", f)
+		}
+	}
+	if len(files) != 1 || filepath.Base(files[0]) != "page.tmpl" {
+		t.Errorf("expected only page.tmpl, got %v", files)
+	}
+}
+
+// TestDiscoverTemplateFiles_MissingBaseDirStillErrors is the counterweight to
+// the tolerance: widening it far enough to swallow this would turn a caller's
+// wrong path into a silent empty result.
+func TestDiscoverTemplateFiles_MissingBaseDirStillErrors(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := DiscoverTemplateFiles(missing, nil); err == nil {
+		t.Error("expected an error for a base directory that does not exist")
+	}
+}
+
+type fakeDirEntry struct {
+	name string
+	dir  bool
+}
+
+func (f fakeDirEntry) Name() string               { return f.name }
+func (f fakeDirEntry) IsDir() bool                { return f.dir }
+func (f fakeDirEntry) Type() fs.FileMode          { return 0 }
+func (f fakeDirEntry) Info() (fs.FileInfo, error) { return nil, nil }


### PR DESCRIPTION
Closes #502.

Template auto-discovery returned **every** `filepath.WalkDir` error, so a directory removed while the walk was in progress aborted the whole thing and `livetemplate.New()` failed:

```
template auto-discovery failed: readdirent .../.uploads/.tmp/session-N/…:
no such file or directory
```

The remover was the upload tests tearing down `.uploads`; the victim was whichever unrelated test happened to be constructing a `Template` at that moment. It cost a false regression alarm on #499 today — a red `Test LVT against Core Changes` that looked like a real break until the error string identified it.

## Two changes

**`walkErrAction` treats `ErrNotExist` below the root as "skip what's gone and keep walking."** A path disappearing underneath a walk isn't a discovery failure.

Deliberately narrow:

| case | behaviour | why |
|---|---|---|
| vanished subdirectory | `SkipDir` | nothing left to descend into |
| vanished file | `nil` | `SkipDir` on a non-directory skips the rest of the containing directory, silently dropping sibling templates |
| **missing root** | **error** | `WalkDir` reports it through the same callback; it means the caller asked to search somewhere that doesn't exist, and surfacing that beats reporting "no templates found" |
| non-`ErrNotExist` (permissions, …) | error | tolerance widens to the concurrent-removal case and nothing else |

**`.uploads` joins `ignoredTemplateDirs`.** It holds uploaded files, never templates, so walking it is pure cost plus exposure to this race. A complement, not the fix — the upload directory is configurable and any transient directory triggers the same abort, so `walkErrAction` is what closes the class.

## Tests reproduce the reported failure, not an approximation

With the fix reverted, the concurrency test fails with the same signature seen in CI:

```
--- FAIL: TestDiscoverTemplateFiles_ToleratesVanishingPaths
    iteration 254: discovery failed while a sibling tree was being removed:
    readdirent /tmp/.../scratch/tmp/session-1: no such file or directory
```

and the `.uploads` test picks up an upload as a template.

**The concurrency test deliberately churns a directory NOT named `.uploads`.** Using that name would make it pass by never walking the tree — proving the skip instead of the tolerance. It also asserts the seeded template is still found each iteration, so tolerating a vanished path can't cost us files that are actually there.

`TestDiscoverTemplateFiles_MissingBaseDirStillErrors` is the counterweight: the tolerance must not widen far enough to turn a caller's wrong path into a silent empty result.

## Not introducing a flake while fixing one

Would be a poor outcome for this particular PR, so: **12 consecutive runs** of the concurrency test, plus the package green under `-race`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG