### PR TITLE
docs: lead with Async/Pending, document Validate, record the lvt-el overlay

### DIFF
--- a/docs/guides/OBSERVABILITY.md
+++ b/docs/guides/OBSERVABILITY.md
@@ -401,6 +401,6 @@ func RequestIDMiddleware(next http.Handler) http.Handler {
 
 ## Related Documentation
 
-- [ARCHITECTURE.md](ARCHITECTURE.md) - System architecture overview
-- [internal/observe/](../internal/observe/) - Package implementation
+- [ARCHITECTURE.md](../design/ARCHITECTURE.md) - System architecture overview
+- [internal/observe/](../../internal/observe/) - Package implementation
 - [Go slog documentation](https://pkg.go.dev/log/slog) - Standard library reference

--- a/docs/guides/SCALING.md
+++ b/docs/guides/SCALING.md
@@ -1393,7 +1393,7 @@ If issues arise after migration:
 3. **Set up alerting** for Redis connectivity issues
 4. **Review capacity planning** for expected load
 
-See [SESSION.md](SESSION.md) for the Session API guide on server-initiated actions.
+See [session.md](../references/session.md) for the Session API guide on server-initiated actions.
 
 ---
 
@@ -1862,7 +1862,7 @@ redis_connected_clients{instance="redis1"} > 9000  # 90% of Redis max clients
 ## Next Steps
 
 - **Roadmap:** See [ROADMAP.md](../../ROADMAP.md) for upcoming scaling features
-- **Architecture:** See [ARCHITECTURE.md](ARCHITECTURE.md) for system design
+- **Architecture:** See [ARCHITECTURE.md](../design/ARCHITECTURE.md) for system design
 
 ---
 

--- a/docs/guides/progressive-complexity.md
+++ b/docs/guides/progressive-complexity.md
@@ -228,10 +228,11 @@ LiveTemplate offers three loading models. Pick the simplest one that fits your u
 |---|---|---|---|
 | Grey out the form | N/A | **7.1 — Auto** (`<fieldset>` + CSS) | 0 lines, 0 attrs |
 | Custom loading UX (spinner, text) | Yes | **7.2 — Client-owned pending** (`lvt-el:*:on:pending`) | 0 lines, 2 attrs |
-| Custom loading UX (spinner, text) | **No** | **7.3 — Server-owned loading** with `Async` + `{{.lvt.Pending}}` | ~5 lines, 0 attrs |
-| Loading fans out to peers / survives reconnect | Either | **7.3 — Server-owned loading** with manual `Loading` field + `ctx.Publish()` | ~15 lines, 0 attrs |
+| Custom loading UX (spinner, text) | **No** | **7.3 — Server-owned loading** with `Async` + `{{.lvt.Pending}}` | ~7 lines, 0 attrs |
+| Loading fans out to peers / survives reconnect | Either | **7.3 — Server-owned loading** with `Async` + a `Loading` field | ~9 lines, 0 attrs |
+| Work starts in `Mount`/`OnConnect`, or reports progress repeatedly | Either | **7.3 — Escape hatch**: manual two-action pattern | ~15 lines, 0 attrs |
 
-**Rule of thumb:** start with 7.1. Move to 7.2 or 7.3 only when you need custom UX (spinners, text changes, progress indicators) or loading that is real application state.
+**Rule of thumb:** start with 7.1. Move to 7.2 or 7.3 only when you need custom UX (spinners, text changes, progress indicators) or loading that is real application state. Within 7.3, reach for the manual two-action pattern only when `Async` is unavailable — it is not the default any more.
 
 ### 7.1 Automatic Form Loading (Tier 1)
 
@@ -285,11 +286,109 @@ The `pending` state fires instantly on click (before the server even receives th
 
 **Trade-offs:** the pending state is client-only — it does not fan out to peer tabs, does not survive reconnect, and cannot drive server-side logic. The action blocks the event loop for its duration (no other clicks or peer pushes until it returns). For loading that is real application state, use 7.3.
 
+It *does* survive a server re-render. Since `@livetemplate/client` v0.18.1 the classes and attributes applied by `lvt-el:` are client-owned: the morph pass re-applies them after each server patch, so re-rendering the element does not wipe the pending class. You do not need `lvt-ignore-attrs` to protect them.
+
 See the [Client Attributes Reference — Reactive Attributes](../references/client-attributes.md#reactive-attributes) for the full `lvt-el:*` pattern.
 
 ### 7.3 Server-Owned Loading (Tier 1)
 
-When loading is real application state — it needs to fan out to peers, survive reconnect, or drive server-side logic — use a server-owned `Loading` field in your state with `{{if .Loading}}` in the template. This keeps everything in Tier 1 (no `lvt-*` attributes), but requires the manual two-action pattern:
+When loading is real application state — it needs to survive reconnect, fan out to peers, or drive server-side logic — model it on the server and render it with ordinary template conditionals. This keeps everything in Tier 1 (no `lvt-*` attributes).
+
+`livetemplate.Async` is the primitive. It runs slow work off the event loop, then re-enters the loop to apply the result to the current state and re-render — one method, no manual goroutine, no dispatch plumbing:
+
+```go
+func Async[S any, R any](
+    ctx *Context,
+    work  func(context.Context) (R, error),
+    apply func(s S, result R, err error) (S, error),
+)
+```
+
+**Scope:** `Async` is supported only inside **action handlers** (e.g. `Greet`, `Save`) that run on the per-connection WebSocket event loop. Calling it from `Mount()`, `OnConnect()`, dispatched actions, server-initiated actions, upload handlers, or HTTP POST handlers logs a warning and drops the operation — there is no event loop to re-enter. Those cases need the [manual two-action pattern](#escape-hatch-the-manual-two-action-pattern) below.
+
+#### The default: `Async` + `{{.lvt.Pending}}`
+
+When the loading indicator is purely visual, you do not need a `Loading` field at all. `{{.lvt.Pending}}` is a framework-provided template variable — `true` on the render that registered async work, `false` on every other render (including the completion render):
+
+```go
+func (c *Controller) Greet(state State, ctx *livetemplate.Context) (State, error) {
+    name := strings.TrimSpace(ctx.GetString("name"))
+    livetemplate.Async(ctx,
+        func(ctx context.Context) (string, error) {
+            time.Sleep(700 * time.Millisecond) // simulate slow work
+            return name, nil
+        },
+        func(s State, name string, err error) (State, error) {
+            s.Name = name
+            return s, nil
+        },
+    )
+    return state, nil
+}
+```
+
+```html
+<button name="greet" {{if .lvt.Pending}}disabled{{end}}>
+    {{if .lvt.Pending}}Loading...{{else}}Greet{{end}}
+</button>
+```
+
+No `Loading` field, no `lvt-*` attributes, one method — pure Go and standard HTML templates.
+
+`{{.lvt.Pending}}` has **per-render** semantics: if another action or a peer dispatch triggers a render on the same connection while the work is still in flight, that render sees `Pending=false`. For an indicator that must stay visible across interleaved renders, use an explicit field — next section.
+
+#### When loading is real state: `Async` + a `Loading` field
+
+Keep a `Loading` field when the loading state has to do more than paint the screen — drive a re-entrancy guard, fan out to peers, or survive a reconnect:
+
+```go
+type State struct {
+    Name    string
+    Loading bool
+}
+
+func (c *Controller) Greet(state State, ctx *livetemplate.Context) (State, error) {
+    state.Loading = true
+    name := strings.TrimSpace(ctx.GetString("name"))
+    livetemplate.Async(ctx,
+        func(ctx context.Context) (string, error) {
+            time.Sleep(700 * time.Millisecond) // simulate slow work
+            return name, nil
+        },
+        func(s State, name string, err error) (State, error) {
+            s.Name = name
+            s.Loading = false
+            return s, nil
+        },
+    )
+    return state, nil // render #1: Loading=true
+    // render #2 happens when work completes: Loading=false
+}
+```
+
+```html
+<button name="greet" {{if .Loading}}disabled{{end}}>
+    {{if .Loading}}Loading...{{else}}Greet{{end}}
+</button>
+```
+
+The key guarantees:
+- **`apply` sees the current state**, not a snapshot — any actions that ran during the async window are visible. Mutate only the fields you own.
+- **`work` must not touch session state** — only its own inputs. It receives a `context.Context` tied to the connection's lifetime.
+- **Connection-scoped** — only the originating connection gets the completion render. To fan out to peers, capture `session := ctx.Session()` *before* defining `apply` and call `session.TriggerAction()` from inside it; `ctx` itself is not in scope there.
+- **Lifetime-bound** — if the connection closes before `work` completes, the goroutine is cancelled and `apply` never runs.
+
+If the indicator must survive a **reconnect**, the field has to carry the `lvt:"persist"` tag. Unpersisted fields reset to their zero value on reconnect, so a guard reading an untagged `Loading` never fires on the new connection.
+
+See the [Async API reference](../references/api-reference.md#async) for the full contract.
+
+#### Escape hatch: the manual two-action pattern
+
+Before `Async`, server-owned loading required two methods: one to set `Loading=true` and spawn the work, another to apply the result. You still need that shape when:
+
+- **the work starts where `Async` is illegal** — `Mount`, `OnConnect`, upload handlers, HTTP POST handlers (see *Scope* above);
+- **the work reports progress repeatedly** rather than completing once. `Async` is one-shot — one `work`, one `apply` — so a ticker, a progress bar, or a streaming job still spawns a goroutine that calls `TriggerAction` per update;
+- **you are re-spawning in-flight work after a reconnect**, which by definition begins in `OnConnect`.
 
 ```go
 type State struct {
@@ -323,82 +422,14 @@ func (c *Controller) FinishGreet(state State, ctx *livetemplate.Context) (State,
 }
 ```
 
-```html
-<button name="greet" {{if .Loading}}disabled{{end}}>
-    {{if .Loading}}Loading...{{else}}Greet{{end}}
-</button>
-```
+**Why two methods?** LiveTemplate's event loop processes one action per render cycle. To show a spinner *and later* clear it, the slow work must return early (render #1: spinner on) and re-enter the event loop via `Session.TriggerAction` (render #2: spinner off). `Async` does exactly this for you — the two renders are the same, only the bookkeeping moves into the framework.
 
-**Why two methods?** LiveTemplate's event loop processes one action per render cycle. To show a spinner *and later* clear it, the slow work must return early (render #1: spinner on) and re-enter the event loop via `Session.TriggerAction` (render #2: spinner off).
-
-**Four things to get right:**
+**Four things to get right** (all of them handled for you by `Async`):
 
 1. **Re-entrancy guard** (`if state.Loading { return }`): prevents double-clicks from spawning duplicate goroutines. The `{{if .Loading}}disabled{{end}}` on the button is the UI-level guard; the Go check is the server-level backup.
 2. **Session nil-check** (`if session == nil`): `ctx.Session()` returns nil during initial HTTP renders (before WebSocket connects). The goroutine + `TriggerAction` pattern requires a live session.
 3. **Goroutine lifetime**: the goroutine should be short-lived. If the connection drops, `TriggerAction` returns `ErrSessionDisconnected` — the goroutine exits cleanly.
 4. **Second action name**: the `FinishGreet` method name must match the string passed to `TriggerAction`. A typo silently fails (the action dispatches but no method handles it).
-
-**Trade-offs vs 7.2:** more verbose (~15 lines across 2 methods), but the loading state is real server state — it fans out to peers via `ctx.Publish()`, survives reconnect (it's in the state struct), and can drive server-side logic (e.g., preventing concurrent operations).
-
-#### Simplified with `Async`
-
-`livetemplate.Async` collapses the two-method pattern to one method (~7 lines) by handling the goroutine, dispatch channel, and re-entry automatically:
-
-```go
-func (c *Controller) Greet(state State, ctx *livetemplate.Context) (State, error) {
-    state.Loading = true
-    name := strings.TrimSpace(ctx.GetString("name"))
-    livetemplate.Async(ctx,
-        func(ctx context.Context) (string, error) {
-            time.Sleep(700 * time.Millisecond) // simulate slow work
-            return name, nil
-        },
-        func(s State, name string, err error) (State, error) {
-            s.Name = name
-            s.Loading = false
-            return s, nil
-        },
-    )
-    return state, nil // render #1: Loading=true
-    // render #2 happens when work completes: Loading=false
-}
-```
-
-The template is identical — `{{if .Loading}}` works the same way. The key guarantees:
-- **`apply` sees the current state**, not a snapshot — any actions that ran during the async window are visible
-- **Connection-scoped** — only the originating connection gets the completion render
-- **Lifetime-bound** — if the connection closes, the goroutine is cancelled and `apply` is skipped
-
-See the [Async API reference](../references/api-reference.md#async) for the full contract.
-
-#### Zero-boilerplate with `{{.lvt.Pending}}`
-
-When loading is purely visual (no need for a `Loading` field in state), combine `Async` with the framework-provided `{{.lvt.Pending}}` template variable. It is `true` on the render that registered async work and `false` on all other renders (including the async completion render):
-
-```go
-func (c *Controller) Greet(state State, ctx *livetemplate.Context) (State, error) {
-    name := strings.TrimSpace(ctx.GetString("name"))
-    livetemplate.Async(ctx,
-        func(ctx context.Context) (string, error) {
-            time.Sleep(700 * time.Millisecond)
-            return name, nil
-        },
-        func(s State, name string, err error) (State, error) {
-            s.Name = name
-            return s, nil
-        },
-    )
-    return state, nil
-}
-```
-
-```html
-<button name="greet" {{if .lvt.Pending}}disabled{{end}}>
-    {{if .lvt.Pending}}Loading...{{else}}Greet{{end}}
-</button>
-```
-
-No `Loading` field, no `lvt-*` attributes — pure Go + standard HTML templates. Use `{{.lvt.Pending}}` when the loading indicator is chrome (visual feedback). Use an explicit `Loading` state field (with `Async`) when loading is real application state that needs to fan out to peers or survive reconnect.
 
 ---
 

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -381,6 +381,12 @@ from ~15 lines / 2 methods to ~7 lines / 1 method.
   `session := ctx.Session()` before defining `apply`, then call
   `session.TriggerAction()` from within the `apply` closure (`ctx`
   itself is not in scope inside `apply`).
+- **`apply` receives only `(state, result, err)`** — there is no `*Context`,
+  so the completion render cannot set a flash, write a cookie, or navigate.
+  Anything that needs `ctx` on the *second* render has to arrive as a real
+  action: keep the manual two-action pattern, or capture the session and
+  `TriggerAction` from inside `apply`. State changes are unaffected — those
+  are what `apply` returns.
 
 **Example:**
 

--- a/docs/references/api-reference.md
+++ b/docs/references/api-reference.md
@@ -109,6 +109,70 @@ handler := tmpl.Handle(&TodoController{DB: db}, livetemplate.AsState(&TodoState{
 
 ---
 
+## Validate
+
+```go
+func Validate(templateText string, opts ...ValidateOption) ([]Diagnostic, error)
+```
+
+Parses `templateText` the way the live renderer does — against the framework's real function set and any supplied component templates — and returns the problems found. An empty slice means the template parses cleanly and will be served rather than silently dropped.
+
+**Why this exists:** `Execute` and `ExecuteUpdates` catch a first-render failure and fall back to an HTML-structure tree. A malformed template — an unclosed `{{range}}`, an unknown function, an unresolved `{{template}}` — therefore renders *degraded* and returns no error. A tool that wants to reject a bad template **before** serving it had nothing to call. `Validate` is that call.
+
+```go
+type Diagnostic struct {
+    Line     int      // 1-based line in the supplied text; 0 if the parser reported none
+    Severity Severity // SeverityError today; SeverityWarning is reserved
+    Message  string
+}
+```
+
+| Severity | Meaning |
+|---|---|
+| `SeverityError` | A problem that prevents the template from being served: the block is dropped at serve time and renders nothing. |
+| `SeverityWarning` | Reserved for problems that degrade a template rather than break it — the home for the data-dependent checks a future sample-data mode would surface. Not emitted today. |
+
+**Diagnostics are not errors.** The returned `error` is reserved for infrastructure failures — a component set that itself fails to parse, or an internal fault. A template that does not parse is *always* reported as a `Diagnostic`, never as an `error`. This mirrors the shape of a linter: problems in the input are data, not errors.
+
+```go
+diags, err := livetemplate.Validate(text)
+if err != nil {
+    return fmt.Errorf("validation could not run: %w", err) // infrastructure fault
+}
+for _, d := range diags {
+    fmt.Printf("%s:%d: %s: %s\n", path, d.Line, d.Severity, d.Message)
+}
+if len(diags) > 0 {
+    return errors.New("template rejected")
+}
+```
+
+**What it checks:** the syntax and composition layer — unclosed or malformed actions (`{{range}}`, `{{if}}`, `{{with}}`), unknown functions (checked against the framework's own builtins, which a downstream caller cannot enumerate, so this check cannot be reproduced outside the module), and unresolved component or composition templates.
+
+**What it does not check:** data-dependent problems that only surface when the template is executed against a value. Those are out of scope until a sample-data mode is added.
+
+**At most one diagnostic per call today.** The underlying parser stops at the first error rather than recovering, so the slice has length 0 or 1. The slice shape anticipates the multi-error reporting a recovering pass could add.
+
+### Validating templates that use components
+
+```go
+func WithValidateComponents(sets ...*TemplateSet) ValidateOption
+```
+
+Makes the given component template sets available, so a template invoking `{{template "ns:name" .}}` resolves the same way it does at serve time. Pass the same sets you pass to `New(WithComponentTemplates(...))`; **without them a component reference is reported — correctly — as an unresolved template.**
+
+```go
+diags, err := livetemplate.Validate(text,
+    livetemplate.WithValidateComponents(uiKit),
+)
+```
+
+Each call re-parses the supplied component sets from their `fs.FS`. That suits pre-serve and dev-time validation rather than per-keystroke use against a large component library.
+
+> **Line-number caveat:** HTML comments are stripped before parsing (matching serve), so a diagnostic below a multi-line HTML comment can report a line shifted by the comment's height.
+
+---
+
 ## Controller+State Pattern
 
 For patterns, examples, and usage guide, see [Controller+State Pattern](controller-pattern.md).

--- a/docs/references/client-attributes.md
+++ b/docs/references/client-attributes.md
@@ -865,6 +865,26 @@ Any form element that currently has focus is skipped during morphdom updates, pr
 
 To override this for a specific input — e.g., when a server-controlled value must always win — add `data-lvt-force-update` to the element.
 
+### Client-Applied Classes and Attributes (`lvt-el:`)
+
+Classes and attributes applied by the five state-mutating [`lvt-el:` actions](#reactive-attributes) — `addClass`, `removeClass`, `toggleClass`, `setAttr`, `toggleAttr` — are **client-owned**. The client records what it applied and re-applies that record onto the incoming element before morphdom compares them, so a server re-render does not wipe it.
+
+```html
+<!-- Stays open across an unrelated server re-render -->
+<div lvt-el:toggleClass:on:click="open" class="menu">…</div>
+```
+
+The rules:
+
+- **The client overlay wins on conflict.** A `removeClass` of a class the server still emits also survives — which is what makes click-away dismissal work.
+- **The server re-owns on agreement.** Once the server's own output matches what the client applied, the record self-cleans. Toggling back likewise retires the entry.
+- **It is not gated on the directive still being present.** This is persistent state, not a one-shot latch — a `data-lvt-target`-ed binding lands on an element carrying no `lvt-el:*` attribute at all, and its state is still preserved.
+- **Element identity is required.** The `replaceWith` / `replaceChildren` paths destroy the node, so client-owned state legitimately dies with it.
+
+You do **not** need `lvt-ignore-attrs` here — see the note under [Manual Preservation](#manual-preservation-with-lvt-ignore) for why it never worked for this case.
+
+**Requires `@livetemplate/client` v0.18.1 or newer.**
+
 ### Overriding with `data-lvt-force-update`
 
 All automatic preservation behaviors can be overridden by adding `data-lvt-force-update` to the element in the server template. When present, the server's value wins over the client-side state. The client strips the attribute from the live DOM after applying the update; because it lives in the server template, the server re-sends it on every render, so it continuously forces the server value.
@@ -880,6 +900,7 @@ All automatic preservation behaviors can be overridden by adding `data-lvt-force
 | Dialog `open` | morphdom update skipped while dialog is open | `data-lvt-force-update` on the dialog |
 | Datalist dropdown | Entire morphdom pass deferred while datalist input focused | `data-lvt-force-update` on the connected `<input>` (overrides deferral for the entire pass) |
 | Focused input elements | morphdom update skipped | `data-lvt-force-update` on the input |
+| Client-applied `lvt-el:` classes/attrs | Overlay record re-applied to the incoming element before morphdom | Server re-owns automatically once its output agrees; the record self-cleans |
 
 ### Manual Preservation with `lvt-ignore`
 
@@ -888,6 +909,8 @@ For cases where automatic preservation doesn't cover your needs, two attributes 
 - **`lvt-ignore`** — Skips the element and its entire subtree during morphdom diff. Use this for third-party widgets (maps, rich-text editors) whose DOM is managed by external JavaScript. Checked on the live DOM element, so it can be set from templates or client JS. Equivalent to Phoenix LiveView's `phx-update="ignore"`.
 
 - **`lvt-ignore-attrs`** — Skips attribute diffing but still diffs children. Use this when client-set attributes (e.g., `open` on `<details>`) need to survive server updates while child content remains server-managed.
+
+  > **Not the tool for `lvt-el:` state.** `lvt-ignore-attrs` only copies attributes the incoming element *lacks*, and any element using `toggleClass` already carries a server-emitted base `class` — so `class` was always skipped and the client's token was lost anyway. Classes and attributes applied by `lvt-el:` are preserved automatically; see [Client-Applied Classes and Attributes](#client-applied-classes-and-attributes-lvt-el).
 
 Both can be overridden by `data-lvt-force-update` when the server needs to take control — adding it to an `lvt-ignore` element re-enables morphdom for that subtree for the current update.
 
@@ -1056,7 +1079,7 @@ Directives use CSS custom properties for configuration: `--lvt-scroll-behavior`,
 | Attribute | Description | Example |
 |-----------|-------------|---------|
 | `lvt-ignore` | Skip this element and its entire subtree during morphdom diff. Checked on the live DOM (`fromEl`), usable from both templates and client JS. Equivalent to Phoenix LiveView's `phx-update="ignore"` | `<div lvt-ignore class="map-widget">` |
-| `lvt-ignore-attrs` | Skip attribute diffing but still diff children. Preserves client-set attributes (e.g. `open` on `<details>`) while keeping child content server-managed | `<details lvt-ignore-attrs>` |
+| `lvt-ignore-attrs` | Skip attribute diffing but still diff children. Preserves client-set attributes (e.g. `open` on `<details>`) while keeping child content server-managed. Not needed for `lvt-el:`-applied classes/attrs, which are preserved automatically | `<details lvt-ignore-attrs>` |
 | `data-lvt-force-update` | Override all preservation (automatic, `lvt-ignore`, and `lvt-ignore-attrs`); server value wins. Client strips it after processing; server re-sends it each render | `<input type="checkbox" data-lvt-force-update>` |
 
 ### Identity Attributes

--- a/docs/references/controller-pattern.md
+++ b/docs/references/controller-pattern.md
@@ -444,7 +444,7 @@ func (c *NotificationController) AddMessage(state NotificationState, ctx *livete
 }
 ```
 
-> `TriggerAction` is also the mechanism behind the server-owned loading pattern (set `Loading=true`, spawn a goroutine, trigger a second action to clear it). See [Loading States §7.3](../guides/progressive-complexity.md#73-server-owned-loading-tier-1) in the Progressive Complexity Guide.
+> `TriggerAction` is the mechanism *behind* server-owned loading, but you rarely write it by hand for that: [`Async`](api-reference.md#async) collapses the set-`Loading`/spawn/trigger-a-second-action dance into one method. Reach for `TriggerAction` directly when the work starts somewhere `Async` cannot run (`Mount`, `OnConnect`, upload handlers) or reports progress repeatedly rather than completing once. See [Loading States §7.3](../guides/progressive-complexity.md#73-server-owned-loading-tier-1) in the Progressive Complexity Guide.
 
 ### Cross-Tab Updates with Subscribe + Publish
 

--- a/docs/references/server-actions.md
+++ b/docs/references/server-actions.md
@@ -239,90 +239,53 @@ func (c *AuthController) ServerWelcome(state AuthState, ctx *livetemplate.Contex
 
 ### Background Job Completion
 
-Notify users when async jobs finish. Use proper cleanup with context cancellation:
+A job kicked off by a user action — an export, a report, a slow upstream call — should use [`Async`](api-reference.md#async) rather than a hand-rolled goroutine. `Async` runs the work off the event loop and re-enters the loop to apply the result:
 
 ```go
 type ExportState struct {
     ExportStatus string
+    DownloadURL  string
 }
 
-type ExportController struct {
-    session      livetemplate.Session
-    cancelExport context.CancelFunc
-    mu           sync.Mutex
-}
-
-func (c *ExportController) OnConnect(state ExportState, ctx *livetemplate.Context) (ExportState, error) {
-    c.mu.Lock()
-    c.session = ctx.Session()
-    c.mu.Unlock()
-    return state, nil
-}
-
-func (c *ExportController) OnDisconnect() {
-    c.mu.Lock()
-    defer c.mu.Unlock()
-
-    // Cancel any running export when user disconnects
-    if c.cancelExport != nil {
-        c.cancelExport()
-        c.cancelExport = nil
-    }
-    c.session = nil
-}
+type ExportController struct{}
 
 func (c *ExportController) StartExport(state ExportState, ctx *livetemplate.Context) (ExportState, error) {
-    // Create cancellable context for the background job
-    jobCtx, cancel := context.WithCancel(context.Background())
-
-    c.mu.Lock()
-    c.cancelExport = cancel
-    c.mu.Unlock()
-
-    go func() {
-        defer cancel() // Clean up when done
-
-        result, err := performLongRunningExport(jobCtx)
-
-        // Check if cancelled before notifying
-        select {
-        case <-jobCtx.Done():
-            return // User disconnected, don't notify
-        default:
-        }
-
-        c.mu.Lock()
-        session := c.session
-        c.mu.Unlock()
-
-        if session != nil {
+    livetemplate.Async(ctx,
+        func(jobCtx context.Context) (ExportResult, error) {
+            return performLongRunningExport(jobCtx) // jobCtx is cancelled on disconnect
+        },
+        func(s ExportState, result ExportResult, err error) (ExportState, error) {
             if err != nil {
-                session.TriggerAction("exportFailed", map[string]interface{}{
-                    "error": err.Error(),
-                })
-            } else {
-                session.TriggerAction("exportComplete", map[string]interface{}{
-                    "downloadURL": result.URL,
-                })
+                s.ExportStatus = "Failed: " + err.Error()
+                return s, nil
             }
-        }
-    }()
+            s.ExportStatus = "Complete"
+            s.DownloadURL = result.URL
+            return s, nil
+        },
+    )
 
     state.ExportStatus = "Processing..."
-    return state, nil
-}
-
-func (c *ExportController) ExportComplete(state ExportState, ctx *livetemplate.Context) (ExportState, error) {
-    state.ExportStatus = "Complete"
-    state.DownloadURL = ctx.GetString("downloadURL")
-    return state, nil
-}
-
-func (c *ExportController) ExportFailed(state ExportState, ctx *livetemplate.Context) (ExportState, error) {
-    state.ExportStatus = "Failed: " + ctx.GetString("error")
-    return state, nil
+    return state, nil // render #1; the completion render follows automatically
 }
 ```
+
+That is the whole controller. `Async` supplies what the manual version had to build by hand:
+
+| Hand-rolled | Supplied by `Async` |
+|---|---|
+| `context.WithCancel` + a `cancelExport` field + `OnDisconnect` cleanup | `work` receives a context already bound to the connection's lifetime |
+| A `select` on `jobCtx.Done()` before notifying | If the connection closed, `apply` never runs |
+| A `session` field, an `OnConnect` to capture it, and a `sync.Mutex` guarding both | `apply` runs on the event loop against the current state |
+| `exportComplete` / `exportFailed` actions and their two handler methods | The `err` parameter of `apply` |
+
+**When you still need the manual pattern.** `Async` is scoped to action handlers and is one-shot — one `work`, one `apply`. Keep a goroutine plus `TriggerAction` when the job:
+
+- **reports progress repeatedly** (a percentage, a streaming log) rather than completing once;
+- **must outlive the connection** — `Async` cancels its work on disconnect, so a job that has to finish server-side regardless needs its own lifetime and should notify through a topic;
+- **starts outside an action handler**, e.g. re-spawned from `OnConnect` after a reconnect. See [Recovery contract](#recovery-contract-idempotent-handlers--onconnect-re-spawn).
+
+In those cases capture the session in `OnConnect` under a mutex, cancel from `OnDisconnect`, and check `jobCtx.Done()` before notifying — the shape the table above replaces.
 
 ### Real-time Notifications (legacy `sync.Map` pattern)
 


### PR DESCRIPTION
The narrative docs mirrored to the docs site still teach patterns the library replaced up to three releases ago. Companion to livetemplate/docs#128; the docs-side half is livetemplate/docs PR (feat/latest-features).

These pages are the source of truth for the docs site — `cmd/sync` mirrors them verbatim on release — so this had to land here, not there.

## What changed

**`docs/guides/progressive-complexity.md` §7.3 — inverted.** It opened with ~50 lines of the manual two-action loading pattern and demoted `Async` to a sub-subsection, so the recommended path was the one `Async` replaced. Now `Async` + `{{.lvt.Pending}}` leads, `Async` + a `Loading` field covers real application state, and the manual pattern survives as an **escape hatch** scoped to the three cases that genuinely still need it:

- work starting where `Async` is illegal (`Mount`, `OnConnect`, upload handlers, HTTP POST),
- work reporting progress repeatedly (`Async` is one-shot),
- reconnect re-spawn, which begins in `OnConnect`.

The scope restriction was undocumented in the guide entirely — a reader could follow §7.3 into `Mount` and have the operation silently dropped with a log warning. It is now stated up front. The decision table gains a row for the escape hatch and stops costing the `Async` path at "~15 lines".

§7.2 also records that `lvt-el`-applied state survives a morph, and that `lvt-ignore-attrs` is not needed for it.

**`docs/references/api-reference.md` — `Validate()` was missing entirely**, two minor versions after v0.21.0 shipped it. Not sync lag; it was never written. Documented with the reason it exists: `Execute`/`ExecuteUpdates` swallow a first-render failure and fall back to an HTML-structure tree, so a malformed template renders degraded and returns no error — a tool wanting to reject one before serving had nothing to call. Includes the diagnostics-are-not-errors contract, what the check covers and does not, and `WithValidateComponents`.

Second commit adds a limitation that was implied but never stated: **`apply` receives only `(state, result, err)`** — no `*Context` — so the completion render cannot `SetFlash`, write a cookie, or navigate. Found while migrating a docs recipe that flashes on both its success and error branch; it cannot use `Async`, and nothing said why.

**`docs/references/client-attributes.md` — closes livetemplate/docs#110.** The preservation section listed four behaviours and not the `lvt-el` overlay shipped in client v0.18.1, while pointing readers at `lvt-ignore-attrs` as the way to protect client-set attributes. That never worked for this case: `lvt-ignore-attrs` only copies attributes the incoming element *lacks*, and any element using `toggleClass` carries a server-emitted base `class`, so `class` was always skipped. Semantics documented from the client's `client-owned-state.ts` behaviour — overlay wins on conflict, server re-owns on agreement, not gated on the directive still being present, dies with element identity on `replaceWith`.

**`docs/references/controller-pattern.md`** — the `TriggerAction` note recommended the two-action loading pattern by name; now routes to `Async` first.

**`docs/references/server-actions.md`** — "Background Job Completion" built `context.WithCancel`, `OnDisconnect` cleanup, a mutex-guarded session field, a cancellation `select` and two follow-up handlers, all of which `Async` supplies. Rewritten around `Async` with a table mapping each hand-rolled piece to its replacement (net ~100 lines shorter), keeping the manual shape for jobs that stream progress, outlive the connection, or start in `OnConnect`. Also fixes a latent bug in the old snippet: `ExportState` declared no `DownloadURL` but `ExportComplete` assigned one.

## Verification

Docs-only; no library behaviour changes. `go build ./...` clean and the full pre-commit suite (gofmt, golangci-lint, complete Go test suite) passed on both commits.

The `Async` claims are backed by existing tests rather than assertion: `TestAsync_ApplyErrorClearsPendingAndReRenders` confirms the error arm re-renders, `TestAsync_DisconnectCancelsWork` the cancellation, `TestAsync_RenderScopeIsOriginatingConnectionOnly` the per-connection scope.

## Note for reviewers

This does not reach the docs site until a release + sync dispatch. The companion docs PR is independent and can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzC2djPjPHkNJgPzFpMX7v