### PR TITLE
test(topic): fix load-flaky WS panic in cross-instance await helpers

### DIFF
--- a/topic_cross_instance_test.go
+++ b/topic_cross_instance_test.go
@@ -50,32 +50,13 @@ func setupTopicServerH(t *testing.T, ctrl interface{}, st State, tmplStr string,
 	return server, wsURL, h
 }
 
-// awaitWSContains retries trigger every ~150ms until ws yields a frame whose
+// awaitWSContains re-drives trigger every ~150ms until ws yields a frame whose
 // raw body contains want, or the deadline elapses. The retry absorbs Redis
 // SUBSCRIBE-propagation latency without a brittle fixed sleep (the publish is
 // re-sent, so a delivery lost before the SUBSCRIBE landed is simply re-driven).
-//
-// It substring-matches the raw frame rather than asserting tree[slot]==want on
-// purpose: a tree update carries only the CHANGED dynamics and the value may be
-// nested, so a raw-body contains check is the robust signal that the value
-// landed end-to-end (which is all these cross-instance tests need to assert).
 func awaitWSContains(t *testing.T, ws *websocket.Conn, want string, trigger func()) {
 	t.Helper()
-	deadline := time.Now().Add(8 * time.Second)
-	for time.Now().Before(deadline) {
-		trigger()
-		if err := ws.SetReadDeadline(time.Now().Add(150 * time.Millisecond)); err != nil {
-			t.Fatalf("SetReadDeadline failed: %v", err)
-		}
-		_, msg, err := ws.ReadMessage()
-		if err != nil {
-			continue // no delivery yet — re-trigger
-		}
-		if strings.Contains(string(msg), want) {
-			return
-		}
-	}
-	t.Fatalf("timed out waiting for WS frame containing %q", want)
+	awaitWSFrame(t, ws, want, "", 150*time.Millisecond, trigger)
 }
 
 // --- shared cross-instance fixtures ---

--- a/topic_cross_instance_test.go
+++ b/topic_cross_instance_test.go
@@ -54,6 +54,9 @@ func setupTopicServerH(t *testing.T, ctrl interface{}, st State, tmplStr string,
 // raw body contains want, or the deadline elapses. The retry absorbs Redis
 // SUBSCRIBE-propagation latency without a brittle fixed sleep (the publish is
 // re-sent, so a delivery lost before the SUBSCRIBE landed is simply re-driven).
+//
+// Call at most once per connection — it dedicates a reader goroutine to ws (see
+// wsFrameReader).
 func awaitWSContains(t *testing.T, ws *websocket.Conn, want string, trigger func()) {
 	t.Helper()
 	awaitWSFrame(t, ws, want, "", 150*time.Millisecond, trigger)

--- a/topic_wildcard_test.go
+++ b/topic_wildcard_test.go
@@ -331,6 +331,9 @@ func TestTopic_V17_CrossInstance_PSubscribeDelivery(t *testing.T) {
 // republishes both want and reject, so a slower cadence narrows the window in
 // which a stale reject frame could arrive. The retry is a propagation guard,
 // not a load driver — normally one iteration.
+//
+// Call at most once per connection — it dedicates a reader goroutine to ws (see
+// wsFrameReader).
 func awaitWSContainsRejecting(t *testing.T, ws *websocket.Conn, want, reject string, trigger func()) {
 	t.Helper()
 	awaitWSFrame(t, ws, want, reject, 400*time.Millisecond, trigger)

--- a/topic_wildcard_test.go
+++ b/topic_wildcard_test.go
@@ -326,32 +326,14 @@ func TestTopic_V17_CrossInstance_PSubscribeDelivery(t *testing.T) {
 }
 
 // awaitWSContainsRejecting is awaitWSContains plus a forbidden-substring guard:
-// succeed when a frame contains want, FAIL if one contains reject first. Same
-// reliability profile as awaitWSContains; the 400ms per-read deadline (vs
-// awaitWSContains's 150ms) narrows the stale-frame window since the retry
-// republishes both want and reject. The retry is a propagation guard, not a
-// load driver — normally one iteration.
+// succeed when a frame contains want, FAIL if one contains reject first. It
+// re-triggers less often than awaitWSContains (400ms vs 150ms): each retry
+// republishes both want and reject, so a slower cadence narrows the window in
+// which a stale reject frame could arrive. The retry is a propagation guard,
+// not a load driver — normally one iteration.
 func awaitWSContainsRejecting(t *testing.T, ws *websocket.Conn, want, reject string, trigger func()) {
 	t.Helper()
-	deadline := time.Now().Add(8 * time.Second)
-	for time.Now().Before(deadline) {
-		trigger()
-		if err := ws.SetReadDeadline(time.Now().Add(400 * time.Millisecond)); err != nil {
-			t.Fatalf("SetReadDeadline failed: %v", err)
-		}
-		_, msg, err := ws.ReadMessage()
-		if err != nil {
-			continue
-		}
-		body := string(msg)
-		if strings.Contains(body, reject) {
-			t.Fatalf("forbidden frame containing %q arrived: %s", reject, body)
-		}
-		if strings.Contains(body, want) {
-			return
-		}
-	}
-	t.Fatalf("timed out waiting for WS frame containing %q", want)
+	awaitWSFrame(t, ws, want, reject, 400*time.Millisecond, trigger)
 }
 
 // TestTopic_V17_CrossInstance_OverDeliveryRejected: B subscribes room/* →

--- a/ws_test_helpers_test.go
+++ b/ws_test_helpers_test.go
@@ -3,10 +3,125 @@ package livetemplate
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
+
+// wsFrameReader starts a goroutine that reads frames from ws and returns a
+// channel of their bodies, closed when the connection errors or closes.
+//
+// The reader sets NO per-read deadline on purpose. gorilla/websocket poisons a
+// connection after ANY read error — a read-deadline timeout included, since
+// hideTempErr still records it in c.readErr — and there is no way to clear that
+// state. A retry loop that calls SetReadDeadline + ReadMessage and continues on
+// error therefore fast-spins on the poisoned conn (each ReadMessage returns the
+// stored error immediately) until gorilla's readErrCount>=1000 guard panics
+// "repeated read on failed websocket connection". That only bites when a frame
+// arrives slower than the deadline, i.e. under CPU load, which made it a
+// load-flaky panic. A single blocking read with no deadline never times out, so
+// it never poisons the conn; callers re-drive delivery with their own ticker.
+//
+// It also clears any deadline connectWS left set for the initial-render read so
+// the blocking read below does not inherit a stale one. t.Cleanup closes ws so
+// the goroutine always unblocks by test end.
+func wsFrameReader(t *testing.T, ws *websocket.Conn) <-chan string {
+	t.Helper()
+	if err := ws.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear read deadline: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+	frames := make(chan string, 16)
+	go func() {
+		defer close(frames)
+		for {
+			_, msg, err := ws.ReadMessage()
+			if err != nil {
+				return
+			}
+			select {
+			case frames <- string(msg):
+			default: // consumer done or momentarily behind — a re-trigger re-drives
+			}
+		}
+	}()
+	return frames
+}
+
+// awaitWSFrame drives trigger once, re-drives it every retrigger to absorb Redis
+// SUBSCRIBE-propagation latency, and returns when a frame read from ws contains
+// want. It fails the test if a frame contains reject first (pass "" to disable
+// that guard), if ws closes, or if the overall 8s deadline elapses.
+//
+// It substring-matches the raw frame rather than asserting tree[slot]==want on
+// purpose: a tree update carries only the CHANGED dynamics and the value may be
+// nested, so a raw-body contains check is the robust signal that the value
+// landed end-to-end (all these cross-instance tests need to assert).
+func awaitWSFrame(t *testing.T, ws *websocket.Conn, want, reject string, retrigger time.Duration, trigger func()) {
+	t.Helper()
+	frames := wsFrameReader(t, ws)
+	overall := time.NewTimer(8 * time.Second)
+	defer overall.Stop()
+	tick := time.NewTicker(retrigger)
+	defer tick.Stop()
+
+	trigger()
+	for {
+		select {
+		case body, ok := <-frames:
+			if !ok {
+				t.Fatalf("WS closed before a frame containing %q arrived", want)
+			}
+			if reject != "" && strings.Contains(body, reject) {
+				t.Fatalf("forbidden frame containing %q arrived: %s", reject, body)
+			}
+			if strings.Contains(body, want) {
+				return
+			}
+		case <-tick.C:
+			trigger()
+		case <-overall.C:
+			t.Fatalf("timed out waiting for WS frame containing %q", want)
+		}
+	}
+}
+
+// TestWSFrameReader_SurvivesSlowFrame is the regression guard for the load-flaky
+// panic that wsFrameReader fixes. It drives awaitWSContains against a server
+// that sends the awaited frame only after 600ms — far longer than the 150ms
+// per-read deadline the previous SetReadDeadline+retry helper used. With that
+// old helper the first read timed out, poisoned the gorilla connection, and the
+// retry loop fast-spun to the "repeated read on failed websocket connection"
+// panic (readErrCount>=1000). wsFrameReader sets no per-read deadline, so the
+// slow frame is simply delivered when it arrives.
+func TestWSFrameReader_SurvivesSlowFrame(t *testing.T) {
+	up := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		time.Sleep(600 * time.Millisecond)
+		_ = c.WriteMessage(websocket.TextMessage, []byte(`{"tree":{"0":"late-hello"}}`))
+		time.Sleep(2 * time.Second) // hold open so the reader goroutine can deliver
+	}))
+	defer srv.Close()
+
+	ws, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = ws.Close() }()
+
+	// The server sends unprompted, so trigger is a no-op; the assertion is that
+	// the 600ms-delayed frame is delivered without a panic.
+	awaitWSContains(t, ws, "late-hello", func() {})
+}
 
 // sendWSAction sends an action message over the WebSocket, matching the
 // wire format the client uses.

