### PR TITLE
feat: LiveHandler.Func() for stdlib http.HandleFunc mounting (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to LiveTemplate will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`LiveHandler.Func()` returns `ServeHTTP` as an `http.HandlerFunc`.** The
+  value `Template.Handle()` returns already satisfied `http.Handler`, so
+  `http.Handle`/`mux.Handle` worked, but the stdlib entry points that take a
+  function — `http.HandleFunc`, and `ServeMux.HandleFunc` with Go 1.22 method
+  patterns — required spelling out `handler.ServeHTTP`. `Func()` is that method
+  value, so `http.HandleFunc("/counter", handler.Func())` and
+  `mux.HandleFunc("GET /counter", handler.Func())` read naturally. It is an
+  accessor, not a downgrade: `Shutdown`, `Publish` and `MetricsHandler` stay
+  available on the `LiveHandler` it came from.
+
+### Changed
+
+- **A failed WebSocket upgrade now logs a `hint` when the `http.ResponseWriter`
+  does not implement `http.Hijacker`.** An upgrade takes over the raw
+  connection, so middleware that wraps the writer (logging, gzip, status
+  capture) without forwarding `Hijack` breaks it — while GET and POST keep
+  rendering, making the symptom "the page renders but never goes live". The
+  underlying upgrader error names `http.Hijacker` but not the middleware that
+  caused it; the hint does, and points at forwarding `Hijack` or leaving the
+  writer unwrapped when `livetemplate.WSIsUpgrade(r)` is true.
+
 ## [v0.22.0] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rendering, making the symptom "the page renders but never goes live". The
   underlying upgrader error names `http.Hijacker` but not the middleware that
   caused it; the hint does, and points at forwarding `Hijack` or leaving the
-  writer unwrapped when `livetemplate.WSIsUpgrade(r)` is true.
+  writer unwrapped when `livetemplate.WSIsUpgrade(r)` is true. It is attached on
+  the writer's own defect, which need not be what the accompanying error reports
+  — an upgrader can reject a handshake earlier (a disallowed `Origin`) and never
+  reach the hijack — so it is worded as a second failure the upgrade would have
+  hit regardless, rather than as the reported cause.
 
 ## [v0.22.0] - 2026-07-26
 

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -426,9 +426,15 @@ type wrapped struct{ http.ResponseWriter }
 ```
 
 The failure is partial and easy to miss — GET and POST keep rendering, only the
-upgrade is refused with a 500 — so LiveTemplate logs a `hint` naming middleware
-as the cause. To keep such middleware, either forward `Hijack` to the underlying
-writer, or leave the writer unwrapped when `livetemplate.WSIsUpgrade(r)` is true.
+upgrade is refused with a 500 — so a failed upgrade logs a `hint` naming
+middleware whenever the writer is not hijackable. To keep such middleware,
+either forward `Hijack` to the underlying writer, or leave the writer unwrapped
+when `livetemplate.WSIsUpgrade(r)` is true.
+
+The hint is attached on the writer's own defect, which need not be what the
+accompanying `error` reports — an upgrader can reject a handshake earlier (a
+disallowed `Origin`, say) and never reach the hijack. Read it as a second
+failure the upgrade would have hit regardless, not as the reported cause.
 
 ---
 

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -375,6 +375,8 @@ type LiveHandler interface {
     http.Handler
     Shutdown(ctx context.Context) error
     MetricsHandler() http.Handler
+    Publish(topic, action string, data map[string]interface{}) error
+    Func() http.HandlerFunc
 }
 ```
 
@@ -385,6 +387,48 @@ Returned by `Template.Handle()`. Serves both HTTP and WebSocket requests.
 | `ServeHTTP` | Handles HTTP requests and WebSocket upgrades |
 | `Shutdown` | Gracefully drains connections with context timeout |
 | `MetricsHandler` | Returns Prometheus metrics endpoint handler |
+| `Publish` | Fans a topic action out to subscribers from outside an action handler ([PubSub](pubsub.md)) |
+| `Func` | Returns `ServeHTTP` as an `http.HandlerFunc` |
+
+### Standard library integration
+
+A `LiveHandler` is an ordinary `net/http` handler — one `ServeHTTP` serves the
+initial GET render, form-action POSTs, and the WebSocket upgrade. It composes
+with `net/http` routing directly, and `Func()` covers the entry points that take
+a function instead of an `http.Handler`:
+
+```go
+handler := tmpl.Handle(&CounterController{}, livetemplate.AsState(&CounterState{}))
+
+http.Handle("/counter", handler)                  // http.Handler
+mux.Handle("/counter", handler)                   // ServeMux
+http.HandleFunc("/counter", handler.Func())       // http.HandlerFunc
+mux.HandleFunc("GET /counter", handler.Func())    // Go 1.22+ method patterns
+mux.HandleFunc("POST /counter", handler.Func())   // form actions still dispatch
+```
+
+`Func()` is exactly `handler.ServeHTTP` — neither form is preferred, and taking
+it does not give up `Shutdown`, `Publish` or `MetricsHandler`, which stay on the
+`LiveHandler` it came from.
+
+Mounting under a subtree with `http.StripPrefix` is supported; the handler reads
+the request path as rewritten.
+
+**Middleware must forward `http.Hijacker`.** A WebSocket upgrade takes over the
+raw connection, so it needs the `http.ResponseWriter` to implement
+`http.Hijacker`. Middleware that only observes the request is fine; middleware
+that *wraps* the writer (logging, gzip, status capture) hides `Hijack` unless it
+forwards the method:
+
+```go
+// Breaks the upgrade: embedding promotes Write/Header/WriteHeader, not Hijack.
+type wrapped struct{ http.ResponseWriter }
+```
+
+The failure is partial and easy to miss — GET and POST keep rendering, only the
+upgrade is refused with a 500 — so LiveTemplate logs a `hint` naming middleware
+as the cause. To keep such middleware, either forward `Hijack` to the underlying
+writer, or leave the writer unwrapped when `livetemplate.WSIsUpgrade(r)` is true.
 
 ---
 

--- a/handlerfunc_test.go
+++ b/handlerfunc_test.go
@@ -131,7 +131,9 @@ func TestLiveHandler_Func_SplitAcrossMethodPatterns(t *testing.T) {
 
 // TestLiveHandler_Func_KeepsLifecycleMethods guards the reason Handle() returns
 // LiveHandler instead of a bare http.HandlerFunc: Func() is an accessor, not a
-// downgrade, so metrics/publish/shutdown stay reachable on the same value.
+// downgrade, so the lifecycle methods stay reachable on the same value while it
+// serves through the mux. Shutdown is left to shutdown_test.go, which owns the
+// teardown ordering against a live server.
 func TestLiveHandler_Func_KeepsLifecycleMethods(t *testing.T) {
 	handler := newStdlibHandler(t)
 
@@ -148,11 +150,10 @@ func TestLiveHandler_Func_KeepsLifecycleMethods(t *testing.T) {
 		t.Errorf("metrics endpoint missing livetemplate_templates_executed_total:\n%s", metrics)
 	}
 
+	// No subscribers here, so this asserts reachability rather than delivery —
+	// fan-out itself is covered by the topic tests.
 	if err := handler.Publish("announcements", "Increment", nil); err != nil {
 		t.Errorf("Publish after Func(): %v", err)
-	}
-	if err := handler.Shutdown(t.Context()); err != nil {
-		t.Errorf("Shutdown after Func(): %v", err)
 	}
 }
 

--- a/handlerfunc_test.go
+++ b/handlerfunc_test.go
@@ -1,0 +1,274 @@
+package livetemplate
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// These tests pin the standard-library integration surface: a LiveHandler is an
+// ordinary net/http handler, so it must work through http.HandleFunc, Go 1.22
+// method patterns, http.StripPrefix and middleware — including the WebSocket
+// upgrade, which is the only part of the request lifecycle stdlib wrapping can
+// break.
+
+type stdlibState struct {
+	Count int `lvt:"persist"`
+}
+
+type stdlibController struct{}
+
+func (c *stdlibController) Mount(state stdlibState, ctx *Context) (stdlibState, error) {
+	return state, nil
+}
+
+func (c *stdlibController) Increment(state stdlibState, ctx *Context) (stdlibState, error) {
+	state.Count++
+	return state, nil
+}
+
+func newStdlibHandler(t *testing.T) LiveHandler {
+	t.Helper()
+	tmpl := Must(Must(New("stdlib")).Parse(
+		`<div><span id="count">{{.Count}}</span><form method="POST"><button name="lvt-action" value="Increment">+</button></form></div>`))
+	return tmpl.Handle(&stdlibController{}, AsState(&stdlibState{}))
+}
+
+// stdlibClient keeps cookies across requests so the session group (and with it
+// the persisted Count) survives the POST → GET hop.
+func stdlibClient(t *testing.T) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar: %v", err)
+	}
+	return &http.Client{Jar: jar}
+}
+
+func getBody(t *testing.T, client *http.Client, target string) string {
+	t.Helper()
+	resp, err := client.Get(target)
+	if err != nil {
+		t.Fatalf("GET %s: %v", target, err)
+	}
+	return okBody(t, resp, "GET "+target)
+}
+
+// postAction submits a form action the way a browser without JavaScript does,
+// so the assertion covers the real POST dispatch path rather than the JSON one.
+func postAction(t *testing.T, client *http.Client, target, action string) string {
+	t.Helper()
+	form := url.Values{"lvt-action": {action}}
+	resp, err := client.Post(target, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("POST %s: %v", target, err)
+	}
+	return okBody(t, resp, "POST "+target)
+}
+
+func okBody(t *testing.T, resp *http.Response, what string) string {
+	t.Helper()
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s: status %d, want 200", what, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("%s: read body: %v", what, err)
+	}
+	return string(body)
+}
+
+func assertCount(t *testing.T, body, want string) {
+	t.Helper()
+	if marker := `<span id="count">` + want + `</span>`; !strings.Contains(body, marker) {
+		t.Errorf("rendered body missing %s\ngot: %s", marker, body)
+	}
+}
+
+// TestLiveHandler_Func_UsableWithStdlibHandleFunc is the issue's literal ask:
+// the value Handle() returns reaches http.HandleFunc, which takes a function
+// rather than an http.Handler. ServeMux.HandleFunc takes the same argument type
+// as the package-level http.HandleFunc, without mutating DefaultServeMux.
+func TestLiveHandler_Func_UsableWithStdlibHandleFunc(t *testing.T) {
+	handler := newStdlibHandler(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/counter", handler.Func())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	assertCount(t, getBody(t, stdlibClient(t), srv.URL+"/counter"), "0")
+}
+
+// TestLiveHandler_Func_SplitAcrossMethodPatterns covers the Go 1.22 routing
+// shape that a stdlib user is most likely to reach for. LiveTemplate routes the
+// initial render (GET) and form actions (POST) through one ServeHTTP, so
+// registering the same Func() under two method patterns has to keep dispatch
+// working rather than serving a bare re-render on POST.
+func TestLiveHandler_Func_SplitAcrossMethodPatterns(t *testing.T) {
+	handler := newStdlibHandler(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /counter", handler.Func())
+	mux.HandleFunc("POST /counter", handler.Func())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := stdlibClient(t)
+	assertCount(t, getBody(t, client, srv.URL+"/counter"), "0")
+	assertCount(t, postAction(t, client, srv.URL+"/counter", "Increment"), "1")
+}
+
+// TestLiveHandler_Func_KeepsLifecycleMethods guards the reason Handle() returns
+// LiveHandler instead of a bare http.HandlerFunc: Func() is an accessor, not a
+// downgrade, so metrics/publish/shutdown stay reachable on the same value.
+func TestLiveHandler_Func_KeepsLifecycleMethods(t *testing.T) {
+	handler := newStdlibHandler(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/counter", handler.Func())
+	mux.Handle("/metrics", handler.MetricsHandler())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := stdlibClient(t)
+	assertCount(t, getBody(t, client, srv.URL+"/counter"), "0")
+
+	if metrics := getBody(t, client, srv.URL+"/metrics"); !strings.Contains(metrics, "livetemplate_templates_executed_total") {
+		t.Errorf("metrics endpoint missing livetemplate_templates_executed_total:\n%s", metrics)
+	}
+
+	if err := handler.Publish("announcements", "Increment", nil); err != nil {
+		t.Errorf("Publish after Func(): %v", err)
+	}
+	if err := handler.Shutdown(t.Context()); err != nil {
+		t.Errorf("Shutdown after Func(): %v", err)
+	}
+}
+
+// TestLiveHandler_ServesBehindStripPrefix checks the handler tolerates being
+// mounted under a subtree: it tracks the last served path per session to detect
+// URL changes, and StripPrefix rewrites exactly that.
+func TestLiveHandler_ServesBehindStripPrefix(t *testing.T) {
+	handler := newStdlibHandler(t)
+
+	mux := http.NewServeMux()
+	mux.Handle("/app/", http.StripPrefix("/app", handler))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := stdlibClient(t)
+	assertCount(t, getBody(t, client, srv.URL+"/app/"), "0")
+	assertCount(t, postAction(t, client, srv.URL+"/app/", "Increment"), "1")
+}
+
+// passThroughMiddleware is the well-behaved shape: it observes the request but
+// hands the original ResponseWriter down, so http.Hijacker survives.
+func passThroughMiddleware(next http.Handler, seen *int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*seen++
+		next.ServeHTTP(w, r)
+	})
+}
+
+// nonHijackableWriter is the shape that breaks upgrades: embedding
+// http.ResponseWriter promotes Write/Header/WriteHeader but NOT Hijack, which
+// is what a logging or gzip middleware typically ends up doing.
+type nonHijackableWriter struct{ http.ResponseWriter }
+
+func wsDialURL(srv *httptest.Server, path string) string {
+	return "ws" + strings.TrimPrefix(srv.URL, "http") + path
+}
+
+// TestLiveHandler_WebSocketUpgrade_ThroughPassThroughMiddleware is the positive
+// composition case: wrapped in stdlib middleware and registered via HandleFunc,
+// the handler still upgrades and delivers the initial render.
+func TestLiveHandler_WebSocketUpgrade_ThroughPassThroughMiddleware(t *testing.T) {
+	handler := newStdlibHandler(t)
+
+	calls := 0
+	mux := http.NewServeMux()
+	mux.Handle("/counter", passThroughMiddleware(handler.Func(), &calls))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ws, _, err := websocket.DefaultDialer.Dial(wsDialURL(srv, "/counter"), nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial through middleware failed: %v", err)
+	}
+	defer func() { _ = ws.Close() }()
+
+	if err := ws.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	_, msg, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("read initial render: %v", err)
+	}
+	if !strings.Contains(string(msg), `id=\"count\"`) {
+		t.Errorf("initial render over WS missing rendered template: %s", msg)
+	}
+	if calls == 0 {
+		t.Error("middleware was bypassed")
+	}
+}
+
+// TestLiveHandler_WebSocketUpgrade_WriterWrappingMiddlewareIsDiagnosed pins the
+// one stdlib composition that cannot work, and the log line that says why. The
+// upgrade is refused cleanly (no panic) and the hint names middleware as the
+// cause, because the upgrader's own error mentions only http.Hijacker.
+//
+// Note: this test mutates the global slog.Default() via SetDefault, so it must
+// not run in parallel with tests that assert on log output.
+func TestLiveHandler_WebSocketUpgrade_WriterWrappingMiddlewareIsDiagnosed(t *testing.T) {
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelError})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	handler := newStdlibHandler(t)
+	stripHijacker := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(nonHijackableWriter{w}, r)
+		})
+	}
+	srv := httptest.NewServer(stripHijacker(handler))
+	defer srv.Close()
+
+	_, resp, err := websocket.DefaultDialer.Dial(wsDialURL(srv, "/"), nil)
+	if err == nil {
+		t.Fatal("expected the upgrade to fail behind a writer-wrapping middleware")
+	}
+	if resp == nil {
+		t.Fatalf("expected an HTTP response describing the failure, got dial error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("upgrade status = %d, want 500", resp.StatusCode)
+	}
+
+	// Assert on the hint's own wording, not on "http.Hijacker" — the upgrader's
+	// error already carries that phrase, so matching it would pass even if the
+	// hint were dropped.
+	got := logs.String()
+	if !strings.Contains(got, "WebSocket upgrade failed") {
+		t.Errorf("upgrade failure was not logged:\n%s", got)
+	}
+	if !strings.Contains(got, "middleware in front of this handler is wrapping the writer") {
+		t.Errorf("log does not name middleware as the cause:\n%s", got)
+	}
+
+	// GET still renders — the failure is scoped to the upgrade, which is what
+	// makes it easy to miss without the hint.
+	assertCount(t, getBody(t, stdlibClient(t), srv.URL+"/"), "0")
+}

--- a/handlerfunc_test.go
+++ b/handlerfunc_test.go
@@ -36,11 +36,24 @@ func (c *stdlibController) Increment(state stdlibState, ctx *Context) (stdlibSta
 	return state, nil
 }
 
-func newStdlibHandler(t *testing.T) LiveHandler {
+func newStdlibHandler(t *testing.T, opts ...Option) LiveHandler {
 	t.Helper()
-	tmpl := Must(Must(New("stdlib")).Parse(
+	tmpl := Must(Must(New("stdlib", opts...)).Parse(
 		`<div><span id="count">{{.Count}}</span><form method="POST"><button name="lvt-action" value="Increment">+</button></form></div>`))
 	return tmpl.Handle(&stdlibController{}, AsState(&stdlibState{}))
+}
+
+// captureErrorLogs redirects slog.Default() for the duration of the test so an
+// assertion can read what the handler logged. It mutates global state, so tests
+// using it must not run in parallel — consistent with this package, which has
+// no parallel tests.
+func captureErrorLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelError})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &logs
 }
 
 // stdlibClient keeps cookies across requests so the session group (and with it
@@ -228,14 +241,8 @@ func TestLiveHandler_WebSocketUpgrade_ThroughPassThroughMiddleware(t *testing.T)
 // one stdlib composition that cannot work, and the log line that says why. The
 // upgrade is refused cleanly (no panic) and the hint names middleware as the
 // cause, because the upgrader's own error mentions only http.Hijacker.
-//
-// Note: this test mutates the global slog.Default() via SetDefault, so it must
-// not run in parallel with tests that assert on log output.
 func TestLiveHandler_WebSocketUpgrade_WriterWrappingMiddlewareIsDiagnosed(t *testing.T) {
-	var logs bytes.Buffer
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelError})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
+	logs := captureErrorLogs(t)
 
 	handler := newStdlibHandler(t)
 	stripHijacker := func(next http.Handler) http.Handler {
@@ -272,4 +279,35 @@ func TestLiveHandler_WebSocketUpgrade_WriterWrappingMiddlewareIsDiagnosed(t *tes
 	// GET still renders — the failure is scoped to the upgrade, which is what
 	// makes it easy to miss without the hint.
 	assertCount(t, getBody(t, stdlibClient(t), srv.URL+"/"), "0")
+}
+
+// TestLiveHandler_WebSocketUpgrade_HintOnlyWhenWriterIsNotHijackable keeps the
+// hint from becoming a red herring. An upgrader rejects a handshake for reasons
+// it checks before it ever reaches the hijack — a disallowed Origin here — and
+// on a plain (hijackable) writer that has nothing to do with middleware, so the
+// hint must stay off.
+func TestLiveHandler_WebSocketUpgrade_HintOnlyWhenWriterIsNotHijackable(t *testing.T) {
+	logs := captureErrorLogs(t)
+
+	// DevMode defaults off, so an Origin outside the allowed list is rejected.
+	handler := newStdlibHandler(t, WithAllowedOrigins([]string{"https://allowed.example"}))
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	header := http.Header{"Origin": []string{"https://disallowed.example"}}
+	if _, resp, err := websocket.DefaultDialer.Dial(wsDialURL(srv, "/"), header); err == nil {
+		t.Fatal("expected the upgrade to be rejected for a disallowed origin")
+	} else if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	// The positive assertion keeps this from passing vacuously: the rejection
+	// must actually have been logged for the absent hint to mean anything.
+	got := logs.String()
+	if !strings.Contains(got, "WebSocket upgrade failed") {
+		t.Fatalf("origin rejection was not logged, so the hint check proves nothing:\n%s", got)
+	}
+	if strings.Contains(got, "middleware in front of this handler is wrapping the writer") {
+		t.Errorf("hint fired on a hijackable writer, misattributing an origin rejection:\n%s", got)
+	}
 }

--- a/mount.go
+++ b/mount.go
@@ -135,6 +135,22 @@ type LiveHandler interface {
 	// malformed developer topic); a transport failure to a remote instance is
 	// logged, not returned (local fan-out still succeeds).
 	Publish(topic, action string, data map[string]interface{}) error
+
+	// Func returns ServeHTTP as an http.HandlerFunc, for the stdlib entry
+	// points that take a function rather than an http.Handler.
+	//
+	//   handler := tmpl.Handle(&CounterController{}, livetemplate.AsState(&CounterState{}))
+	//   http.HandleFunc("/counter", handler.Func())
+	//   mux.HandleFunc("GET /counter", handler.Func())   // Go 1.22+ method patterns
+	//
+	// It is exactly h.ServeHTTP — same request handling, same GET/POST/upgrade
+	// routing — so http.Handle(pattern, handler) stays equally valid and neither
+	// form is preferred over the other. Func exists so the handler can be passed
+	// where an http.HandlerFunc is wanted without an explicit method value.
+	//
+	// The returned func closes over the handler, so Shutdown, Publish and
+	// MetricsHandler remain available on the LiveHandler it came from.
+	Func() http.HandlerFunc
 }
 
 // defaultEphemeralSweepTTL is how long idle HTTP template cache entries survive in
@@ -404,6 +420,18 @@ func (h *liveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (h *liveHandler) Func() http.HandlerFunc { return h.ServeHTTP }
+
+// hijackerHint names the one way stdlib middleware breaks a LiveTemplate
+// handler: an upgrade takes over the raw connection, so it needs the writer to
+// implement http.Hijacker, and middleware that wraps the writer (logging, gzip,
+// status capture) hides Hijack unless it forwards the method. GET and POST keep
+// rendering, so the symptom is "the page renders but never goes live" — and the
+// upgrader's own error names Hijacker but not the middleware that caused it.
+const hijackerHint = "the http.ResponseWriter does not implement http.Hijacker, which a WebSocket upgrade requires; " +
+	"middleware in front of this handler is wrapping the writer without forwarding Hijack — either forward it, " +
+	"or leave the writer unwrapped when livetemplate.WSIsUpgrade(r) is true"
+
 func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Check if shutting down - reject new connections
 	if h.isShutdown.Load() {
@@ -454,9 +482,14 @@ func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Upgrade to WebSocket after authentication and limit check succeeds
 	conn, err := h.config.Upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		slog.Error("WebSocket upgrade failed",
+		attrs := []any{
 			slog.String("component", "live_handler"),
-			slog.Any("error", err))
+			slog.Any("error", err),
+		}
+		if _, ok := w.(http.Hijacker); !ok {
+			attrs = append(attrs, slog.String("hint", hijackerHint))
+		}
+		slog.Error("WebSocket upgrade failed", attrs...)
 		return
 	}
 	defer func() {

--- a/mount.go
+++ b/mount.go
@@ -428,9 +428,15 @@ func (h *liveHandler) Func() http.HandlerFunc { return h.ServeHTTP }
 // status capture) hides Hijack unless it forwards the method. GET and POST keep
 // rendering, so the symptom is "the page renders but never goes live" — and the
 // upgrader's own error names Hijacker but not the middleware that caused it.
-const hijackerHint = "the http.ResponseWriter does not implement http.Hijacker, which a WebSocket upgrade requires; " +
-	"middleware in front of this handler is wrapping the writer without forwarding Hijack — either forward it, " +
-	"or leave the writer unwrapped when livetemplate.WSIsUpgrade(r) is true"
+//
+// It is attached whenever the writer is not hijackable, which need not be what
+// the accompanying error reports: an upgrader may reject the handshake earlier
+// (a disallowed Origin, say) and never reach the hijack. So the wording states
+// the writer defect and its consequence rather than claiming to be the reported
+// cause — it is a second failure the upgrade would have hit regardless.
+const hijackerHint = "the http.ResponseWriter does not implement http.Hijacker, so this upgrade could not have " +
+	"succeeded regardless of the error above: middleware in front of this handler is wrapping the writer without " +
+	"forwarding Hijack — either forward it, or leave the writer unwrapped when livetemplate.WSIsUpgrade(r) is true"
 
 func (h *liveHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Check if shutting down - reject new connections


### PR DESCRIPTION
# Done: issue #474 — LiveTemplate on standard `net/http`

Branch `issue-474`, two commits on top of `main` (v0.22.0).

## Answer to the investigation

Yes — the core already is a standard handler. One `ServeHTTP` routes the initial
GET render, form-action POSTs and the WebSocket upgrade, so `http.Handle` and
`mux.Handle` worked before this change. The only gap was ergonomic, and the
audit turned up exactly one composition that genuinely fails.

## Changes

**`mount.go`**
- `LiveHandler.Func() http.HandlerFunc` — returns `ServeHTTP` as a method value,
  for the stdlib entry points that take a function: `http.HandleFunc("/counter",
  handler.Func())` and `mux.HandleFunc("GET /counter", handler.Func())`.
  An accessor, not a downgrade — `Shutdown`, `Publish` and `MetricsHandler` stay
  on the `LiveHandler` it came from, which is why `Handle()` keeps returning the
  richer type rather than a bare `http.HandlerFunc`.
- A failed WebSocket upgrade now logs a `hint` when the `http.ResponseWriter`
  does not implement `http.Hijacker`. Placed at the `Upgrade` error site rather
  than in `ServeHTTP`, because `WithUpgrader` is public and a `ServeHTTP`
  precheck would break custom upgraders that don't hijack.

**`handlerfunc_test.go`** (new) — six tests pinning the composition surface.

**`docs/references/api-reference.md`** — new "Standard library integration"
section; the `LiveHandler` block also gains the `Publish` method it had drifted
from (it listed only `ServeHTTP`/`Shutdown`/`MetricsHandler`).

**`CHANGELOG.md`** — `[Unreleased]` Added + Changed entries.

## Verified empirically, not assumed

| Composition | Result |
|---|---|
| `http.Handle` / `mux.Handle` | worked already |
| `mux.HandleFunc` + `Func()` | works |
| `GET /x` + `POST /x` method patterns | works, POST dispatch intact |
| `http.StripPrefix` subtree | works, GET and POST |
| pass-through middleware + WS upgrade | works |
| writer-wrapping middleware + WS upgrade | **fails** — 500, now diagnosed |

The last row is inherent to `net/http` plus any WebSocket library: an upgrade
takes over the raw connection, so it needs `http.Hijacker`, and middleware that
wraps the writer (logging, gzip, status capture) hides `Hijack` unless it
forwards the method. The failure is partial — GET and POST keep rendering, so
the symptom is "the page renders but never goes live" — and the upgrader's own
error names `Hijacker` but not the middleware that caused it. Hence the hint.

## Test notes

- The hint assertion was **negative-gated**: deleting the hint from `mount.go`
  turns the test red. The first version of that assertion matched
  `"http.Hijacker"`, which gorilla's own error already contains — it would have
  passed with the hint removed. It now matches the hint's own wording.
- `Publish` in the lifecycle test asserts reachability, not delivery (no
  subscribers); fan-out is covered by the topic tests.
- The second commit scopes that test off `Shutdown`, which was racing
  `srv.Close()` in deferred teardown.

## Checks

Full suite (`go test ./...`), `golangci-lint` with the pre-commit set, `-race`
on the new tests, and the pre-commit hook on both commits — all green. No
`--no-verify`.

## Deliberately not done

- **No new `../docs/examples` app.** This is a two-line accessor with no
  behavior change and no new user-facing concept; in-repo reference docs is the
  right scope.
- **No chromedp E2E.** `Func()` returns the identical `ServeHTTP`, so there is
  no render or wire-path delta. The WebSocket-through-middleware cases are
  covered by real upgrade tests over `httptest` servers.

## Note for the reviewer

The branch was 23 commits behind `main` (v0.19.1) when this started and was
fast-forwarded first. `.muster/plan.md` is tracked in `main` holding a
*different* issue's plan (#481) — `main`'s version was left in place and is not
part of either commit. This `done.md` is untracked by design.

Closes #474