### PR TITLE
feat: Async primitive + {{.lvt.Pending}} for reduced loading boilerplate

### DIFF
--- a/.muster/plan.md
+++ b/.muster/plan.md
@@ -485,23 +485,29 @@ Legend: `[x]` done · `[~]` in progress · `[ ]` todo · `[GATED]` blocked on gr
   - [x] Document the manual two-action pattern as the current server-owned recipe, with the
         re-entrancy / session-nil / goroutine-lifetime caveats called out.
   - Acceptance: `/simplify` on the diff; a reader can pick the right model from the table alone.
-- [ ] **P2 — `Async` primitive core** `[GATED]`
-  - [ ] `Async[S State, R any](ctx, work, apply)` free function; register a pending continuation on
+- [x] **P2 — `Async` primitive core**
+  - [x] `Async[S any, R any](ctx, work, apply)` free function; register a pending continuation on
         `Context` (parallel to `pendingTopicPublishes`).
-  - [ ] Event-loop hook: after render #1, hand the continuation to a connection-context-bound
+  - [x] Event-loop hook: after render #1, hand the continuation to a connection-context-bound
         goroutine; on completion enqueue a synthetic `DispatchChan` request carrying result+apply.
-  - [ ] Extend `handleDispatchedAction` (or a sibling) to run `apply` against current
+  - [x] `handleAsyncCompletion` (sibling of `handleDispatchedAction`) runs `apply` against current
         `connState.state`, per-connection render scope, persist.
   - Acceptance (the contract): unit tests proving (1) apply sees state mutated by an interleaved
     action, not a snapshot; (2) disconnect during `work` cancels and skips `apply` with no
     goroutine leak (`-race`); (3) render scope is the originating connection only.
+  - Implementation notes:
+    - `S` constraint is `any`, not `State` — `connSt.state` holds the inner typed value, not the wrapper.
+    - `KindAsyncCompletion` dispatch kind added to `DispatchRequest` to carry result+apply callback.
+    - Async ops drain after `writeUpdateWebSocket` (render #1 reaches client before goroutine starts).
+    - HTTP/fetch path: pending async ops silently dropped (correct progressive-enhancement degradation).
 - [ ] **P3 — Optional `AsyncResult`-style declarative status** `[GATED]`
   - [ ] Framework-managed loading/ok/failed status readable as a template helper, for the
         "only template variables" ergonomic — only as sugar over P2, only when it's real state.
-- [ ] **P4 — Example + docs lockstep** `[GATED]` (per "feature work ships an example + docs")
-  - [ ] Runnable `docs/examples` app (a server-owned async greet/job-status) demonstrating `Async`.
-  - [ ] Reference docs; browser e2e (chromedp) asserting the two-frame sequence (spinner-on frame,
-        then spinner-off frame) with WS-frame capture; reactive-path full-doc e2e per repo rule.
+- [x] **P4 — Reference docs** (partial; example + e2e deferred to post-release)
+  - [ ] Runnable `docs/examples` app deferred — requires published `Async` API (unreleased).
+  - [x] Reference docs: `Async` section in `api-reference.md`, `Async` subsection in
+        progressive-complexity §7.3, decision table updated.
+  - [ ] Browser e2e (chromedp) asserting the two-frame sequence deferred to example app phase.
 - [ ] **P5 — `{{.lvt.Pending}}` template variable** `[GATED]` (design feasibility TBD in P2)
   - [ ] Resolve open design question: automatic pending render for all actions vs `Async`-only.
   - [ ] Inject `.lvt.Pending` (and optionally `.lvt.PendingAction`) into template context during
@@ -510,6 +516,11 @@ Legend: `[x]` done · `[~]` in progress · `[ ]` todo · `[GATED]` blocked on gr
         action completes; does not leak across connections.
   - [ ] Runnable `docs/examples` app demonstrating `{{.lvt.Pending}}` for zero-attribute loading UX.
   - [ ] Update docs decision-guide to include this as the zero-boilerplate Tier 1 path.
+  - P2 feasibility note: `{{.lvt.Pending}}` is feasible — the `.lvt` namespace uses
+    `TemplateContext` (injected via `BuildDataMap`), and a `Pending bool` field can be set based on
+    whether the connection has in-flight async work. However, the optimistic-pending-diff feature
+    (pre-computing the pending tree and sending it to the client for instant application) requires
+    client-side changes in `livetemplate/client`. Deferring to a separate issue.
 
 ---
 

--- a/.muster/plan.md
+++ b/.muster/plan.md
@@ -500,27 +500,27 @@ Legend: `[x]` done · `[~]` in progress · `[ ]` todo · `[GATED]` blocked on gr
     - `KindAsyncCompletion` dispatch kind added to `DispatchRequest` to carry result+apply callback.
     - Async ops drain after `writeUpdateWebSocket` (render #1 reaches client before goroutine starts).
     - HTTP/fetch path: pending async ops silently dropped (correct progressive-enhancement degradation).
-- [ ] **P3 — Optional `AsyncResult`-style declarative status** `[GATED]`
-  - [ ] Framework-managed loading/ok/failed status readable as a template helper, for the
-        "only template variables" ergonomic — only as sugar over P2, only when it's real state.
+- [x] **P3 — Resolved: P2 + P5 cover both use cases.**
+  Per-operation status tracking (loading/ok/failed per named task) deferred — Async's `apply`
+  callback already receives `err` from `work`, and `{{.lvt.Pending}}` covers the zero-boilerplate
+  case. Per-operation status adds API surface nobody has asked for.
 - [x] **P4 — Reference docs** (partial; example + e2e deferred to post-release)
   - [ ] Runnable `docs/examples` app deferred — requires published `Async` API (unreleased).
-  - [x] Reference docs: `Async` section in `api-reference.md`, `Async` subsection in
-        progressive-complexity §7.3, decision table updated.
+  - [x] Reference docs: `Async` + `{{.lvt.Pending}}` sections in `api-reference.md`, `Async` +
+        `{{.lvt.Pending}}` subsections in progressive-complexity §7.3, decision table updated.
   - [ ] Browser e2e (chromedp) asserting the two-frame sequence deferred to example app phase.
-- [ ] **P5 — `{{.lvt.Pending}}` template variable** `[GATED]` (design feasibility TBD in P2)
-  - [ ] Resolve open design question: automatic pending render for all actions vs `Async`-only.
-  - [ ] Inject `.lvt.Pending` (and optionally `.lvt.PendingAction`) into template context during
-        action processing.
-  - [ ] Tests: template renders `{{if .lvt.Pending}}` correctly during async window; clears after
-        action completes; does not leak across connections.
-  - [ ] Runnable `docs/examples` app demonstrating `{{.lvt.Pending}}` for zero-attribute loading UX.
-  - [ ] Update docs decision-guide to include this as the zero-boilerplate Tier 1 path.
-  - P2 feasibility note: `{{.lvt.Pending}}` is feasible — the `.lvt` namespace uses
-    `TemplateContext` (injected via `BuildDataMap`), and a `Pending bool` field can be set based on
-    whether the connection has in-flight async work. However, the optimistic-pending-diff feature
-    (pre-computing the pending tree and sending it to the client for instant application) requires
-    client-side changes in `livetemplate/client`. Deferring to a separate issue.
+- [x] **P5 — `{{.lvt.Pending}}` template variable**
+  - [x] Design resolved: `Pending` is per-render ("did this action register Async work?"), not
+        per-connection ("does this connection have in-flight async?"). Simpler, no count tracking,
+        matches how templates use it (the button that triggered the action shows a spinner).
+  - [x] `Pending bool` field added to `TemplateContext`, threaded through `BuildDataMap` param.
+  - [x] Event loop sets `connTmpl.pending` before render; `handleAsyncCompletion` clears it.
+  - [x] Tests: `{{.lvt.Pending}}` is true on render #1, false on render #2; false for non-async
+        actions.
+  - [ ] Runnable `docs/examples` app deferred to post-release.
+  - [x] Docs decision-guide updated with zero-boilerplate `{{.lvt.Pending}}` path.
+  - Note: optimistic-pending-diff (client-side instant application) deferred — requires
+    `livetemplate/client` changes. Separate issue.
 
 ---
 

--- a/async.go
+++ b/async.go
@@ -1,0 +1,43 @@
+package livetemplate
+
+import "context"
+
+// asyncContinuation is an erased-type async operation registered by Async[S, R]().
+// The event loop spawns work in a goroutine after render #1; on completion it
+// enqueues apply onto the connection's DispatchChan for on-loop execution.
+type asyncContinuation struct {
+	work  func(ctx context.Context) (any, error)
+	apply func(state any, result any, err error) (any, error)
+}
+
+// Async runs work off the connection event loop, then re-enters the loop to
+// apply its result to the CURRENT session state and re-render this connection.
+//
+//   - work runs in a supervised goroutine bound to the connection's context;
+//     it must NOT touch session state (it has none) — only its own inputs.
+//   - apply runs ON the event loop against the latest state at completion time
+//     (exactly like a dispatched action), so it composes safely with any edits
+//     that landed during the async window. It should mutate only the fields it owns.
+//   - If the connection closes first, work is cancelled and apply never runs.
+//
+// On HTTP/fetch (no persistent connection), pending async operations are
+// silently dropped — the action returns synchronously with its state changes.
+func Async[S any, R any](
+	ctx *Context,
+	work func(context.Context) (R, error),
+	apply func(s S, result R, err error) (S, error),
+) {
+	ctx.pendingAsync = append(ctx.pendingAsync, asyncContinuation{
+		work: func(ctx context.Context) (any, error) {
+			return work(ctx)
+		},
+		apply: func(state any, result any, err error) (any, error) {
+			s := state.(S)
+			var r R
+			if result != nil {
+				r = result.(R)
+			}
+			return apply(s, r, err)
+		},
+	})
+}

--- a/async.go
+++ b/async.go
@@ -2,9 +2,6 @@ package livetemplate
 
 import "context"
 
-// asyncContinuation is an erased-type async operation registered by Async[S, R]().
-// The event loop spawns work in a goroutine after render #1; on completion it
-// enqueues apply onto the connection's DispatchChan for on-loop execution.
 type asyncContinuation struct {
 	work  func(ctx context.Context) (any, error)
 	apply func(state any, result any, err error) (any, error)

--- a/async_test.go
+++ b/async_test.go
@@ -408,6 +408,68 @@ func TestAsync_WorkPanicRecoveredAsError(t *testing.T) {
 	}
 }
 
+// --- Contract test: apply panic is recovered and client still gets an update ---
+
+type asyncApplyPanicController struct{}
+type asyncApplyPanicState struct {
+	Status string
+}
+
+func (c *asyncApplyPanicController) Mount(state asyncApplyPanicState, ctx *Context) (asyncApplyPanicState, error) {
+	return state, nil
+}
+
+func (c *asyncApplyPanicController) Crash(state asyncApplyPanicState, ctx *Context) (asyncApplyPanicState, error) {
+	state.Status = "loading"
+	Async(ctx,
+		func(ctx context.Context) (string, error) {
+			return "done", nil
+		},
+		func(s asyncApplyPanicState, result string, err error) (asyncApplyPanicState, error) {
+			panic("apply kaboom")
+		},
+	)
+	return state, nil
+}
+
+func TestAsync_ApplyPanicRecoveredAndReRenders(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>{{.lvt.Pending}} {{.Status}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	handler := tmpl.Handle(&asyncApplyPanicController{}, AsState(&asyncApplyPanicState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	ws, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	sendWSAction(t, ws, "crash", nil)
+
+	// Render #1: Pending=true, Status=loading
+	resp1 := readWSUpdate(t, ws, 3*time.Second)
+	tree1 := resp1["tree"].(map[string]any)
+	if got := fmt.Sprintf("%v", tree1["0"]); got != "true" {
+		t.Fatalf("render #1: Pending = %q, want \"true\"", got)
+	}
+
+	// Render #2: apply panicked, but the client must still get an update with
+	// Pending=false (state unchanged since apply panic prevented mutation).
+	got := wsHasUpdate(t, ws, 3*time.Second)
+	if !got {
+		t.Fatal("no re-render after apply panic — client would be stuck on Loading")
+	}
+}
+
 // --- P5: {{.lvt.Pending}} template variable ---
 
 // pendingTemplateController uses {{.lvt.Pending}} in its template for zero-Go-code loading UX.

--- a/async_test.go
+++ b/async_test.go
@@ -293,3 +293,121 @@ func TestAsync_ImmediateCompletion(t *testing.T) {
 		t.Errorf("Name = %q, want \"Quick(counter=0)\"", got)
 	}
 }
+
+// --- P5: {{.lvt.Pending}} template variable ---
+
+// pendingTemplateController uses {{.lvt.Pending}} in its template for zero-Go-code loading UX.
+type pendingTemplateController struct {
+	workGate chan struct{}
+}
+
+type pendingTemplateState struct {
+	Name string
+}
+
+func (c *pendingTemplateController) Mount(state pendingTemplateState, ctx *Context) (pendingTemplateState, error) {
+	return state, nil
+}
+
+func (c *pendingTemplateController) Greet(state pendingTemplateState, ctx *Context) (pendingTemplateState, error) {
+	name := ctx.GetString("name")
+	gate := c.workGate
+
+	Async(ctx,
+		func(ctx context.Context) (string, error) {
+			if gate != nil {
+				select {
+				case <-gate:
+				case <-ctx.Done():
+					return "", ctx.Err()
+				}
+			}
+			return name, nil
+		},
+		func(s pendingTemplateState, result string, err error) (pendingTemplateState, error) {
+			s.Name = result
+			return s, nil
+		},
+	)
+	return state, nil
+}
+
+func TestLvtPending_TrueOnRender1_FalseOnRender2(t *testing.T) {
+	gate := make(chan struct{})
+	ctrl := &pendingTemplateController{workGate: gate}
+
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	// Use {{.lvt.Pending}} directly (renders "true"/"false") to avoid
+	// nested conditional sub-trees in the diff.
+	tmpl, err = tmpl.Parse(`<div>{{.lvt.Pending}} {{.Name}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(ctrl, AsState(&pendingTemplateState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	ws, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Trigger Greet (registers Async, gate blocks work)
+	sendWSAction(t, ws, "greet", map[string]any{"name": "Alice"})
+
+	// Render #1: .lvt.Pending should be true
+	resp1 := readWSUpdate(t, ws, 3*time.Second)
+	tree1 := resp1["tree"].(map[string]any)
+	if got := fmt.Sprintf("%v", tree1["0"]); got != "true" {
+		t.Errorf("render #1: .lvt.Pending = %q, want \"true\"", got)
+	}
+
+	// Unblock async work
+	close(gate)
+
+	// Render #2: .lvt.Pending should be false, Name = "Alice"
+	resp2 := readWSUpdate(t, ws, 3*time.Second)
+	tree2 := resp2["tree"].(map[string]any)
+	if got := fmt.Sprintf("%v", tree2["0"]); got != "false" {
+		t.Errorf("render #2: .lvt.Pending = %q, want \"false\"", got)
+	}
+	if got := fmt.Sprintf("%v", tree2["1"]); got != "Alice" {
+		t.Errorf("render #2: Name = %q, want \"Alice\"", got)
+	}
+}
+
+func TestLvtPending_FalseForNonAsyncActions(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>{{.lvt.Pending}} {{.Count}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	handler := tmpl.Handle(&testHandleController{}, AsState(&testHandleState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	ws, initial := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// The initial render should have .lvt.Pending = false
+	pendingVal := treeDynamic(t, initial, "0")
+	if pendingVal != "false" {
+		t.Errorf("initial render: .lvt.Pending = %q, want \"false\"", pendingVal)
+	}
+}

--- a/async_test.go
+++ b/async_test.go
@@ -3,7 +3,6 @@ package livetemplate
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -79,16 +78,6 @@ func (c *asyncTestController) Greet(state asyncTestState, ctx *Context) (asyncTe
 func (c *asyncTestController) Increment(state asyncTestState, ctx *Context) (asyncTestState, error) {
 	state.Counter++
 	return state, nil
-}
-
-// asyncFixedGroupAuth forces all connections into one group.
-type asyncFixedGroupAuth struct {
-	groupID string
-}
-
-func (a *asyncFixedGroupAuth) Identify(_ *http.Request) (string, error) { return "", nil }
-func (a *asyncFixedGroupAuth) GetSessionGroup(_ *http.Request, _ string) (string, error) {
-	return a.groupID, nil
 }
 
 func setupAsyncTestServer(t *testing.T, ctrl *asyncTestController, opts ...Option) string {
@@ -217,7 +206,7 @@ func TestAsync_DisconnectCancelsWork(t *testing.T) {
 func TestAsync_RenderScopeIsOriginatingConnectionOnly(t *testing.T) {
 	gate := make(chan struct{})
 	ctrl := &asyncTestController{workGate: gate}
-	auth := &asyncFixedGroupAuth{groupID: "async-scope-group"}
+	auth := &fixedGroupAuth{groupID: "async-scope-group"}
 
 	wsURL := setupAsyncTestServer(t, ctrl, WithAuthenticator(auth))
 

--- a/async_test.go
+++ b/async_test.go
@@ -283,6 +283,131 @@ func TestAsync_ImmediateCompletion(t *testing.T) {
 	}
 }
 
+// --- Contract test: apply error clears pending and re-renders ---
+
+type asyncErrorController struct{}
+type asyncErrorState struct {
+	Status string
+}
+
+func (c *asyncErrorController) Mount(state asyncErrorState, ctx *Context) (asyncErrorState, error) {
+	return state, nil
+}
+
+func (c *asyncErrorController) Fail(state asyncErrorState, ctx *Context) (asyncErrorState, error) {
+	state.Status = "loading"
+	Async(ctx,
+		func(ctx context.Context) (string, error) {
+			return "done", nil
+		},
+		func(s asyncErrorState, result string, err error) (asyncErrorState, error) {
+			return s, fmt.Errorf("apply failed on purpose")
+		},
+	)
+	return state, nil
+}
+
+func TestAsync_ApplyErrorClearsPendingAndReRenders(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>{{.lvt.Pending}} {{.Status}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	handler := tmpl.Handle(&asyncErrorController{}, AsState(&asyncErrorState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	ws, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	sendWSAction(t, ws, "fail", nil)
+
+	// Render #1: Pending=true, Status=loading
+	resp1 := readWSUpdate(t, ws, 3*time.Second)
+	tree1 := resp1["tree"].(map[string]any)
+	if got := fmt.Sprintf("%v", tree1["0"]); got != "true" {
+		t.Fatalf("render #1: Pending = %q, want \"true\"", got)
+	}
+
+	// Render #2: even though apply returned an error, Pending must be
+	// cleared and the client must receive an update (not hang forever).
+	got := wsHasUpdate(t, ws, 3*time.Second)
+	if !got {
+		t.Fatal("no re-render after apply error — client would be stuck on Loading")
+	}
+}
+
+// --- Contract test: work panic is recovered and surfaced as error ---
+
+type asyncPanicController struct{}
+type asyncPanicState struct {
+	Result string
+}
+
+func (c *asyncPanicController) Mount(state asyncPanicState, ctx *Context) (asyncPanicState, error) {
+	return state, nil
+}
+
+func (c *asyncPanicController) Boom(state asyncPanicState, ctx *Context) (asyncPanicState, error) {
+	state.Result = "loading"
+	Async(ctx,
+		func(ctx context.Context) (string, error) {
+			panic("kaboom")
+		},
+		func(s asyncPanicState, result string, err error) (asyncPanicState, error) {
+			if err != nil {
+				s.Result = "error"
+			} else {
+				s.Result = result
+			}
+			return s, nil
+		},
+	)
+	return state, nil
+}
+
+func TestAsync_WorkPanicRecoveredAsError(t *testing.T) {
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>{{.Result}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	handler := tmpl.Handle(&asyncPanicController{}, AsState(&asyncPanicState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	ws, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	sendWSAction(t, ws, "boom", nil)
+
+	// Render #1: Result=loading
+	readWSUpdate(t, ws, 3*time.Second)
+
+	// Render #2: apply should receive the panic as an error and set Result="error"
+	resp2 := readWSUpdate(t, ws, 3*time.Second)
+	tree2 := resp2["tree"].(map[string]any)
+	if got := fmt.Sprintf("%v", tree2["0"]); got != "error" {
+		t.Errorf("Result = %q, want \"error\" (panic should be surfaced as err to apply)", got)
+	}
+}
+
 // --- P5: {{.lvt.Pending}} template variable ---
 
 // pendingTemplateController uses {{.lvt.Pending}} in its template for zero-Go-code loading UX.

--- a/async_test.go
+++ b/async_test.go
@@ -1,0 +1,295 @@
+package livetemplate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// ============================================================================
+// Async Primitive — P2 Acceptance Tests
+// ============================================================================
+
+// --- Test infrastructure ---
+
+type asyncTestState struct {
+	Loading bool
+	Name    string
+	Counter int
+}
+
+type asyncTestController struct {
+	workDelay time.Duration // how long the async work takes
+	workGate  chan struct{} // if non-nil, work blocks until closed
+
+	mu         sync.Mutex
+	applyCalls int
+}
+
+func (c *asyncTestController) Mount(state asyncTestState, ctx *Context) (asyncTestState, error) {
+	return state, nil
+}
+
+// Greet triggers Async: sets Loading=true, spawns work, apply clears Loading and sets Name.
+// The apply callback reads Counter to prove it sees the live state, not a snapshot.
+func (c *asyncTestController) Greet(state asyncTestState, ctx *Context) (asyncTestState, error) {
+	state.Loading = true
+	name := ctx.GetString("name")
+	delay := c.workDelay
+	gate := c.workGate
+
+	Async(ctx,
+		func(ctx context.Context) (string, error) {
+			if gate != nil {
+				select {
+				case <-gate:
+				case <-ctx.Done():
+					return "", ctx.Err()
+				}
+			} else if delay > 0 {
+				select {
+				case <-time.After(delay):
+				case <-ctx.Done():
+					return "", ctx.Err()
+				}
+			}
+			return name, nil
+		},
+		func(s asyncTestState, result string, err error) (asyncTestState, error) {
+			c.mu.Lock()
+			c.applyCalls++
+			c.mu.Unlock()
+			// Encode Counter into Name to prove apply saw the interleaved state.
+			s.Name = fmt.Sprintf("%s(counter=%d)", result, s.Counter)
+			s.Loading = false
+			return s, nil
+		},
+	)
+	return state, nil
+}
+
+// Increment modifies Counter — used to interleave state changes during async work.
+func (c *asyncTestController) Increment(state asyncTestState, ctx *Context) (asyncTestState, error) {
+	state.Counter++
+	return state, nil
+}
+
+// asyncFixedGroupAuth forces all connections into one group.
+type asyncFixedGroupAuth struct {
+	groupID string
+}
+
+func (a *asyncFixedGroupAuth) Identify(_ *http.Request) (string, error) { return "", nil }
+func (a *asyncFixedGroupAuth) GetSessionGroup(_ *http.Request, _ string) (string, error) {
+	return a.groupID, nil
+}
+
+func setupAsyncTestServer(t *testing.T, ctrl *asyncTestController, opts ...Option) string {
+	t.Helper()
+	tmpl, err := New("test", opts...)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse("<div>{{.Loading}} {{.Name}} {{.Counter}}</div>")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	handler := tmpl.Handle(ctrl, AsState(&asyncTestState{}))
+	server := httptest.NewServer(handler)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	t.Cleanup(server.Close)
+	return wsURL
+}
+
+// wsHasUpdate reads a WS update with a timeout, returning true if an update
+// was received. Unlike readWSUpdate in broadcast_test.go, this does not Fatal
+// on timeout — it returns false so callers can assert that NO update arrived.
+func wsHasUpdate(t *testing.T, ws *websocket.Conn, timeout time.Duration) bool {
+	t.Helper()
+	if err := ws.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		t.Fatalf("SetReadDeadline failed: %v", err)
+	}
+	_, _, err := ws.ReadMessage()
+	return err == nil
+}
+
+// --- Contract test 1: apply sees state mutated by an interleaved action ---
+
+func TestAsync_ApplySeesInterleavedState(t *testing.T) {
+	gate := make(chan struct{})
+	ctrl := &asyncTestController{workGate: gate}
+
+	wsURL := setupAsyncTestServer(t, ctrl)
+
+	ws, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// 1. Trigger Greet (starts async work, blocked on gate)
+	sendWSAction(t, ws, "greet", map[string]any{"name": "Alice"})
+
+	// Read render #1: Loading=true
+	resp1 := readWSUpdate(t, ws, 3*time.Second)
+	tree1 := resp1["tree"].(map[string]any)
+	if got := fmt.Sprintf("%v", tree1["0"]); got != "true" {
+		t.Fatalf("render #1: Loading = %q, want \"true\"", got)
+	}
+
+	// 2. While async work is blocked, send an interleaved Increment action
+	sendWSAction(t, ws, "increment", nil)
+	respIncr := readWSUpdate(t, ws, 3*time.Second)
+	treeIncr := respIncr["tree"].(map[string]any)
+	if got := fmt.Sprintf("%v", treeIncr["2"]); got != "1" {
+		t.Fatalf("increment: Counter = %q, want \"1\"", got)
+	}
+
+	// 3. Unblock async work
+	close(gate)
+
+	// Read render #2: async completion
+	resp2 := readWSUpdate(t, ws, 3*time.Second)
+	tree2 := resp2["tree"].(map[string]any)
+
+	// Loading should be false
+	if got := fmt.Sprintf("%v", tree2["0"]); got != "false" {
+		t.Errorf("async completion: Loading = %q, want \"false\"", got)
+	}
+	// Name encodes the Counter value that apply saw. If apply received a
+	// snapshot from when Greet ran (Counter=0), it would be "Alice(counter=0)".
+	// If it correctly received the current state (Counter=1 from Increment),
+	// it will be "Alice(counter=1)".
+	if got := fmt.Sprintf("%v", tree2["1"]); got != "Alice(counter=1)" {
+		t.Errorf("async completion: Name = %q, want \"Alice(counter=1)\" (apply must use current state)", got)
+	}
+}
+
+// --- Contract test 2: disconnect cancels work and skips apply ---
+
+func TestAsync_DisconnectCancelsWork(t *testing.T) {
+	gate := make(chan struct{})
+	ctrl := &asyncTestController{workGate: gate}
+
+	wsURL := setupAsyncTestServer(t, ctrl)
+
+	ws, _ := connectWSRaw(t, wsURL)
+
+	// Trigger Greet (starts async work, blocked on gate)
+	sendWSAction(t, ws, "greet", map[string]any{"name": "Bob"})
+
+	// Read render #1
+	readWSUpdate(t, ws, 3*time.Second)
+
+	// Close the connection while work is in flight.
+	// Brief pause lets the server-side event loop break and Unregister
+	// (which closes connection.Done()) before we unblock the work goroutine.
+	if err := ws.Close(); err != nil {
+		t.Logf("ws close: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	// Unblock work — should be cancelled (context.Done closed)
+	close(gate)
+
+	// Give time for any goroutine to settle
+	time.Sleep(100 * time.Millisecond)
+
+	// Apply should NOT have been called
+	ctrl.mu.Lock()
+	calls := ctrl.applyCalls
+	ctrl.mu.Unlock()
+	if calls != 0 {
+		t.Errorf("apply was called %d times after disconnect, want 0", calls)
+	}
+}
+
+// --- Contract test 3: render scope is originating connection only ---
+
+func TestAsync_RenderScopeIsOriginatingConnectionOnly(t *testing.T) {
+	gate := make(chan struct{})
+	ctrl := &asyncTestController{workGate: gate}
+	auth := &asyncFixedGroupAuth{groupID: "async-scope-group"}
+
+	wsURL := setupAsyncTestServer(t, ctrl, WithAuthenticator(auth))
+
+	// Connect two clients in the same group
+	ws1, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws1.Close(); err != nil {
+			t.Logf("ws1 close: %v", err)
+		}
+	}()
+	ws2, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws2.Close(); err != nil {
+			t.Logf("ws2 close: %v", err)
+		}
+	}()
+
+	// Client 1 triggers Greet
+	sendWSAction(t, ws1, "greet", map[string]any{"name": "Charlie"})
+
+	// Client 1 gets render #1 (Loading=true)
+	readWSUpdate(t, ws1, 3*time.Second)
+
+	// Client 2 should NOT get any update from client 1's action
+	got := wsHasUpdate(t, ws2, 500*time.Millisecond)
+	if got {
+		t.Log("ws2 received an update during greet action — expected for shared-group dispatch")
+	}
+
+	// Unblock async work
+	close(gate)
+
+	// Client 1 gets render #2 (async completion)
+	resp := readWSUpdate(t, ws1, 3*time.Second)
+	tree := resp["tree"].(map[string]any)
+	if v := fmt.Sprintf("%v", tree["1"]); v != "Charlie(counter=0)" {
+		t.Errorf("ws1 async completion: Name = %q, want \"Charlie(counter=0)\"", v)
+	}
+
+	// Client 2 must NOT get the async completion (per-connection scope)
+	got = wsHasUpdate(t, ws2, 500*time.Millisecond)
+	if got {
+		t.Errorf("ws2 received async completion update — Async must only re-render the originating connection")
+	}
+}
+
+// --- Additional: Async with immediate completion ---
+
+func TestAsync_ImmediateCompletion(t *testing.T) {
+	ctrl := &asyncTestController{workDelay: 0}
+
+	wsURL := setupAsyncTestServer(t, ctrl)
+
+	ws, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	sendWSAction(t, ws, "greet", map[string]any{"name": "Quick"})
+
+	// Render #1: Loading=true
+	readWSUpdate(t, ws, 3*time.Second)
+
+	// Render #2: async completion (should arrive quickly)
+	resp := readWSUpdate(t, ws, 3*time.Second)
+	tree := resp["tree"].(map[string]any)
+	if got := fmt.Sprintf("%v", tree["0"]); got != "false" {
+		t.Errorf("Loading = %q, want \"false\"", got)
+	}
+	if got := fmt.Sprintf("%v", tree["1"]); got != "Quick(counter=0)" {
+		t.Errorf("Name = %q, want \"Quick(counter=0)\"", got)
+	}
+}

--- a/async_test.go
+++ b/async_test.go
@@ -559,6 +559,58 @@ func TestLvtPending_TrueOnRender1_FalseOnRender2(t *testing.T) {
 	}
 }
 
+// Pin per-render semantics: an interleaved non-async action renders
+// .lvt.Pending=false even though async work is still in flight.
+func TestLvtPending_PerRenderSemantics(t *testing.T) {
+	gate := make(chan struct{})
+	ctrl := &asyncTestController{workGate: gate}
+
+	tmpl, err := New("test")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	tmpl, err = tmpl.Parse(`<div>{{.lvt.Pending}} {{.Loading}} {{.Name}} {{.Counter}}</div>`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	handler := tmpl.Handle(ctrl, AsState(&asyncTestState{}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+
+	ws, _ := connectWSRaw(t, wsURL)
+	defer func() {
+		if err := ws.Close(); err != nil {
+			t.Logf("ws close: %v", err)
+		}
+	}()
+
+	// Trigger Greet (registers Async, gate blocks work)
+	sendWSAction(t, ws, "greet", map[string]any{"name": "Alice"})
+
+	// Render #1: .lvt.Pending=true (this action registered async work)
+	resp1 := readWSUpdate(t, ws, 3*time.Second)
+	tree1 := resp1["tree"].(map[string]any)
+	if got := fmt.Sprintf("%v", tree1["0"]); got != "true" {
+		t.Fatalf("render #1: .lvt.Pending = %q, want \"true\"", got)
+	}
+
+	// Send a non-async Increment while async work is still blocked
+	sendWSAction(t, ws, "increment", nil)
+	resp2 := readWSUpdate(t, ws, 3*time.Second)
+	tree2 := resp2["tree"].(map[string]any)
+
+	// .lvt.Pending should be false on this render (Increment didn't register
+	// async work), even though Greet's async work is still in flight.
+	if got := fmt.Sprintf("%v", tree2["0"]); got != "false" {
+		t.Errorf("interleaved render: .lvt.Pending = %q, want \"false\" (per-render semantics)", got)
+	}
+
+	// Unblock async work and verify completion still arrives
+	close(gate)
+	readWSUpdate(t, ws, 3*time.Second)
+}
+
 func TestLvtPending_FalseForNonAsyncActions(t *testing.T) {
 	tmpl, err := New("test")
 	if err != nil {

--- a/context.go
+++ b/context.go
@@ -90,18 +90,19 @@ func (k ConnectKind) String() string {
 // - Action methods(state, ctx) - user interactions
 type Context struct {
 	context.Context
-	action      string
-	submitter   string // SubmitEvent.submitter.name; distinct from action under lvt-on:submit routing
-	data        *ActionData
-	userID      string
-	groupID     string
-	session     Session
-	uploads     UploadAccessor
-	flashSetter FlashSetter
-	formSchema  *FormSchema
-	topicSub    topicSubscriber
-	topicPubs   []topicPublish
-	connectKind ConnectKind
+	action       string
+	submitter    string // SubmitEvent.submitter.name; distinct from action under lvt-on:submit routing
+	data         *ActionData
+	userID       string
+	groupID      string
+	session      Session
+	uploads      UploadAccessor
+	flashSetter  FlashSetter
+	formSchema   *FormSchema
+	topicSub     topicSubscriber
+	topicPubs    []topicPublish
+	pendingAsync []asyncContinuation
+	connectKind  ConnectKind
 
 	// HTTP context (nil for WebSocket actions)
 	w          http.ResponseWriter
@@ -744,4 +745,13 @@ func (c *Context) ClearAllFlash() {
 	if c.flashSetter != nil {
 		c.flashSetter.clearAllFlash()
 	}
+}
+
+// pendingAsyncOps returns and clears pending Async continuations. Drained by
+// the event loop after render #1, so the spinner-on frame reaches the client
+// before the goroutine starts.
+func (c *Context) pendingAsyncOps() []asyncContinuation {
+	ops := c.pendingAsync
+	c.pendingAsync = nil
+	return ops
 }

--- a/docs/guides/progressive-complexity.md
+++ b/docs/guides/progressive-complexity.md
@@ -228,8 +228,8 @@ LiveTemplate offers three loading models. Pick the simplest one that fits your u
 |---|---|---|---|
 | Grey out the form | N/A | **7.1 — Auto** (`<fieldset>` + CSS) | 0 lines, 0 attrs |
 | Custom loading UX (spinner, text) | Yes | **7.2 — Client-owned pending** (`lvt-el:*:on:pending`) | 0 lines, 2 attrs |
-| Custom loading UX (spinner, text) | **No** | **7.3 — Server-owned loading** (`{{if .Loading}}`) | ~15 lines, 0 attrs |
-| Loading fans out to peers / survives reconnect | Either | **7.3 — Server-owned loading** | ~15 lines, 0 attrs |
+| Custom loading UX (spinner, text) | **No** | **7.3 — Server-owned loading** with `Async` | ~7 lines, 0 attrs |
+| Loading fans out to peers / survives reconnect | Either | **7.3 — Server-owned loading** with `Async` | ~7 lines, 0 attrs |
 
 **Rule of thumb:** start with 7.1. Move to 7.2 or 7.3 only when you need custom UX (spinners, text changes, progress indicators) or loading that is real application state.
 
@@ -339,6 +339,37 @@ func (c *Controller) FinishGreet(state State, ctx *livetemplate.Context) (State,
 4. **Second action name**: the `FinishGreet` method name must match the string passed to `TriggerAction`. A typo silently fails (the action dispatches but no method handles it).
 
 **Trade-offs vs 7.2:** more verbose (~15 lines across 2 methods), but the loading state is real server state — it fans out to peers via `ctx.Publish()`, survives reconnect (it's in the state struct), and can drive server-side logic (e.g., preventing concurrent operations).
+
+#### Simplified with `Async`
+
+`livetemplate.Async` collapses the two-method pattern to one method (~7 lines) by handling the goroutine, dispatch channel, and re-entry automatically:
+
+```go
+func (c *Controller) Greet(state State, ctx *livetemplate.Context) (State, error) {
+    state.Loading = true
+    name := strings.TrimSpace(ctx.GetString("name"))
+    livetemplate.Async(ctx,
+        func(ctx context.Context) (string, error) {
+            time.Sleep(700 * time.Millisecond) // simulate slow work
+            return name, nil
+        },
+        func(s State, name string, err error) (State, error) {
+            s.Name = name
+            s.Loading = false
+            return s, nil
+        },
+    )
+    return state, nil // render #1: Loading=true
+    // render #2 happens when work completes: Loading=false
+}
+```
+
+The template is identical — `{{if .Loading}}` works the same way. The key guarantees:
+- **`apply` sees the current state**, not a snapshot — any actions that ran during the async window are visible
+- **Connection-scoped** — only the originating connection gets the completion render
+- **Lifetime-bound** — if the connection closes, the goroutine is cancelled and `apply` is skipped
+
+See the [Async API reference](../references/api-reference.md#async) for the full contract.
 
 ---
 

--- a/docs/guides/progressive-complexity.md
+++ b/docs/guides/progressive-complexity.md
@@ -229,7 +229,7 @@ LiveTemplate offers three loading models. Pick the simplest one that fits your u
 | Grey out the form | N/A | **7.1 — Auto** (`<fieldset>` + CSS) | 0 lines, 0 attrs |
 | Custom loading UX (spinner, text) | Yes | **7.2 — Client-owned pending** (`lvt-el:*:on:pending`) | 0 lines, 2 attrs |
 | Custom loading UX (spinner, text) | **No** | **7.3 — Server-owned loading** with `Async` + `{{.lvt.Pending}}` | ~5 lines, 0 attrs |
-| Loading fans out to peers / survives reconnect | Either | **7.3 — Server-owned loading** with `Async` | ~7 lines, 0 attrs |
+| Loading fans out to peers / survives reconnect | Either | **7.3 — Server-owned loading** with manual `Loading` field + `ctx.Publish()` | ~15 lines, 0 attrs |
 
 **Rule of thumb:** start with 7.1. Move to 7.2 or 7.3 only when you need custom UX (spinners, text changes, progress indicators) or loading that is real application state.
 

--- a/docs/guides/progressive-complexity.md
+++ b/docs/guides/progressive-complexity.md
@@ -228,7 +228,7 @@ LiveTemplate offers three loading models. Pick the simplest one that fits your u
 |---|---|---|---|
 | Grey out the form | N/A | **7.1 — Auto** (`<fieldset>` + CSS) | 0 lines, 0 attrs |
 | Custom loading UX (spinner, text) | Yes | **7.2 — Client-owned pending** (`lvt-el:*:on:pending`) | 0 lines, 2 attrs |
-| Custom loading UX (spinner, text) | **No** | **7.3 — Server-owned loading** with `Async` | ~7 lines, 0 attrs |
+| Custom loading UX (spinner, text) | **No** | **7.3 — Server-owned loading** with `Async` + `{{.lvt.Pending}}` | ~5 lines, 0 attrs |
 | Loading fans out to peers / survives reconnect | Either | **7.3 — Server-owned loading** with `Async` | ~7 lines, 0 attrs |
 
 **Rule of thumb:** start with 7.1. Move to 7.2 or 7.3 only when you need custom UX (spinners, text changes, progress indicators) or loading that is real application state.
@@ -370,6 +370,35 @@ The template is identical — `{{if .Loading}}` works the same way. The key guar
 - **Lifetime-bound** — if the connection closes, the goroutine is cancelled and `apply` is skipped
 
 See the [Async API reference](../references/api-reference.md#async) for the full contract.
+
+#### Zero-boilerplate with `{{.lvt.Pending}}`
+
+When loading is purely visual (no need for a `Loading` field in state), combine `Async` with the framework-provided `{{.lvt.Pending}}` template variable. It is `true` on the render that registered async work and `false` on all other renders (including the async completion render):
+
+```go
+func (c *Controller) Greet(state State, ctx *livetemplate.Context) (State, error) {
+    name := strings.TrimSpace(ctx.GetString("name"))
+    livetemplate.Async(ctx,
+        func(ctx context.Context) (string, error) {
+            time.Sleep(700 * time.Millisecond)
+            return name, nil
+        },
+        func(s State, name string, err error) (State, error) {
+            s.Name = name
+            return s, nil
+        },
+    )
+    return state, nil
+}
+```
+
+```html
+<button name="greet" {{if .lvt.Pending}}disabled{{end}}>
+    {{if .lvt.Pending}}Loading...{{else}}Greet{{end}}
+</button>
+```
+
+No `Loading` field, no `lvt-*` attributes — pure Go + standard HTML templates. Use `{{.lvt.Pending}}` when the loading indicator is chrome (visual feedback). Use an explicit `Loading` state field (with `Async`) when loading is real application state that needs to fan out to peers or survive reconnect.
 
 ---
 

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -349,8 +349,13 @@ to re-enter.
 
 **`{{.lvt.Pending}}`:** A framework-provided template variable that is `true`
 on the render that registered async work and `false` on all other renders.
-Use it instead of a manual `Loading` state field when the loading indicator
-is purely visual:
+It has **per-render** semantics: if another action or a peer dispatch
+triggers a render on the same connection while async work is still in
+flight, that render will see `Pending=false` (it did not register async
+work). For loading indicators that must stay visible across interleaved
+renders, use an explicit `Loading bool` field in your state instead.
+Use `{{.lvt.Pending}}` when the loading indicator is purely visual and
+single-action flows are the norm:
 
 ```html
 <button name="greet" {{if .lvt.Pending}}disabled{{end}}>

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -342,6 +342,17 @@ func (c *Controller) Greet(state State, ctx *livetemplate.Context) (State, error
 (no persistent connection), pending async operations are silently dropped —
 the action returns synchronously with its state changes.
 
+**`{{.lvt.Pending}}`:** A framework-provided template variable that is `true`
+on the render that registered async work and `false` on all other renders.
+Use it instead of a manual `Loading` state field when the loading indicator
+is purely visual:
+
+```html
+<button name="greet" {{if .lvt.Pending}}disabled{{end}}>
+    {{if .lvt.Pending}}Loading...{{else}}Greet{{end}}
+</button>
+```
+
 See [Loading States §7.3](../guides/progressive-complexity.md#73-server-owned-loading-tier-1)
 for the full comparison of loading approaches.
 

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -340,9 +340,12 @@ func (c *Controller) Greet(state State, ctx *livetemplate.Context) (State, error
 }
 ```
 
-**Transport:** `Async` requires a WebSocket connection. On HTTP/fetch
-(no persistent connection), pending async operations are silently dropped —
-the action returns synchronously with its state changes.
+**Scope:** `Async` is supported only inside **action handlers** (e.g.
+`Greet`, `Save`) that run on the per-connection WebSocket event loop.
+Calling `Async` in `Mount()`, `OnConnect()`, dispatched actions, server-
+initiated actions, upload handlers, or HTTP POST handlers logs a warning
+and drops the operation — there is no persistent connection or event loop
+to re-enter.
 
 **`{{.lvt.Pending}}`:** A framework-provided template variable that is `true`
 on the render that registered async work and `false` on all other renders.

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -288,6 +288,65 @@ can be captured and used from background goroutines. See
 
 ---
 
+## Async
+
+```go
+func Async[S any, R any](
+    ctx *Context,
+    work  func(context.Context) (R, error),
+    apply func(s S, result R, err error) (S, error),
+)
+```
+
+Runs `work` off the connection event loop, then re-enters the loop to apply
+its result to the **current** session state and re-render the originating
+connection. Reduces the [manual two-action loading pattern](../guides/progressive-complexity.md#73-server-owned-loading-tier-1)
+from ~15 lines / 2 methods to ~7 lines / 1 method.
+
+- **`work`** runs in a supervised goroutine. It receives a `context.Context`
+  tied to the connection's lifetime (cancelled on disconnect). It must not
+  touch session state — only its own inputs.
+- **`apply`** runs **on the event loop** against the latest state at
+  completion time, not a snapshot from when `work` started. Any state
+  changes from other actions during the async window are visible. Mutate
+  only the fields you own.
+- If the connection closes before `work` completes, the goroutine is
+  cancelled and `apply` never runs.
+- Render scope is **per-connection** — only the connection that called
+  `Async` gets the completion render. For group-wide fan-out, call
+  `ctx.Session().TriggerAction()` inside `apply`.
+
+**Example:**
+
+```go
+func (c *Controller) Greet(state State, ctx *livetemplate.Context) (State, error) {
+    state.Loading = true
+    name := strings.TrimSpace(ctx.GetString("name"))
+    livetemplate.Async(ctx,
+        func(ctx context.Context) (string, error) {
+            time.Sleep(700 * time.Millisecond) // simulate slow work
+            return name, nil
+        },
+        func(s State, name string, err error) (State, error) {
+            s.Name = name
+            s.Loading = false
+            return s, nil
+        },
+    )
+    return state, nil // render #1: Loading=true (spinner on)
+    // render #2 happens automatically when work completes: Loading=false
+}
+```
+
+**Transport:** `Async` requires a WebSocket connection. On HTTP/fetch
+(no persistent connection), pending async operations are silently dropped —
+the action returns synchronously with its state changes.
+
+See [Loading States §7.3](../guides/progressive-complexity.md#73-server-owned-loading-tier-1)
+for the full comparison of loading approaches.
+
+---
+
 ## LiveHandler
 
 ```go

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -313,8 +313,10 @@ from ~15 lines / 2 methods to ~7 lines / 1 method.
 - If the connection closes before `work` completes, the goroutine is
   cancelled and `apply` never runs.
 - Render scope is **per-connection** — only the connection that called
-  `Async` gets the completion render. For group-wide fan-out, call
-  `ctx.Session().TriggerAction()` inside `apply`.
+  `Async` gets the completion render. For group-wide fan-out, capture
+  `session := ctx.Session()` before defining `apply`, then call
+  `session.TriggerAction()` from within the `apply` closure (`ctx`
+  itself is not in scope inside `apply`).
 
 **Example:**
 

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -55,6 +55,7 @@ func putBuffer(buf *bytes.Buffer) {
 type TemplateContext struct {
 	messages      map[string]string // Unified map: field errors + flash (prefixed with "_flash:")
 	DevMode       bool              // Development mode - exposed to templates as {{.lvt.DevMode}}
+	Pending       bool              // True when the current action registered async work via Async()
 	uploadEntries interface{}       // *upload.Registry for accessing upload state
 }
 
@@ -417,7 +418,7 @@ const (
 // Note: If struct fields or map keys conflict with the reserved "lvt" key, they will be
 // skipped to ensure the lvt context remains accessible in templates.
 func ExecuteTemplateWithContext(tmpl *template.Template, data interface{}, messages map[string]string, devMode bool, uploadRegistry interface{}, precomputeAllow map[string]struct{}) ([]byte, error) {
-	dataMap := BuildDataMap(data, messages, devMode, uploadRegistry, precomputeAllow)
+	dataMap := BuildDataMap(data, messages, devMode, uploadRegistry, precomputeAllow, false)
 	return executeWithBuffer(tmpl, dataMap)
 }
 

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -1210,7 +1210,7 @@ func BenchmarkPrecompute(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_ = BuildDataMap(state, nil, false, nil, tc.allow)
+				_ = BuildDataMap(state, nil, false, nil, tc.allow, false)
 			}
 		})
 	}

--- a/internal/context/data.go
+++ b/internal/context/data.go
@@ -89,12 +89,13 @@ func safeMethodCall(method reflect.Value) (results []reflect.Value, panicked boo
 // identifiers referenced by the templates — see parse.CollectReferencedIdents), so a
 // method the templates never reference is skipped entirely. A nil set means evaluate
 // all qualifying methods, preserving the original eager behavior for direct callers.
-func BuildDataMap(data interface{}, messages map[string]string, devMode bool, uploadRegistry interface{}, precomputeAllow map[string]struct{}) interface{} {
+func BuildDataMap(data interface{}, messages map[string]string, devMode bool, uploadRegistry interface{}, precomputeAllow map[string]struct{}, pending bool) interface{} {
 	if messages == nil {
 		messages = make(map[string]string)
 	}
 
 	lvtContext := NewTemplateContext(messages, devMode)
+	lvtContext.Pending = pending
 	if uploadRegistry != nil {
 		lvtContext.SetUploadRegistry(uploadRegistry)
 	}
@@ -255,5 +256,5 @@ func AddLvtToData(data interface{}, messages map[string]string, devMode bool, up
 	if len(uploadRegistry) > 0 {
 		registry = uploadRegistry[0]
 	}
-	return BuildDataMap(data, messages, devMode, registry, nil)
+	return BuildDataMap(data, messages, devMode, registry, nil, false)
 }

--- a/internal/context/data_test.go
+++ b/internal/context/data_test.go
@@ -69,7 +69,7 @@ func TestBuildDataMap_AllowSetScopesMethods(t *testing.T) {
 	state := CounterState{Value: 5}
 
 	// Only Doubled is referenced: Display must be skipped, the field stays.
-	dm := BuildDataMap(state, nil, false, nil, map[string]struct{}{"Doubled": {}}).(map[string]interface{})
+	dm := BuildDataMap(state, nil, false, nil, map[string]struct{}{"Doubled": {}}, false).(map[string]interface{})
 	if got, ok := dm["Doubled"].(int); !ok || got != 10 {
 		t.Errorf("Doubled should be precomputed, got %v", dm["Doubled"])
 	}
@@ -83,7 +83,7 @@ func TestBuildDataMap_AllowSetScopesMethods(t *testing.T) {
 
 func TestBuildDataMap_EmptyAllowSetSkipsAllMethods(t *testing.T) {
 	state := CounterState{Value: 5}
-	dm := BuildDataMap(state, nil, false, nil, map[string]struct{}{}).(map[string]interface{})
+	dm := BuildDataMap(state, nil, false, nil, map[string]struct{}{}, false).(map[string]interface{})
 	if _, exists := dm["Doubled"]; exists {
 		t.Error("empty allow-set must skip all methods (Doubled)")
 	}
@@ -97,7 +97,7 @@ func TestBuildDataMap_EmptyAllowSetSkipsAllMethods(t *testing.T) {
 
 func TestBuildDataMap_NilAllowSetPrecomputesAll(t *testing.T) {
 	state := CounterState{Value: 5}
-	dm := BuildDataMap(state, nil, false, nil, nil).(map[string]interface{})
+	dm := BuildDataMap(state, nil, false, nil, nil, false).(map[string]interface{})
 	if _, ok := dm["Doubled"]; !ok {
 		t.Error("nil allow-set must precompute all methods (Doubled missing)")
 	}
@@ -108,7 +108,7 @@ func TestBuildDataMap_NilAllowSetPrecomputesAll(t *testing.T) {
 
 func TestBuildDataMap_StructMethodsPreserved(t *testing.T) {
 	state := CounterState{Value: 5}
-	result := BuildDataMap(state, nil, false, nil, nil)
+	result := BuildDataMap(state, nil, false, nil, nil, false)
 
 	dataMap, ok := result.(map[string]interface{})
 	if !ok {
@@ -131,7 +131,7 @@ func TestBuildDataMap_StructMethodsPreserved(t *testing.T) {
 
 func TestBuildDataMap_StructMethodsWorkInTemplates(t *testing.T) {
 	state := CounterState{Value: 5}
-	dataMap := BuildDataMap(state, nil, false, nil, nil)
+	dataMap := BuildDataMap(state, nil, false, nil, nil, false)
 
 	tmpl, err := template.New("test").Parse(`Value={{.Value}} Doubled={{.Doubled}}`)
 	if err != nil {
@@ -158,7 +158,7 @@ func TestBuildDataMap_TodoMethodsInTemplates(t *testing.T) {
 		},
 		Filter: "active",
 	}
-	dataMap := BuildDataMap(state, nil, false, nil, nil)
+	dataMap := BuildDataMap(state, nil, false, nil, nil, false)
 
 	tmpl, err := template.New("test").Parse(`Active={{.ActiveCount}} Items={{len .FilteredItems}}`)
 	if err != nil {
@@ -178,7 +178,7 @@ func TestBuildDataMap_TodoMethodsInTemplates(t *testing.T) {
 
 func TestBuildDataMap_PointerMethodsPreserved(t *testing.T) {
 	state := &StateWithPointerMethod{Name: "World"}
-	dataMap := BuildDataMap(state, nil, false, nil, nil)
+	dataMap := BuildDataMap(state, nil, false, nil, nil, false)
 
 	dm, ok := dataMap.(map[string]interface{})
 	if !ok {
@@ -206,7 +206,7 @@ func TestBuildDataMap_FieldTakesPrecedenceOverMethod(t *testing.T) {
 	// A JSON tag can alias a field to a name that matches a method.
 	// The field value (via JSON tag) should win.
 	state := JSONTagCollision{Computed: "from-field"}
-	dataMap := BuildDataMap(state, nil, false, nil, nil)
+	dataMap := BuildDataMap(state, nil, false, nil, nil, false)
 
 	dm := dataMap.(map[string]interface{})
 	if v, ok := dm["Doubled"].(string); !ok || v != "from-field" {
@@ -229,7 +229,7 @@ func TestBuildDataMap_ErrorMethodOmittedWhenNonNil(t *testing.T) {
 	// When a method returns (T, error) and the error is non-nil,
 	// the method is silently omitted from the map.
 	state := FallibleState{OK: false}
-	dataMap := BuildDataMap(state, nil, false, nil, nil)
+	dataMap := BuildDataMap(state, nil, false, nil, nil, false)
 	dm := dataMap.(map[string]interface{})
 
 	if _, exists := dm["Name"]; exists {
@@ -239,7 +239,7 @@ func TestBuildDataMap_ErrorMethodOmittedWhenNonNil(t *testing.T) {
 
 func TestBuildDataMap_ErrorMethodIncludedWhenNil(t *testing.T) {
 	state := FallibleState{OK: true}
-	dataMap := BuildDataMap(state, nil, false, nil, nil)
+	dataMap := BuildDataMap(state, nil, false, nil, nil, false)
 	dm := dataMap.(map[string]interface{})
 
 	if v, ok := dm["Name"].(string); !ok || v != "ready" {
@@ -261,7 +261,7 @@ func (s PanickingState) OK() string {
 
 func TestBuildDataMap_PanickingMethodSkipped(t *testing.T) {
 	state := PanickingState{Safe: "value"}
-	dataMap := BuildDataMap(state, nil, false, nil, nil)
+	dataMap := BuildDataMap(state, nil, false, nil, nil, false)
 	dm := dataMap.(map[string]interface{})
 
 	if _, exists := dm["Boom"]; exists {
@@ -277,7 +277,7 @@ func TestBuildDataMap_PanickingMethodSkipped(t *testing.T) {
 
 func TestBuildDataMap_LvtContextAlwaysPresent(t *testing.T) {
 	state := CounterState{Value: 1}
-	dataMap := BuildDataMap(state, nil, true, nil, nil)
+	dataMap := BuildDataMap(state, nil, true, nil, nil, false)
 
 	dm := dataMap.(map[string]interface{})
 	lvt, ok := dm[TemplateContextKey]
@@ -293,7 +293,7 @@ func TestBuildDataMap_MethodsWithPointerReceiverOnValueInput(t *testing.T) {
 	// Pass by value — pointer receiver methods should still be captured
 	// because we create a pointer via reflect.New
 	state := StateWithPointerMethod{Name: "Value"}
-	dataMap := BuildDataMap(state, nil, false, nil, nil)
+	dataMap := BuildDataMap(state, nil, false, nil, nil, false)
 
 	dm := dataMap.(map[string]interface{})
 	if _, ok := dm["Greeting"]; !ok {
@@ -333,7 +333,7 @@ func TestGetMethodMeta_ValueIndexReceiverKinds(t *testing.T) {
 // input that has at least one pointer-receiver method must allocate the pointer
 // and route ALL calls through it, so the value-receiver method still resolves.
 func TestBuildDataMap_MixedReceiversOnValueInput(t *testing.T) {
-	dm := BuildDataMap(MixedReceiverState{Name: "x"}, nil, false, nil, nil).(map[string]interface{})
+	dm := BuildDataMap(MixedReceiverState{Name: "x"}, nil, false, nil, nil, false).(map[string]interface{})
 
 	if got := dm["ValueGreeting"]; got != "value x" {
 		t.Errorf("ValueGreeting: got %v, want %q", got, "value x")

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -81,6 +81,11 @@ const (
 	// KindAction is a named-action dispatch resolved to a controller method by
 	// name (the only kind in v1; the zero value, so it is backward-compatible).
 	KindAction DispatchKind = iota
+
+	// KindAsyncCompletion carries the result of an Async work function.
+	// The event loop runs AsyncApply against the current state instead of
+	// routing through DispatchWithState.
+	KindAsyncCompletion
 )
 
 // DispatchRequest represents an action to dispatch on a connection's event loop.
@@ -90,6 +95,11 @@ type DispatchRequest struct {
 	Action string
 	Data   map[string]interface{}
 	Kind   DispatchKind
+
+	// KindAsyncCompletion fields (zero for KindAction).
+	AsyncResult any
+	AsyncError  error
+	AsyncApply  func(state any, result any, err error) (any, error)
 }
 
 // Done returns a channel that is closed when the connection is shutting down.

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -96,10 +96,16 @@ type DispatchRequest struct {
 	Data   map[string]interface{}
 	Kind   DispatchKind
 
-	// KindAsyncCompletion fields (zero for KindAction).
-	AsyncResult any
-	AsyncError  error
-	AsyncApply  func(state any, result any, err error) (any, error)
+	// Non-nil for KindAsyncCompletion; nil for KindAction.
+	Async *AsyncCompletion
+}
+
+// AsyncCompletion carries the result of an Async work function.
+// Apply runs on the event loop against the current state.
+type AsyncCompletion struct {
+	Result any
+	Err    error
+	Apply  func(state any, result any, err error) (any, error)
 }
 
 // Done returns a channel that is closed when the connection is shutting down.

--- a/mount.go
+++ b/mount.go
@@ -733,6 +733,12 @@ func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// callers guard with ctx.IsInitialMount() / ctx.IsReconnect().
 	h.processTopicPublishes(connection, lifecycleCtx.pendingTopicPublishes())
 
+	if dropped := lifecycleCtx.pendingAsyncOps(); len(dropped) > 0 {
+		slog.Warn("Async() calls in Mount/OnConnect are ignored (Async is only supported inside action handlers)",
+			slog.String("component", "live_handler"),
+			slog.Int("dropped", len(dropped)))
+	}
+
 	// Schedule OnDisconnect call when WebSocket closes
 	defer callOnDisconnect(h.config.Controller)
 
@@ -1249,6 +1255,12 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		// transport-agnostic and fans out to existing subscribers on every
 		// GET/POST (excludeConn nil: the HTTP responder is not a WS subscriber).
 		h.processTopicPublishes(nil, lifecycleCtx.pendingTopicPublishes())
+
+		if dropped := lifecycleCtx.pendingAsyncOps(); len(dropped) > 0 {
+			slog.Warn("Async() calls in Mount are ignored on HTTP requests (Async requires a WebSocket connection)",
+				slog.String("component", "live_handler"),
+				slog.Int("dropped", len(dropped)))
+		}
 		// Commit path after successful Mount (not before, to allow retries).
 		// Skip when no persist fields — pathChanged is never checked.
 		if isHTTPGet && h.persistable != nil {
@@ -1635,6 +1647,13 @@ func (h *liveHandler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		h.processTopicPublishes(nil, actionCtx.pendingTopicPublishes())
 	}
 
+	if dropped := actionCtx.pendingAsyncOps(); len(dropped) > 0 {
+		slog.Warn("Async() calls are ignored on HTTP POST (Async requires a WebSocket connection)",
+			slog.String("component", "live_handler"),
+			slog.String("action", actionCtx.action),
+			slog.Int("dropped", len(dropped)))
+	}
+
 	// Check if we should return HTML for progressive enhancement
 	// Progressive enhancement is enabled AND client does not want JSON
 	if h.config.ProgressiveEnhancement && !wantsJSON(r) {
@@ -1956,6 +1975,13 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 			slog.Int("dropped_count", len(dropped)))
 	}
 
+	if dropped := ctx.pendingAsyncOps(); len(dropped) > 0 {
+		slog.Warn("Async() calls inside a dispatched action are ignored (Async is only supported inside action handlers)",
+			slog.String("component", "live_handler"),
+			slog.String("action", req.Action),
+			slog.Int("dropped", len(dropped)))
+	}
+
 	if err := h.sendUpdate(connection, connSt.state, connSt.getMessages()); err != nil {
 		slog.Warn("sendUpdate failed during dispatched action",
 			slog.String("component", "live_handler"),
@@ -2012,7 +2038,16 @@ func spawnAsyncWork(connection *session.Connection, cont asyncContinuation) {
 // Runs apply against the current connState (not a snapshot), persists, and
 // re-renders the originating connection only.
 func (h *liveHandler) handleAsyncCompletion(connSt *connState, connection *session.Connection, req *session.DispatchRequest) {
-	newState, applyErr := req.Async.Apply(connSt.state, req.Async.Result, req.Async.Err)
+	var newState any
+	var applyErr error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				applyErr = fmt.Errorf("Async apply panicked: %v", r)
+			}
+		}()
+		newState, applyErr = req.Async.Apply(connSt.state, req.Async.Result, req.Async.Err)
+	}()
 
 	// Clear .lvt.Pending and re-render regardless of apply outcome so the
 	// client never gets stuck on a "Loading…" frame.
@@ -2449,6 +2484,13 @@ func (h *liveHandler) handleServerActionMessage(msg *pubsub.ServerActionMessage)
 				slog.String("action", msg.Action),
 				slog.String("user_id", msg.UserID),
 				slog.Int("dropped_count", len(dropped)))
+		}
+
+		if dropped := actionCtx.pendingAsyncOps(); len(dropped) > 0 {
+			slog.Warn("Async() calls inside a server-initiated action are ignored (Async is only supported inside action handlers)",
+				slog.String("component", "pubsub_handler"),
+				slog.String("action", msg.Action),
+				slog.Int("dropped", len(dropped)))
 		}
 
 		// Send update to this connection (with flash messages)
@@ -3227,6 +3269,12 @@ func (h *liveHandler) handleUploadComplete(ctx context.Context, rawData []byte, 
 			// Drain ctx.Publish from an upload-complete handler — consistent
 			// with the WS-action and HTTP-POST action paths.
 			h.processTopicPublishes(connection, actionCtx.pendingTopicPublishes())
+
+			if dropped := actionCtx.pendingAsyncOps(); len(dropped) > 0 {
+				slog.Warn("Async() calls inside an upload handler are ignored (Async is only supported inside action handlers)",
+					slog.String("component", "upload_handler"),
+					slog.Int("dropped", len(dropped)))
+			}
 		}
 	}
 

--- a/mount.go
+++ b/mount.go
@@ -951,6 +951,9 @@ eventLoop:
 				h.processTopicPublishes(connection, actionCtx.pendingTopicPublishes())
 			}
 
+			// Set .lvt.Pending for this render: true when the action registered Async work.
+			connTmpl.pending = len(actionCtx.pendingAsync) > 0
+
 			// Generate tree update
 			buf.Reset()
 			if err = connTmpl.ExecuteUpdates(&buf, connSt.state, connSt.getMessages()); err != nil {
@@ -2010,6 +2013,11 @@ func (h *liveHandler) handleAsyncCompletion(connSt *connState, connection *sessi
 	connSt.state = newState
 	connection.State = connSt.state
 	h.persistState(context.Background(), connSt.groupID, connSt.state)
+
+	// Clear .lvt.Pending for the completion render — no async ops in flight for this render.
+	if tmpl, ok := connection.Template.(*Template); ok {
+		tmpl.pending = false
+	}
 
 	if err := h.sendUpdate(connection, connSt.state, connSt.getMessages()); err != nil {
 		slog.Warn("sendUpdate failed during async completion",

--- a/mount.go
+++ b/mount.go
@@ -1979,7 +1979,16 @@ func spawnAsyncWork(connection *session.Connection, cont asyncContinuation) {
 		}()
 		defer cancel()
 
-		result, err := cont.work(ctx)
+		var result any
+		var err error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("Async work panicked: %v", r)
+				}
+			}()
+			result, err = cont.work(ctx)
+		}()
 
 		// Skip apply if the connection closed during work.
 		select {
@@ -2003,22 +2012,23 @@ func spawnAsyncWork(connection *session.Connection, cont asyncContinuation) {
 // Runs apply against the current connState (not a snapshot), persists, and
 // re-renders the originating connection only.
 func (h *liveHandler) handleAsyncCompletion(connSt *connState, connection *session.Connection, req *session.DispatchRequest) {
-	newState, err := req.Async.Apply(connSt.state, req.Async.Result, req.Async.Err)
-	if err != nil {
+	newState, applyErr := req.Async.Apply(connSt.state, req.Async.Result, req.Async.Err)
+
+	// Clear .lvt.Pending and re-render regardless of apply outcome so the
+	// client never gets stuck on a "Loading…" frame.
+	if tmpl, ok := connection.Template.(*Template); ok {
+		tmpl.pending = false
+	}
+
+	if applyErr != nil {
 		slog.Warn("Async apply failed",
 			slog.String("component", "live_handler"),
 			slog.String("group_id", connSt.groupID),
-			slog.Any("error", err))
-		return
-	}
-
-	connSt.state = newState
-	connection.State = connSt.state
-	h.persistState(context.Background(), connSt.groupID, connSt.state)
-
-	// Clear .lvt.Pending for the completion render — no async ops in flight for this render.
-	if tmpl, ok := connection.Template.(*Template); ok {
-		tmpl.pending = false
+			slog.Any("error", applyErr))
+	} else {
+		connSt.state = newState
+		connection.State = connSt.state
+		h.persistState(context.Background(), connSt.groupID, connSt.state)
 	}
 
 	if err := h.sendUpdate(connection, connSt.state, connSt.getMessages()); err != nil {

--- a/mount.go
+++ b/mount.go
@@ -1989,10 +1989,12 @@ func spawnAsyncWork(connection *session.Connection, cont asyncContinuation) {
 		}
 
 		connection.EnqueueDispatch(&session.DispatchRequest{
-			Kind:        session.KindAsyncCompletion,
-			AsyncResult: result,
-			AsyncError:  err,
-			AsyncApply:  cont.apply,
+			Kind: session.KindAsyncCompletion,
+			Async: &session.AsyncCompletion{
+				Result: result,
+				Err:    err,
+				Apply:  cont.apply,
+			},
 		})
 	}()
 }
@@ -2001,7 +2003,7 @@ func spawnAsyncWork(connection *session.Connection, cont asyncContinuation) {
 // Runs apply against the current connState (not a snapshot), persists, and
 // re-renders the originating connection only.
 func (h *liveHandler) handleAsyncCompletion(connSt *connState, connection *session.Connection, req *session.DispatchRequest) {
-	newState, err := req.AsyncApply(connSt.state, req.AsyncResult, req.AsyncError)
+	newState, err := req.Async.Apply(connSt.state, req.Async.Result, req.Async.Err)
 	if err != nil {
 		slog.Warn("Async apply failed",
 			slog.String("component", "live_handler"),

--- a/mount.go
+++ b/mount.go
@@ -992,7 +992,16 @@ eventLoop:
 				break eventLoop
 			}
 
+			// Spawn async continuations after render #1 reaches the client.
+			for _, cont := range actionCtx.pendingAsyncOps() {
+				spawnAsyncWork(connection, cont)
+			}
+
 		case req := <-connection.DispatchChan:
+			if req.Kind == session.KindAsyncCompletion {
+				h.handleAsyncCompletion(connSt, connection, req)
+				continue
+			}
 			h.handleDispatchedAction(connSt, connection, req, userID)
 		}
 	}
@@ -1948,6 +1957,63 @@ func (h *liveHandler) handleDispatchedAction(connSt *connState, connection *sess
 		slog.Warn("sendUpdate failed during dispatched action",
 			slog.String("component", "live_handler"),
 			slog.String("action", req.Action),
+			slog.Any("error", err))
+	}
+}
+
+// spawnAsyncWork launches a goroutine for an Async continuation. The goroutine
+// runs work under a context tied to the connection's lifetime; on completion it
+// enqueues the result onto DispatchChan as KindAsyncCompletion.
+func spawnAsyncWork(connection *session.Connection, cont asyncContinuation) {
+	go func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			select {
+			case <-connection.Done():
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+		defer cancel()
+
+		result, err := cont.work(ctx)
+
+		// Skip apply if the connection closed during work.
+		select {
+		case <-connection.Done():
+			return
+		default:
+		}
+
+		connection.EnqueueDispatch(&session.DispatchRequest{
+			Kind:        session.KindAsyncCompletion,
+			AsyncResult: result,
+			AsyncError:  err,
+			AsyncApply:  cont.apply,
+		})
+	}()
+}
+
+// handleAsyncCompletion processes a KindAsyncCompletion dispatch request.
+// Runs apply against the current connState (not a snapshot), persists, and
+// re-renders the originating connection only.
+func (h *liveHandler) handleAsyncCompletion(connSt *connState, connection *session.Connection, req *session.DispatchRequest) {
+	newState, err := req.AsyncApply(connSt.state, req.AsyncResult, req.AsyncError)
+	if err != nil {
+		slog.Warn("Async apply failed",
+			slog.String("component", "live_handler"),
+			slog.String("group_id", connSt.groupID),
+			slog.Any("error", err))
+		return
+	}
+
+	connSt.state = newState
+	connection.State = connSt.state
+	h.persistState(context.Background(), connSt.groupID, connSt.state)
+
+	if err := h.sendUpdate(connection, connSt.state, connSt.getMessages()); err != nil {
+		slog.Warn("sendUpdate failed during async completion",
+			slog.String("component", "live_handler"),
 			slog.Any("error", err))
 	}
 }

--- a/mount.go
+++ b/mount.go
@@ -930,6 +930,11 @@ eventLoop:
 			if msg.Action == actionNavigate {
 				actionCtx = actionCtx.WithAction("") // ctx.Action()=="" matches connect-time Mount
 				newState, actionErr = callMount(h.config.Controller, connSt.state, actionCtx)
+				if dropped := actionCtx.pendingAsyncOps(); len(dropped) > 0 {
+					slog.Warn("Async() calls in Mount (via navigate) are ignored (Async is only supported inside action handlers)",
+						slog.String("component", "live_handler"),
+						slog.Int("dropped", len(dropped)))
+				}
 			} else {
 				newState, actionErr = DispatchWithState(h.config.Controller, connSt.state, actionCtx)
 			}

--- a/template.go
+++ b/template.go
@@ -248,6 +248,7 @@ type Template struct {
 	wiredActions           map[string]struct{} // Cached set of client-wired action names (form/button name=, lvt-on:) extracted from templateStr; immutable after parse; drives the Publish symmetry-collision warning
 	wiredCollisionWarned   *sync.Map           // action -> struct{}: dedups the Publish symmetry-collision slog.Warn to once per action name; shared by pointer across per-session clones so the warning is app-global, not per-connection
 	precomputeAllow        map[string]struct{} // Superset of identifiers referenced by the parsed templates; immutable after parse; scopes eager method precompute in BuildDataMap so unreferenced State methods are never called
+	pending                bool                // True when the current render has pending Async work; set per-render by the event loop, consumed by buildTree
 }
 
 // Funcs registers a template.FuncMap that will be applied to all template parsing and execution.
@@ -1979,7 +1980,7 @@ func (t *Template) buildTree(data interface{}, messages map[string]string) (*tre
 	// The result is reused for both HTML rendering and tree building,
 	// eliminating the duplicate reflection that previously occurred in
 	// renderHTML (via ExecuteTemplateWithContext) and AddLvtToData.
-	dataWithLvt := context.BuildDataMap(data, messages, t.config.DevMode, t.uploadRegistry, t.precomputeAllow)
+	dataWithLvt := context.BuildDataMap(data, messages, t.config.DevMode, t.uploadRegistry, t.precomputeAllow, t.pending)
 
 	// Phase 4: Render HTML using pre-built data map (no reflection)
 	currentHTML, err := t.renderHTMLWithData(dataWithLvt)

--- a/testing_test.go
+++ b/testing_test.go
@@ -232,7 +232,7 @@ func TestStateMethodsInTemplates(t *testing.T) {
 		Items:  []string{"alpha", "beta", ""},
 		Filter: "a",
 	}
-	dataMap := lvtcontext.BuildDataMap(state, nil, false, nil, nil)
+	dataMap := lvtcontext.BuildDataMap(state, nil, false, nil, nil, false)
 
 	tmpl, err := template.New("test").Parse(
 		`Count={{.ActiveCount}} Filtered={{len .FilteredItems}} Items={{len .Items}}`)


### PR DESCRIPTION
## Summary

- **Docs decision-guide (P1):** Expanded §7 Loading States in the Progressive Complexity Guide into a three-tier guide (auto form loading, client-owned pending, server-owned loading) with a decision table and cross-links from client-attributes.md and controller-pattern.md
- **`Async[S, R]` primitive (P2):** Free generic function that collapses the manual two-action server-owned loading pattern from ~15 lines / 2 methods to ~7 lines / 1 method. Reuses existing DispatchChan + connection.Done() machinery — no new channels or goroutine management patterns
- **`{{.lvt.Pending}}` template variable (P5):** Framework-provided boolean that is `true` on the render that registered Async work, enabling zero-Go-code, zero-attribute loading UX with just `{{if .lvt.Pending}}Loading...{{end}}`

## Concurrency contract (tested with `-race`)

1. Apply sees state mutated by interleaved actions (not a snapshot)
2. Disconnect during work cancels the goroutine and skips apply
3. Render scope is the originating connection only

## Test plan

- [x] `TestAsync_ApplySeesInterleavedState` — interleaved state mutation visible to apply
- [x] `TestAsync_DisconnectCancelsWork` — goroutine cancelled, apply skipped
- [x] `TestAsync_RenderScopeIsOriginatingConnectionOnly` — peer connection gets no completion update
- [x] `TestAsync_ImmediateCompletion` — zero-delay async completes correctly
- [x] `TestLvtPending_TrueOnRender1_FalseOnRender2` — pending flag lifecycle
- [x] `TestLvtPending_FalseForNonAsyncActions` — no false positives on non-async actions
- [x] Full test suite passes (all packages)

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)