--- a/ws_test_helpers_test.go
+++ b/ws_test_helpers_test.go
@@ -29,6 +29,12 @@ import (
 // It also clears any deadline connectWS left set for the initial-render read so
 // the blocking read below does not inherit a stale one. t.Cleanup closes ws so
 // the goroutine always unblocks by test end.
+//
+// Call at most once per connection: the goroutine owns ws.ReadMessage for the
+// connection's lifetime, and gorilla/websocket forbids concurrent reads — a
+// second reader on the same conn is a data race. Every current caller awaits a
+// given conn once; a test needing two sequential frames should keep reading the
+// single returned channel rather than starting another reader.
 func wsFrameReader(t *testing.T, ws *websocket.Conn) <-chan string {
 	t.Helper()
 	if err := ws.SetReadDeadline(time.Time{}); err != nil {


### PR DESCRIPTION
## TL;DR — a gorilla read-deadline antipattern, not a container race

This started as an investigation into a flaky panic that looked like a testcontainer/teardown race under concurrent load. **The root cause turned out to be a `gorilla/websocket` antipattern in two test helpers** — which is why the diff is three test files, not container-lifecycle code.

## Symptom

`TestTopic_V8_…CrossInstance` (and the `awaitWSContains` / `awaitWSContainsRejecting` helper class) intermittently panicked `repeated read on failed websocket connection` during the full `go test ./...` run — never in isolation (passed 4/4 alone).

## Root cause (proven, not inferred)

The helpers looped `SetReadDeadline(150ms)` + `ReadMessage`, doing `continue` on any error:

```go
for time.Now().Before(deadline) {
    trigger()
    ws.SetReadDeadline(time.Now().Add(150 * time.Millisecond))
    _, msg, err := ws.ReadMessage()
    if err != nil { continue }   // ← poisons on the first timeout
    ...
}
```

gorilla records a read-deadline **timeout** in `c.readErr` (via `hideTempErr`, which wraps but still returns the error), and there is **no way to clear it**. Once poisoned, every `ReadMessage` returns the stored error *immediately*, so the loop fast-spins and gorilla's `readErrCount >= 1000` guard panics (`conn.go:1030`). This only triggers when a frame arrives slower than the 150ms deadline — i.e. under CPU saturation during the concurrent `./...` run — which is exactly why it masqueraded as a load/container race.

Evidence:
- **Source**: `NextReader`'s `for c.readErr == nil` loop is skipped once `readErr` is set; `SetReadDeadline` doesn't touch `readErr`.
- **Deterministic repro** (load-independent): `SetReadDeadline(1ms)` + retry-loop `ReadMessage` against a silent server panics with the exact string in <1s.
- **Negative control**: a targeted high-churn container repro (topic×6 ‖ pubsub×4) did **not** reproduce it — ruling out churn as the cause.

## Fix

A single reader goroutine (`wsFrameReader`) owns `ReadMessage` with **no per-read deadline**, so it never times out and never poisons the conn. The wait loop `select`s on the delivered-frame channel vs a re-trigger ticker vs one overall 8s deadline. `awaitWSContains` / `awaitWSContainsRejecting` collapse to thin wrappers over a shared `awaitWSFrame`.

`wsFrameReader` also clears the stale deadline `connectWS` leaves set for the initial-render read, and closes `ws` via `t.Cleanup` so the reader goroutine always exits.

## Regression guard

`TestWSFrameReader_SurvivesSlowFrame` delivers a 600ms-delayed frame without panicking. Verified it **discriminates**: the pre-fix helper panics on that same input (throwaway control), the new helper passes.

## Verification

- Full `go test ./...` — green
- `go test -race -run 'TestTopic|TestWSFrameReader' -count=2` — 0 data races, 0 panics (matches CI's `-race` job; no double-reader-on-one-conn since each test awaits one conn once)
- Topic tests ×8 under **all-core CPU saturation** — 0 panics (the exact condition that exposed the flake)

## Context

Surfaced while wiring release-script tests into CI (#513 / #517); split out as its own PR since it's an unrelated, pre-existing flake on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)