### PR TITLE
ci(review): let the reviewer read the files it reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,7 +69,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: claude-review-execution-log
-          path: ${{ steps.claude-review.outputs.execution_file }}
+          # Falls back to the action's documented temp path: a step that FAILED
+          # never sets its outputs, so execution_file is empty in exactly the
+          # case this upload exists for.
+          path: ${{ steps.claude-review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,25 +54,12 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-
-      # The run's turn-by-turn log, kept whatever the outcome. When the review
-      # fails, the job log reports only the aggregate — `is_error: true` with a
-      # `permission_denials_count` — and never names the tool that was denied,
-      # which is the one fact needed to fix it. That detail lives in this file,
-      # written to the runner's temp dir and otherwise discarded with the runner.
-      # Runs are cheap to re-trigger but not to reproduce: which tool the model
-      # reaches for varies per PR, so a failure not captured when it happens may
-      # not recur on demand.
-      - name: Upload review execution log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: claude-review-execution-log
-          # Falls back to the action's documented temp path: a step that FAILED
-          # never sets its outputs, so execution_file is empty in exactly the
-          # case this upload exists for.
-          path: ${{ steps.claude-review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
-          if-no-files-found: warn
-          retention-days: 14
+          #
+          # Read/Grep/Glob are read-only over the checked-out tree. Without them the
+          # review can see the diff but not the file around it, and CLAUDE.md asks it
+          # to verify paths, function names and call-site counts cited in doc changes
+          # — none of which is answerable from a diff alone. Reaching for a tool that
+          # is not listed is a denial, and a denial ends the run as a failure, so the
+          # omission cost whole reviews rather than degrading them.
+          claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,3 +56,20 @@ jobs:
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
+      # The run's turn-by-turn log, kept whatever the outcome. When the review
+      # fails, the job log reports only the aggregate — `is_error: true` with a
+      # `permission_denials_count` — and never names the tool that was denied,
+      # which is the one fact needed to fix it. That detail lives in this file,
+      # written to the runner's temp dir and otherwise discarded with the runner.
+      # Runs are cheap to re-trigger but not to reproduce: which tool the model
+      # reaches for varies per PR, so a failure not captured when it happens may
+      # not recur on demand.
+      - name: Upload review execution log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-review-execution-log
+          path: ${{ steps.claude-review.outputs.execution_file }}
+          if-no-files-found: warn
+          retention-days: 14
+


### PR DESCRIPTION
Core's review bot has been failing while the same workflow recovered on its own in the other two repos. This grants it file access.

## The evidence

Across the three repos running this workflow, the split is clean:

| Repo | Recent runs | `Read` in allowlist |
|---|---|---|
| client | fail → **pass, pass** | yes |
| docs | fail → **pass** | no allowlist set, so permissive defaults |
| **core** | fail → fail → **fail** | **no** |

Core is the only repo whose allowlist omits `Read`, and the only one still failing. Its list granted seven `gh` subcommands and no file access at all — the review could fetch the diff but never open the file around it. Since CLAUDE.md asks the bot to verify paths, function names and call-site counts cited in doc changes, and none of that is answerable from a diff, it reaches for `Read`, gets denied, and a denial ends the run as a failure. The omission cost whole reviews rather than degrading them.

## What this rules out

Three plausible causes, all eliminated:

- **Not auth.** Runs initialize (`"model": "claude-sonnet-5"`) and bill real budget. The empty `ANTHROPIC_API_KEY` in the env dump is a red herring — this workflow authenticates via `claude_code_oauth_token`, so that variable is *expected* to be blank. I initially misread it as the cause.
- **Not quota.** An exhausted quota fails at init or returns 429; it does not run four turns and charge $0.16.
- **Not an action upgrade.** All three repos pin the floating `@v1` tag, but that tag last moved at `2026-07-19T02:57:33Z`, hours *before* the last green run. Same version both succeeded and failed.

## Scope

`Read`, `Grep` and `Glob` are read-only over the checked-out tree, which the job already has via `contents: read` and can already see in full through `gh pr diff`. This grants no reach it didn't have.

## What this branch previously carried

An execution-log capture step, to make the denial self-identifying. Removed, because it could not work: the action prints `Log saved to $RUNNER_TEMP/claude-execution-output.json` but leaves nothing there — a search of `RUNNER_TEMP` on a green run found no such file, only runner scratch scripts. A step that always warns "no files found" is worse than no step, since it reads as *captured* on the next failure.

The companion PRs in client and docs are being closed for the same reason.

## Verification

This PR is its own test: if core's `claude-review` posts a review here, the diagnosis holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG