### PR TITLE
feat(parse): key through nested wrappers, not just one level (closes #505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to LiveTemplate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Template auto-discovery no longer fails when a directory disappears while it
+  is being searched.** `livetemplate.New()` walks the template directory, and any
+  error from that walk aborted it — including a transient directory being removed
+  by something else at that moment, which surfaced as
+  `template auto-discovery failed: readdirent …: no such file or directory` from
+  an unrelated part of the app. A path vanishing underneath the walk is now
+  skipped rather than fatal. Deliberately narrow: a missing *base* directory
+  still errors, since that means the caller pointed at somewhere that does not
+  exist, and non-ENOENT failures such as permissions still surface. `.uploads` is
+  also skipped outright, being uploaded files rather than templates. (#502)
+- **Range items whose keyed element sits under more than one wrapper keep their
+  stable identity.** Nested constructs stack wrappers, so
+  `{{if}}{{if}}<li data-key="…">` puts the keyed element two levels below the
+  range item; key lookup only looked one level down and fell back to hashing the
+  item's content. Because a content hash changes when the content does, editing
+  such an item changed its key and the client removed and re-inserted the row
+  instead of patching it — the churn `data-key` exists to avoid. Lookup now
+  descends through nested wrappers, bounded at four levels. Items with no key at
+  any depth still use content hashes, as before. (#505)
+
 ## [v0.19.1] - 2026-07-18
 
 Documentation-only. No library behavior changes; released so the docs site,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Template auto-discovery no longer fails when a directory disappears while it
-  is being searched.** `livetemplate.New()` walks the template directory, and any
-  error from that walk aborted it — including a transient directory being removed
-  by something else at that moment, which surfaced as
-  `template auto-discovery failed: readdirent …: no such file or directory` from
-  an unrelated part of the app. A path vanishing underneath the walk is now
-  skipped rather than fatal. Deliberately narrow: a missing *base* directory
-  still errors, since that means the caller pointed at somewhere that does not
-  exist, and non-ENOENT failures such as permissions still surface. `.uploads` is
-  also skipped outright, being uploaded files rather than templates. (#502)
 - **Range items whose keyed element sits under more than one wrapper keep their
   stable identity.** Nested constructs stack wrappers, so
   `{{if}}{{if}}<li data-key="…">` puts the keyed element two levels below the

--- a/internal/parse/keys.go
+++ b/internal/parse/keys.go
@@ -103,9 +103,10 @@ func generateItemHash(item *TreeNode) string {
 // wrapped one, and narrowing this to WrapperInvocation would drop {{if}}-wrapped
 // keyed ranges back to content hashing — a keying regression, not a fix.
 //
-// Returns ("", false) when the item is not a wrapper, holds more than one nested
-// child, or the child carries no key attribute — callers then fall back to
-// content hashing.
+// Returns ("", false) when the item carries a key attribute itself (the ordinary
+// keyed-range path handles that), is not a wrapper, holds more than one nested
+// child, or has no keyed child within the descent limit — callers then fall back
+// to content hashing.
 func wrappedItemKey(item *TreeNode) (string, bool) {
 	if item == nil || hasExplicitKeyAttribute(item.Statics) {
 		return "", false

--- a/internal/parse/keys.go
+++ b/internal/parse/keys.go
@@ -107,29 +107,64 @@ func generateItemHash(item *TreeNode) string {
 // child, or the child carries no key attribute — callers then fall back to
 // content hashing.
 func wrappedItemKey(item *TreeNode) (string, bool) {
-	if item == nil || !item.Wrapper.IsWrapper() || hasExplicitKeyAttribute(item.Statics) {
+	if item == nil || hasExplicitKeyAttribute(item.Statics) {
 		return "", false
 	}
+	// Descend while the node is a wrapper we created, stopping at the first
+	// child that carries a key attribute. Nested constructs stack wrappers —
+	// {{if}}{{if}}<li data-key=…> puts the keyed element two levels down — and
+	// looking only one level meant those items fell back to content hashing
+	// despite having a perfectly good explicit key (issue #505).
+	//
+	// Descending is only safe because wrappers are tagged: each step checks the
+	// node the parser marked, never a shape that merely resembles one, so this
+	// cannot re-introduce the guessing removed in #497.
+	node := item
+	for depth := 0; depth < maxWrapperDescent; depth++ {
+		if !node.Wrapper.IsWrapper() {
+			return "", false
+		}
+		child := soleNestedChild(node)
+		if child == nil {
+			return "", false
+		}
+		if hasExplicitKeyAttribute(child.Statics) {
+			if v, ok := child.GetDynamic(detectIDKey(child.Statics)); ok {
+				if s, ok := v.(string); ok && s != "" {
+					return s, true
+				}
+			}
+			return "", false
+		}
+		node = child
+	}
+	return "", false
+}
+
+// maxWrapperDescent bounds the search above. Every level costs a lookup per item
+// per render, and allWrappedItemKeys is all-or-nothing, so an item that never
+// yields a key makes the whole range pay the full descent each time. Four is
+// well past what real templates stack — {{if}}{{if}} is already unusual — while
+// keeping the miss cost flat.
+const maxWrapperDescent = 4
+
+// soleNestedChild returns the one nested *TreeNode among node's dynamics, or nil
+// if there is none or more than one. More than one means the node holds real
+// content rather than just wrapping a child, so there is no single element for
+// the item's identity to come from.
+func soleNestedChild(node *TreeNode) *TreeNode {
 	var child *TreeNode
-	for _, d := range item.Dynamics {
+	for _, d := range node.Dynamics {
 		c, ok := d.(*TreeNode)
 		if !ok {
 			continue
 		}
 		if child != nil {
-			return "", false // more than one nested child: not the simple wrapper
+			return nil
 		}
 		child = c
 	}
-	if child == nil || !hasExplicitKeyAttribute(child.Statics) {
-		return "", false
-	}
-	if v, ok := child.GetDynamic(detectIDKey(child.Statics)); ok {
-		if s, ok := v.(string); ok && s != "" {
-			return s, true
-		}
-	}
-	return "", false
+	return child
 }
 
 // allWrappedItemKeys returns the through-wrapper data-key of every item, or

--- a/internal/parse/keys.go
+++ b/internal/parse/keys.go
@@ -95,8 +95,8 @@ func generateItemHash(item *TreeNode) string {
 // The wrapper is identified by the tag createWrapper set, not by its shape.
 // Shape cannot decide it: `["", ""]` statics plus one nested child describes a
 // conditional wrapper, an invocation wrapper and a plain field node holding a
-// tree alike, so the old structural test also matched nodes the parser never
-// wrapped and keyed them off a descendant's data-key by coincidence (issue #497).
+// tree alike, so a structural test also matches nodes the parser never wrapped
+// and would key them off a descendant's data-key by coincidence.
 //
 // Any wrapper kind qualifies, deliberately. The child's real data-key is the
 // right identity for a conditional-wrapped item just as much as an invocation-
@@ -113,12 +113,12 @@ func wrappedItemKey(item *TreeNode) (string, bool) {
 	// Descend while the node is a wrapper we created, stopping at the first
 	// child that carries a key attribute. Nested constructs stack wrappers —
 	// {{if}}{{if}}<li data-key=…> puts the keyed element two levels down — and
-	// looking only one level meant those items fell back to content hashing
-	// despite having a perfectly good explicit key (issue #505).
+	// looking only one level down leaves those items on content hashes despite
+	// their having a perfectly good explicit key.
 	//
-	// Descending is only safe because wrappers are tagged: each step checks the
+	// Descending is safe only because wrappers are tagged: each step checks a
 	// node the parser marked, never a shape that merely resembles one, so this
-	// cannot re-introduce the guessing removed in #497.
+	// does not reintroduce guessing.
 	node := item
 	for depth := 0; depth < maxWrapperDescent; depth++ {
 		if !node.Wrapper.IsWrapper() {

--- a/internal/parse/wrapper_kind_test.go
+++ b/internal/parse/wrapper_kind_test.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/livetemplate/livetemplate/internal/build"
@@ -154,5 +155,109 @@ func TestWalkList_WrapperSurvivesSurroundingText(t *testing.T) {
 					"changed whether the wrapper tag propagated", itemTree.AutoKey, "/a.go")
 			}
 		})
+	}
+}
+
+// TestWrappedItemKey_DescendsNestedWrappers covers issue #505: nested constructs
+// stack wrappers, so {{if}}{{if}}<li data-key=…> puts the keyed element two
+// levels below the range item. Looking only one level down meant those items
+// fell back to content hashing despite carrying a perfectly good explicit key —
+// losing stable identity, so a change to one item made the client rebuild the
+// row instead of patching it.
+//
+// Descending is safe only because wrappers are tagged (#497): each step tests a
+// node the parser marked, never a shape that happens to resemble one.
+func TestWrappedItemKey_DescendsNestedWrappers(t *testing.T) {
+	type item struct{ Name, Path string }
+	data := struct{ Items []item }{Items: []item{{Name: "a.go", Path: "/a.go"}}}
+
+	keyed := func(depth int) string {
+		var b strings.Builder
+		b.WriteString("{{range .Items}}")
+		for i := 0; i < depth; i++ {
+			b.WriteString("{{if .Name}}")
+		}
+		b.WriteString(`<li data-key="{{.Path}}">{{.Name}}</li>`)
+		for i := 0; i < depth; i++ {
+			b.WriteString("{{end}}")
+		}
+		b.WriteString("{{end}}")
+		return b.String()
+	}
+
+	tests := []struct {
+		name    string
+		src     string
+		wantKey string // "" means content-hash fallback
+	}{
+		{"one wrapper", keyed(1), "/a.go"},
+		{"two wrappers", keyed(2), "/a.go"},
+		{"three wrappers", keyed(3), "/a.go"},
+		{"at the descent limit", keyed(maxWrapperDescent), "/a.go"},
+		{
+			// Bounded deliberately: allWrappedItemKeys is all-or-nothing, so an
+			// item that never yields a key makes the whole range pay the full
+			// descent on every render. Falling back here is correct, not a gap.
+			name: "beyond the descent limit falls back", src: keyed(maxWrapperDescent + 1), wantKey: "",
+		},
+		{
+			// Nothing to find however deep we look.
+			name: "nested but unkeyed falls back",
+			src:  `{{range .Items}}{{if .Name}}{{if .Path}}<li>{{.Name}}</li>{{end}}{{end}}{{end}}`, wantKey: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := Parse(tt.src, nil)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			tree, err := BuildTree(tmpl, data, build.NewContext())
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			if tree.Range == nil || len(tree.Range.Items) != 1 {
+				t.Fatalf("expected a one-item range, got %#v", tree.Range)
+			}
+			itemTree, ok := tree.Range.Items[0].(*TreeNode)
+			if !ok {
+				t.Fatalf("range item is %T, want *TreeNode", tree.Range.Items[0])
+			}
+
+			if tt.wantKey != "" {
+				if itemTree.AutoKey != tt.wantKey {
+					t.Errorf("keyed by %q, want the child's data-key %q", itemTree.AutoKey, tt.wantKey)
+				}
+				return
+			}
+			if itemTree.AutoKey == "/a.go" {
+				t.Errorf("expected a content hash, got the data-key %q", itemTree.AutoKey)
+			}
+		})
+	}
+}
+
+// TestSoleNestedChild pins the "exactly one" rule the descent relies on. A node
+// holding two nested trees is real content, not a wrapper around a single
+// element, so there is no one child for the item's identity to come from.
+func TestSoleNestedChild(t *testing.T) {
+	one := NewTreeNode()
+	one.SetDynamic(0, NewTreeNode())
+	if soleNestedChild(one) == nil {
+		t.Error("a node with exactly one nested child must yield it")
+	}
+
+	two := NewTreeNode()
+	two.SetDynamic(0, NewTreeNode())
+	two.SetDynamic(1, NewTreeNode())
+	if soleNestedChild(two) != nil {
+		t.Error("a node with two nested children must yield none")
+	}
+
+	none := NewTreeNode()
+	none.SetDynamic(0, "text")
+	if soleNestedChild(none) != nil {
+		t.Error("a node whose dynamics are all strings must yield none")
 	}
 }


### PR DESCRIPTION
Closes #505.

Nested constructs stack wrappers, so `{{if}}{{if}}<li data-key="…">` puts the keyed element **two** levels below the range item. `wrappedItemKey` looked exactly one level down, so those items fell back to content hashing despite carrying a perfectly good explicit key.

The cost is real: content hashes change with content, so editing an item changed its key, and the client removed and re-inserted the row instead of patching it — exactly what `data-key` exists to prevent.

## The change

Descend while the node is a wrapper, stopping at the first child carrying a key attribute.

**This is only safe because wrappers are tagged (#497).** Each step tests a node the parser *marked*, never a shape that happens to resemble one — so the descent can't re-introduce the guessing that issue removed. It's why #505 was worth doing after #504 rather than before it.

**Bounded at four levels.** `allWrappedItemKeys` is all-or-nothing, so an item that never yields a key makes the whole range pay the full descent on every render. Four is well past what real templates stack (`{{if}}{{if}}` is already unusual) while keeping the miss cost flat.

## Measured, not assumed

A twelve-shape matrix on `main` and on this branch. **Exactly three lines change:**

```
  recursive              datakey=true      (unchanged)
  if_keyed               datakey=true      (unchanged)
  if_keyed_indented      datakey=true      (unchanged)
  if_keyed_container     datakey=true      (unchanged)
  plain_keyed            datakey=false     (unchanged)
  unkeyed                datakey=false     (unchanged)
- double_if              datakey=false
+ double_if              datakey=true
- double_if_indented     datakey=false
+ double_if_indented     datakey=true
- triple_if              datakey=false
+ triple_if              datakey=true
  double_if_unkeyed      datakey=false     (unchanged — no key at any depth)
```

Indented and container-wrapped variants are in the matrix deliberately: a minified-only matrix is what let a formatting-sensitive regression through on #504, and I'd rather not repeat that.

## Boundary and gates

The cap is pinned in both directions — four levels key, five falls back. And the descent test was verified to fail when the loop is reverted to a single level:

```
--- FAIL: .../two_wrappers
--- FAIL: .../three_wrappers
--- FAIL: .../at_the_descent_limit
```

`TestSoleNestedChild` pins the "exactly one nested child" rule the descent relies on — a node with two nested trees is real content, not a wrapper, so there's no single element for identity to come from.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG