### PR TITLE
docs(changelog): file the v0.8.5 breaking notice under v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,18 +333,6 @@ channel names (`livetemplate:broadcast:*`) are unchanged.
 
 
 
-## [Unreleased]
-
-### Breaking changes
-
-- **Retroactive breaking-change notice for v0.8.5: `TreeNode` internal API changed in [#220](https://github.com/livefir/livetemplate/pull/220)** (commit `3fe784ca`, shipped in `v0.8.5`). The `Dynamics` field type and the helper signatures changed when the internal map was replaced with a slice for ~20% speedup:
-  - `Dynamics` field: `map[string]interface{}` → `[]interface{}`
-  - `SetDynamic(position string, value interface{})` → `SetDynamic(index int, value interface{})`
-  - `GetDynamic(position string)` → `GetDynamic(index int)`
-  - New `AutoKey string` Go field replaces the previous `"_k"` map key. The `"_k"` *wire-format* key is unchanged — only the in-memory Go field name moved.
-
-  `TreeNode` lives in `internal/build` and is not part of the public `livetemplate` API surface; the breaking surface is therefore limited to **library forks and downstream modules that vendor or replace `internal/build`**, plus internal test fixtures. Application code that consumes `livetemplate` through its exported API is unaffected. The on-the-wire tree format (numeric string keys: `"0"`, `"1"`, ...) is unchanged; only the in-memory Go API moved.
-
 ## [v0.8.23] - 2026-05-02
 
 ### Changes
@@ -582,6 +570,18 @@ Key changes:
 
 <a name="v0.8.5"></a>
 ## [v0.8.5] - 2026-03-25
+
+### Breaking changes
+
+> Added retroactively — this change shipped in v0.8.5 but was not recorded at the time.
+
+- **`TreeNode` internal API changed in [#220](https://github.com/livefir/livetemplate/pull/220)** (commit `3fe784ca`). The `Dynamics` field type and the helper signatures changed when the internal map was replaced with a slice for ~20% speedup:
+  - `Dynamics` field: `map[string]interface{}` → `[]interface{}`
+  - `SetDynamic(position string, value interface{})` → `SetDynamic(index int, value interface{})`
+  - `GetDynamic(position string)` → `GetDynamic(index int)`
+  - New `AutoKey string` Go field replaces the previous `"_k"` map key. The `"_k"` *wire-format* key is unchanged — only the in-memory Go field name moved.
+
+  `TreeNode` lives in `internal/build` and is not part of the public `livetemplate` API surface; the breaking surface is therefore limited to **library forks and downstream modules that vendor or replace `internal/build`**, plus internal test fixtures. Application code that consumes `livetemplate` through its exported API is unaffected. The on-the-wire tree format (numeric string keys: `"0"`, `"1"`, ...) is unchanged; only the in-memory Go API moved.
 
 ### Bug Fixes
 


### PR DESCRIPTION
CHANGELOG.md had **two `## [Unreleased]` sections** — one at the top (correct, holding the unreleased #502/#505 fixes) and a second buried between v0.9.0 and v0.8.23.

## Why this is a defect, not untidiness

`release.sh` extracts release notes by header and stops at the first match. So the lower section could never ship, and a future edit landing in the wrong one would be silently dropped. This is the same class of bug that just bit the client release, where notes ended up in a section that claimed to be unreleased.

## What the stale section actually held

Not junk — a **retroactive breaking-change notice** for the `TreeNode` internal API change that shipped in v0.8.5 ([#220](https://github.com/livefir/livetemplate/pull/220)): `Dynamics` going `map[string]interface{}` → `[]interface{}`, the `SetDynamic`/`GetDynamic` signature changes, and the `AutoKey` field replacing the `"_k"` map key.

So the fix is to **re-file it, not delete it**. It now lives in the real v0.8.5 section, where someone looking up that version will find it, marked as added retroactively so it doesn't read as having been there all along.

Content is unchanged — verified the bullets and the scope paragraph survive the move intact.

## Verification

```
$ grep -c "^## \[Unreleased\]" CHANGELOG.md
1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG