### PR TITLE
fix(release): refuse to release on a stale client pin

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -147,12 +147,24 @@ check_client_pin() {
     latest=$(gh release list --repo livetemplate/client --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || true)
     latest=${latest#v}
 
-    # A failed lookup is no evidence either way, and blocking a release on a
-    # GitHub API hiccup is worse than proceeding. Say the check was SKIPPED
-    # rather than letting silence read as a pass.
-    if [ -z "$latest" ]; then
-        log_warn "SKIPPED the client-pin check — could not reach the client repo"
+    # Require a semver-shaped answer rather than merely a non-empty one. jq
+    # yields the literal string "null" when the release list is empty, which is
+    # non-empty, survives the "v" strip, and sorts *below* any real version — so
+    # a bare -z check would let it through and refuse the release citing
+    # "Latest: null". Anything unparseable is treated as no answer at all.
+    if ! printf '%s' "$latest" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+        log_warn "SKIPPED the client-pin check — no usable version from the client repo"
         log_warn "ClientVersion is $pinned; confirm by hand that it is current"
+        return 0
+    fi
+
+    # version_order leans on `sort -V`. Absent it, sort still succeeds and
+    # returns a lexicographic order — silently wrong, and inside a [ ] test that
+    # `set -e` does not trap. Probe with a pair whose lexicographic and numeric
+    # orders disagree, and skip rather than trust a bad comparison.
+    if [ "$(printf '0.10.0\n0.9.0\n' | sort -V | head -1)" != "0.9.0" ]; then
+        log_warn "SKIPPED the client-pin check — this sort(1) lacks working -V"
+        log_warn "ClientVersion is $pinned, client released $latest; compare by hand"
         return 0
     fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -107,6 +107,95 @@ get_current_version() {
     cat VERSION | tr -d '\n'
 }
 
+# The @livetemplate/client version this release will point browsers at.
+read_client_pin() {
+    grep -oE '^const ClientVersion = "[0-9]+\.[0-9]+\.[0-9]+"' client_assets.go 2>/dev/null \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true
+}
+
+# "same" | "older" | "newer", describing $1 relative to $2.
+version_order() {
+    if [ "$1" = "$2" ]; then
+        echo same
+    elif [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]; then
+        echo older
+    else
+        echo newer
+    fi
+}
+
+# Refuse to release while ClientVersion trails the client's latest release.
+#
+# ClientScriptURL is built from that constant, so it decides which bundle every
+# application on the documented <script src="{{ .ClientScriptURL }}"> path
+# loads. A stale pin means a published client fix reaches nobody — which is what
+# happened between client 0.19.1 and core v0.20.1: the upload field-serialization
+# fix sat on npm for two core releases while the pin stayed at 0.18.2 (#452, #515).
+#
+# Nothing else catches this. The unit tests assert the pin is well-formed semver
+# and that the URL is HTTPS; a stale-but-valid pin passes both.
+check_client_pin() {
+    local pinned latest
+    pinned=$(read_client_pin)
+
+    if [ -z "$pinned" ]; then
+        log_error "Could not read ClientVersion from client_assets.go"
+        echo "Expected a line like: const ClientVersion = \"1.2.3\""
+        exit 1
+    fi
+
+    latest=$(gh release list --repo livetemplate/client --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || true)
+    latest=${latest#v}
+
+    # A failed lookup is no evidence either way, and blocking a release on a
+    # GitHub API hiccup is worse than proceeding. Say the check was SKIPPED
+    # rather than letting silence read as a pass.
+    if [ -z "$latest" ]; then
+        log_warn "SKIPPED the client-pin check — could not reach the client repo"
+        log_warn "ClientVersion is $pinned; confirm by hand that it is current"
+        return 0
+    fi
+
+    case "$(version_order "$pinned" "$latest")" in
+        same)
+            log_info "Client pin is current ($pinned)"
+            ;;
+        older)
+            # Overridable, because staying behind is occasionally correct — a
+            # client release carrying a wire change this server cannot serve yet
+            # should not be adopted. Not overridable for "newer": an unpublished
+            # pin 404s for everyone, and no intent makes that right.
+            if [ -n "${LVT_ALLOW_CLIENT_PIN_DRIFT:-}" ]; then
+                log_warn "ClientVersion $pinned trails the released $latest — proceeding (LVT_ALLOW_CLIENT_PIN_DRIFT set)"
+                return 0
+            fi
+            log_error "ClientVersion is behind the released client"
+            echo ""
+            echo "  Pinned in client_assets.go: $pinned"
+            echo "  Latest @livetemplate/client: $latest"
+            echo ""
+            echo "ClientScriptURL is built from this constant, so releasing now ships"
+            echo "$pinned to every application using the documented <script> path — any"
+            echo "client fix released since then reaches nobody."
+            echo ""
+            echo "Bump ClientVersion to $latest and re-run. If this release is meant to"
+            echo "stay on $pinned (e.g. $latest carries a wire change this server cannot"
+            echo "serve yet), re-run with LVT_ALLOW_CLIENT_PIN_DRIFT=1."
+            exit 1
+            ;;
+        newer)
+            log_error "ClientVersion is ahead of the released client"
+            echo ""
+            echo "  Pinned in client_assets.go: $pinned"
+            echo "  Latest @livetemplate/client: $latest"
+            echo ""
+            echo "$pinned is not published, so ClientScriptURL would 404 for every"
+            echo "application. Release the client first, or correct the pin."
+            exit 1
+            ;;
+    esac
+}
+
 # Bump version
 bump_version() {
     local current_version=$1
@@ -444,6 +533,7 @@ main() {
     echo ""
 
     check_prerequisites
+    check_client_pin
 
     # Check git status
     if [ -n "$(git status --porcelain)" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -157,6 +157,28 @@ version_order() {
 #
 # Nothing else catches this. The unit tests assert the pin is well-formed semver
 # and that the URL is HTTPS; a stale-but-valid pin passes both.
+# The highest published, non-pre-release @livetemplate/client version, bare
+# (no leading "v"), or empty if none can be determined.
+#
+# Takes the true semver max rather than trusting list order: `gh release list`
+# is ordered by creation time, so a patch to an older line published after a
+# newer minor would otherwise be read as "latest". --exclude-drafts /
+# --exclude-pre-releases drop those at the source; the end-anchored filter is
+# the belt to that suspenders, dropping any -rc/-beta tag (and any non-semver
+# junk, including the literal "null" an empty list can produce) that reaches us
+# regardless. Callers get a clean bare semver or nothing — no "null", no
+# pre-release, no v-prefix to strip.
+latest_client_release() {
+    gh release list --repo livetemplate/client \
+        --exclude-drafts --exclude-pre-releases \
+        --limit 30 --json tagName --jq '.[].tagName' 2>/dev/null \
+        | sed 's/^v//' \
+        | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+        | sort -V \
+        | tail -n1 \
+        || true
+}
+
 check_client_pin() {
     local pinned latest
     pinned=$(read_client_pin)
@@ -167,27 +189,26 @@ check_client_pin() {
         exit 1
     fi
 
-    latest=$(gh release list --repo livetemplate/client --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || true)
-    latest=${latest#v}
-
-    # Require a semver-shaped answer rather than merely a non-empty one. jq
-    # yields the literal string "null" when the release list is empty, which is
-    # non-empty, survives the "v" strip, and sorts *below* any real version — so
-    # a bare -z check would let it through and refuse the release citing
-    # "Latest: null". Anything unparseable is treated as no answer at all.
-    if ! printf '%s' "$latest" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
-        log_warn "SKIPPED the client-pin check — no usable version from the client repo"
-        log_warn "ClientVersion is $pinned; confirm by hand that it is current"
+    # version_order and latest_client_release both lean on `sort -V`. Absent it,
+    # sort still succeeds and returns a lexicographic order — silently wrong, and
+    # inside a [ ] test that `set -e` does not trap. Probe with a pair whose
+    # lexicographic and numeric orders disagree, and skip before making the
+    # lookup rather than trust a bad comparison.
+    if [ "$(printf '0.10.0\n0.9.0\n' | sort -V | head -1)" != "0.9.0" ]; then
+        log_warn "SKIPPED the client-pin check — this sort(1) lacks working -V"
+        log_warn "ClientVersion is $pinned; confirm it is current by hand"
         return 0
     fi
 
-    # version_order leans on `sort -V`. Absent it, sort still succeeds and
-    # returns a lexicographic order — silently wrong, and inside a [ ] test that
-    # `set -e` does not trap. Probe with a pair whose lexicographic and numeric
-    # orders disagree, and skip rather than trust a bad comparison.
-    if [ "$(printf '0.10.0\n0.9.0\n' | sort -V | head -1)" != "0.9.0" ]; then
-        log_warn "SKIPPED the client-pin check — this sort(1) lacks working -V"
-        log_warn "ClientVersion is $pinned, client released $latest; compare by hand"
+    latest=$(latest_client_release)
+
+    # Empty means the lookup found nothing usable: a network hiccup, no releases,
+    # or only drafts/pre-releases. None of that is evidence the pin is wrong, and
+    # blocking a release on a GitHub hiccup is worse than proceeding — but say
+    # SKIPPED rather than letting silence read as a pass.
+    if [ -z "$latest" ]; then
+        log_warn "SKIPPED the client-pin check — no published client release found"
+        log_warn "ClientVersion is $pinned; confirm it is current by hand"
         return 0
     fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -113,6 +113,29 @@ read_client_pin() {
         | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true
 }
 
+# Whether LVT_ALLOW_CLIENT_PIN_DRIFT opts out of the stale-pin refusal.
+#
+# Deliberately not a bare -n test. That treats every non-empty value as true,
+# so LVT_ALLOW_CLIENT_PIN_DRIFT=false — a natural way to write "disabled" in a
+# CI config — would silently enable the bypass and ship the stale pin this guard
+# exists to catch. Accepts the same vocabulary as parseBool in config.go, and
+# refuses to guess at anything else rather than defaulting either way.
+pin_drift_allowed() {
+    local raw
+    raw=$(printf '%s' "${LVT_ALLOW_CLIENT_PIN_DRIFT:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+
+    case "$raw" in
+        "")                return 1 ;;
+        true|1|yes|on)     return 0 ;;
+        false|0|no|off)    return 1 ;;
+        *)
+            log_error "LVT_ALLOW_CLIENT_PIN_DRIFT is set to '$LVT_ALLOW_CLIENT_PIN_DRIFT', which is neither true nor false"
+            echo "Use true/false or 1/0. Refusing to guess whether you meant to bypass the client-pin check."
+            exit 1
+            ;;
+    esac
+}
+
 # "same" | "older" | "newer", describing $1 relative to $2.
 version_order() {
     if [ "$1" = "$2" ]; then
@@ -177,7 +200,7 @@ check_client_pin() {
             # client release carrying a wire change this server cannot serve yet
             # should not be adopted. Not overridable for "newer": an unpublished
             # pin 404s for everyone, and no intent makes that right.
-            if [ -n "${LVT_ALLOW_CLIENT_PIN_DRIFT:-}" ]; then
+            if pin_drift_allowed; then
                 log_warn "ClientVersion $pinned trails the released $latest — proceeding (LVT_ALLOW_CLIENT_PIN_DRIFT set)"
                 return 0
             fi

--- a/scripts/test_release_client_pin.sh
+++ b/scripts/test_release_client_pin.sh
@@ -148,6 +148,36 @@ else
     fail "override must not bypass the 'newer' case — that URL 404s for everyone" "$out"
 fi
 
+# An empty release list makes `gh ... --jq '.[0].tagName'` emit the literal
+# string "null". It is non-empty, survives the "v" strip, and sorts BELOW any
+# real version — so a bare -z check would treat it as a valid answer and refuse
+# the release citing "Latest: null". Blocking on garbage is worse than skipping.
+out=$(run_guard "0.20.0" "null")
+if [[ "$out" == *"EXIT:0"* && "$out" == *"SKIPPED"* ]]; then
+    pass "a 'null' version is treated as no answer, not as a stale pin"
+else
+    fail "'null' must skip, not block" "$out"
+fi
+
+out=$(run_guard "0.20.0" "not-a-version")
+if [[ "$out" == *"EXIT:0"* && "$out" == *"SKIPPED"* ]]; then
+    pass "unparseable version skips rather than comparing"
+else
+    fail "garbage version must skip" "$out"
+fi
+
+# Without a working `sort -V`, sort still succeeds and returns a lexicographic
+# order — silently wrong, and inside a [ ] test that `set -e` does not trap. The
+# probe must notice. Simulated by stripping -V from the arguments.
+sort() { command sort "${@/-V/}"; }
+out=$(run_guard "0.9.0" "0.10.0")
+unset -f sort
+if [[ "$out" == *"EXIT:0"* && "$out" == *"SKIPPED"* && "$out" == *"-V"* ]]; then
+    pass "a sort(1) without -V skips instead of comparing wrongly"
+else
+    fail "missing sort -V must skip, not silently misorder" "$out"
+fi
+
 # A lookup failure is not a pass. Blocking on a GitHub hiccup would be worse
 # than proceeding, but the output has to say the check did not run.
 cat > client_assets.go <<'EOF'

--- a/scripts/test_release_client_pin.sh
+++ b/scripts/test_release_client_pin.sh
@@ -169,13 +169,66 @@ fi
 # Without a working `sort -V`, sort still succeeds and returns a lexicographic
 # order — silently wrong, and inside a [ ] test that `set -e` does not trap. The
 # probe must notice. Simulated by stripping -V from the arguments.
-sort() { command sort "${@/-V/}"; }
+# Drop -V entirely rather than "${@/-V/}", which substitutes an empty string but
+# leaves it as an argument — GNU sort then reads "" as a filename and errors,
+# which happens to satisfy the probe for the wrong reason and leaks stderr into
+# the captured output. Filtering gives a real lexicographic sort of stdin.
+sort() {
+    local a args=()
+    for a in "$@"; do [ "$a" = "-V" ] || args+=("$a"); done
+    command sort "${args[@]}"
+}
 out=$(run_guard "0.9.0" "0.10.0")
 unset -f sort
 if [[ "$out" == *"EXIT:0"* && "$out" == *"SKIPPED"* && "$out" == *"-V"* ]]; then
     pass "a sort(1) without -V skips instead of comparing wrongly"
 else
     fail "missing sort -V must skip, not silently misorder" "$out"
+fi
+
+# An unreadable pin must stop the release outright: without a version there is
+# nothing to compare, and proceeding would ship whatever the constant now says.
+cat > client_assets.go <<'EOF'
+package livetemplate
+
+const (
+    ClientVersion = "0.20.0"
+)
+EOF
+out=$(guard_result)
+if [[ "$out" == *"EXIT:1"* && "$out" == *"Could not read ClientVersion"* ]]; then
+    pass "a reformatted const block stops the release rather than passing"
+else
+    fail "unreadable pin must exit 1" "$out"
+fi
+
+# The dangerous direction: a value meaning "off" must not enable the bypass.
+out=$(LVT_ALLOW_CLIENT_PIN_DRIFT=false run_guard "0.18.2" "0.20.0")
+if [[ "$out" == *"EXIT:1"* && "$out" == *"behind"* ]]; then
+    pass "LVT_ALLOW_CLIENT_PIN_DRIFT=false does NOT bypass the guard"
+else
+    fail "a 'false' override must not let a stale pin through" "$out"
+fi
+
+out=$(LVT_ALLOW_CLIENT_PIN_DRIFT=0 run_guard "0.18.2" "0.20.0")
+if [[ "$out" == *"EXIT:1"* && "$out" == *"behind"* ]]; then
+    pass "LVT_ALLOW_CLIENT_PIN_DRIFT=0 does NOT bypass the guard"
+else
+    fail "a '0' override must not let a stale pin through" "$out"
+fi
+
+out=$(LVT_ALLOW_CLIENT_PIN_DRIFT=true run_guard "0.18.2" "0.20.0")
+if [[ "$out" == *"EXIT:0"* && "$out" == *"proceeding"* ]]; then
+    pass "LVT_ALLOW_CLIENT_PIN_DRIFT=true is honoured, not silently ignored"
+else
+    fail "'true' should work as an override" "$out"
+fi
+
+out=$(LVT_ALLOW_CLIENT_PIN_DRIFT=banana run_guard "0.18.2" "0.20.0")
+if [[ "$out" == *"EXIT:1"* && "$out" == *"neither true nor false"* ]]; then
+    pass "an unparseable override errors rather than guessing"
+else
+    fail "unparseable override must not be assumed either way" "$out"
 fi
 
 # A lookup failure is not a pass. Blocking on a GitHub hiccup would be worse

--- a/scripts/test_release_client_pin.sh
+++ b/scripts/test_release_client_pin.sh
@@ -75,7 +75,53 @@ else
 fi
 
 echo ""
-echo "3️⃣  check_client_pin decisions"
+echo "3️⃣  latest_client_release selection"
+# gh is stubbed to emit tag lines; the flags it would pass to filter drafts and
+# pre-releases are bypassed by the stub, so these assert the shell-side safety
+# net (end-anchored bare-semver filter + true semver max), which is what runs
+# regardless of whether the flags took effect.
+
+# Ordered by creation time, gh could return an older line last; the max must win
+# over list order.
+gh() { printf 'v0.19.1\nv0.20.0\nv0.18.2\n'; }
+got=$(latest_client_release)
+if [ "$got" = "0.20.0" ]; then
+    pass "picks the semver max, not the list order"
+else
+    fail "latest_client_release → '$got' (want 0.20.0)" ""
+fi
+
+# 0.10.0 must outrank 0.9.0 — the case a lexicographic max gets wrong.
+gh() { printf 'v0.9.0\nv0.10.0\n'; }
+got=$(latest_client_release)
+if [ "$got" = "0.10.0" ]; then
+    pass "0.10.0 outranks 0.9.0 (numeric, not lexicographic)"
+else
+    fail "latest_client_release → '$got' (want 0.10.0)" ""
+fi
+
+# A pre-release-suffixed tag that slips past the --exclude flag is dropped by the
+# end-anchored filter rather than fed into the comparison.
+gh() { printf 'v0.21.0-rc.1\nv0.20.0\n'; }
+got=$(latest_client_release)
+if [ "$got" = "0.20.0" ]; then
+    pass "a -rc pre-release is excluded, not treated as newest"
+else
+    fail "latest_client_release → '$got' (want 0.20.0)" ""
+fi
+
+# Nothing usable → empty, which check_client_pin turns into a SKIP.
+gh() { printf ''; }
+got=$(latest_client_release)
+if [ -z "$got" ]; then
+    pass "no usable tags → empty"
+else
+    fail "latest_client_release → '$got' (want empty)" ""
+fi
+unset -f gh
+
+echo ""
+echo "4️⃣  check_client_pin decisions"
 # Stub the lookup rather than hitting the network. Redefining gh keeps
 # check_client_pin itself under test, including its ${latest#v} handling.
 run_guard() {

--- a/scripts/test_release_client_pin.sh
+++ b/scripts/test_release_client_pin.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Tests the client-pin guard in release.sh: version ordering, reading the pin
+# out of client_assets.go, and the decision the guard makes for each case.
+#
+# Sources release.sh with RELEASE_SH_LIB=1 so the functions are defined without
+# main() running. No network — check_client_pin's lookup is stubbed.
+
+set -e
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIR=$(mktemp -d)
+
+failures=0
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; echo "$2" | sed 's/^/      /'; failures=$((failures + 1)); }
+
+# Source before installing the cleanup trap: release.sh registers its own EXIT
+# trap at top level, which would otherwise replace ours and leak TMPDIR.
+# shellcheck source=/dev/null
+RELEASE_SH_LIB=1 source "$PROJECT_ROOT/scripts/release.sh"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🔥 Testing release.sh client-pin guard..."
+
+echo ""
+echo "1️⃣  version_order"
+check_order() {
+    local got
+    got=$(version_order "$1" "$2")
+    if [ "$got" = "$3" ]; then
+        pass "$1 vs $2 → $3"
+    else
+        fail "$1 vs $2 → $got (want $3)" ""
+    fi
+}
+check_order "0.20.0" "0.20.0" same
+check_order "0.18.2" "0.20.0" older
+check_order "0.20.0" "0.18.2" newer
+# Numeric, not lexicographic — the case a plain string compare gets wrong.
+check_order "0.9.0"  "0.10.0" older
+check_order "0.20.9" "0.20.10" older
+check_order "1.0.0"  "0.99.99" newer
+
+echo ""
+echo "2️⃣  read_client_pin"
+cd "$TMPDIR"
+cat > client_assets.go <<'EOF'
+package livetemplate
+
+// ClientVersion is the version of the @livetemplate/client browser bundle.
+const ClientVersion = "0.20.0"
+
+const clientCDNBase = "https://cdn.jsdelivr.net/npm/@livetemplate/client@" + ClientVersion
+EOF
+got=$(read_client_pin)
+if [ "$got" = "0.20.0" ]; then
+    pass "reads the constant"
+else
+    fail "read_client_pin → '$got' (want 0.20.0)" ""
+fi
+
+# The godoc above the constant mentions other versions in prose in the real
+# file; the anchor is the assignment line, not the first version-shaped string.
+cat > client_assets.go <<'EOF'
+package livetemplate
+
+// Bumped from 0.18.2; see the 0.19.1 release notes for why 9.9.9 is not used.
+const ClientVersion = "0.20.0"
+EOF
+got=$(read_client_pin)
+if [ "$got" = "0.20.0" ]; then
+    pass "ignores versions mentioned in surrounding comments"
+else
+    fail "read_client_pin → '$got' (want 0.20.0)" ""
+fi
+
+echo ""
+echo "3️⃣  check_client_pin decisions"
+# Stub the lookup rather than hitting the network. Redefining gh keeps
+# check_client_pin itself under test, including its ${latest#v} handling.
+run_guard() {
+    local pinned=$1
+    # Deliberately NOT a local named `latest`: check_client_pin declares its own
+    # `local latest`, and bash's dynamic scoping means the stub would read that
+    # (empty, mid-assignment) instead of ours. A global name cannot be shadowed.
+    STUB_LATEST=$2
+    cat > client_assets.go <<EOF
+package livetemplate
+
+const ClientVersion = "$pinned"
+EOF
+    gh() { echo "v$STUB_LATEST"; }
+    guard_result
+}
+
+# Run check_client_pin and emit its output followed by EXIT:<status>. Cannot be
+# a subshell ending in `echo "EXIT:$?"`: check_client_pin calls `exit 1`, which
+# terminates the subshell before that echo ever runs — the status would be lost
+# and `set -e` would kill the harness at the assignment.
+guard_result() {
+    local out rc
+    set +e
+    out=$(check_client_pin 2>&1)
+    rc=$?
+    set -e
+    printf '%s\nEXIT:%d\n' "$out" "$rc"
+}
+
+out=$(run_guard "0.20.0" "0.20.0")
+if [[ "$out" == *"EXIT:0"* && "$out" == *"Client pin is current"* ]]; then
+    pass "matching pin passes"
+else
+    fail "matching pin should pass" "$out"
+fi
+
+out=$(run_guard "0.18.2" "0.20.0")
+if [[ "$out" == *"EXIT:1"* && "$out" == *"behind"* ]]; then
+    pass "stale pin blocks the release"
+else
+    fail "stale pin should block" "$out"
+fi
+# The regression this guard exists for, named explicitly: 0.18.2 pinned while
+# 0.20.0 was published is exactly what shipped between #452 and #515.
+if [[ "$out" == *"0.18.2"* && "$out" == *"0.20.0"* ]]; then
+    pass "message names both versions"
+else
+    fail "message should name both versions" "$out"
+fi
+
+out=$(LVT_ALLOW_CLIENT_PIN_DRIFT=1 run_guard "0.18.2" "0.20.0")
+if [[ "$out" == *"EXIT:0"* && "$out" == *"proceeding"* ]]; then
+    pass "override lets a deliberate lag through"
+else
+    fail "override should allow a stale pin" "$out"
+fi
+
+out=$(run_guard "0.21.0" "0.20.0")
+if [[ "$out" == *"EXIT:1"* && "$out" == *"ahead"* ]]; then
+    pass "unpublished pin blocks the release"
+else
+    fail "unpublished pin should block" "$out"
+fi
+
+out=$(LVT_ALLOW_CLIENT_PIN_DRIFT=1 run_guard "0.21.0" "0.20.0")
+if [[ "$out" == *"EXIT:1"* ]]; then
+    pass "override does NOT excuse an unpublished pin"
+else
+    fail "override must not bypass the 'newer' case — that URL 404s for everyone" "$out"
+fi
+
+# A lookup failure is not a pass. Blocking on a GitHub hiccup would be worse
+# than proceeding, but the output has to say the check did not run.
+cat > client_assets.go <<'EOF'
+package livetemplate
+
+const ClientVersion = "0.20.0"
+EOF
+gh() { return 1; }
+out=$(guard_result)
+if [[ "$out" == *"EXIT:0"* && "$out" == *"SKIPPED"* ]]; then
+    pass "unreachable lookup skips loudly rather than passing silently"
+else
+    fail "lookup failure should warn SKIPPED and continue" "$out"
+fi
+
+echo ""
+if [ "$failures" -ne 0 ]; then
+    echo "❌ $failures check(s) failed"
+    exit 1
+fi
+echo "✅ All client-pin checks passed"


### PR DESCRIPTION
Closes #515.

## Why

`ClientVersion` decides which bundle every application on the documented `<script src="{{ .ClientScriptURL }}">` path loads. Nothing checked that it was current, and it sat at **0.18.2 across two core releases** while the client shipped 0.19.1 and 0.20.0 — so the upload field-serialization fix (#452) was published to npm and reached nobody through the library's own path. A security fix shipped but not delivered. Corrected in #514; this is the guard so it cannot recur.

The existing unit tests assert the pin is **well-formed** semver and that the URL is HTTPS. A stale-but-valid pin passes both — which is exactly how this survived. The only real control was a *"Maintainers: bump this"* line in the constant's godoc, i.e. someone remembering.

## What it does

`release.sh` compares the pin against the client's latest release, before anything else happens:

| State | Behaviour |
|---|---|
| equal | proceed |
| **behind** | refuse — names both versions and the bump to make |
| **ahead** | refuse — that version is unpublished, so the URL 404s |

Two deliberate asymmetries:

- **`behind` is overridable** (`LVT_ALLOW_CLIENT_PIN_DRIFT=1`). Staying behind is occasionally correct — a client release carrying a wire change this server can't serve yet shouldn't be adopted. **`ahead` is not overridable**: no intent makes a 404 right.
- **A failed lookup does not block the release.** Blocking on a GitHub API hiccup would be worse than proceeding — but it reports `SKIPPED` rather than letting silence read as a pass. That distinction is itself tested.

## Verification

**Against the real regression, with a live lookup.** Set the pin back to 0.18.2 and ran `--dry-run`:

```
✗ ClientVersion is behind the released client

  Pinned in client_assets.go: 0.18.2
  Latest @livetemplate/client: 0.20.0

ClientScriptURL is built from this constant, so releasing now ships
0.18.2 to every application using the documented <script> path — any
client fix released since then reaches nobody.

Bump ClientVersion to 0.20.0 and re-run. If this release is meant to
stay on 0.18.2 (e.g. 0.20.0 carries a wire change this server cannot
serve yet), re-run with LVT_ALLOW_CLIENT_PIN_DRIFT=1.
```

The current 0.20.0 pin passes: `✓ Client pin is current (0.20.0)`.

**`scripts/test_release_client_pin.sh`** — 15 checks covering version ordering (including `0.9.0 < 0.10.0`, which a string compare gets wrong), the pin parse, and all five decisions including both override cases. 0 failures in 15 consecutive runs.

Two bugs found and fixed while writing those tests, both worth knowing about:

- The `gh` stub read the wrong variable. `check_client_pin` declares `local latest`, and bash's dynamic scoping meant the stub resolved *that* — empty, mid-assignment — instead of the test's. A test then passed **spuriously**, because the skip message happens to contain the word "current".
- The result helper couldn't be a subshell ending in `echo "EXIT:$?"`: `check_client_pin` calls `exit 1`, which terminates the subshell before that line runs, losing the status and killing the harness via `set -e`.

## Note

Like the other shell tests, this doesn't run in CI — #513 tracks that, and it applies here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG